### PR TITLE
LIX-62 # Add settings flags for zoom-compensated connector and resize handle scaling

### DIFF
--- a/services/web-ui/src/infographics/workspace/README.md
+++ b/services/web-ui/src/infographics/workspace/README.md
@@ -182,7 +182,7 @@ Image resize always preserves aspect ratio using the `aspectRatio` value stored 
 
 On image load the client verifies the image's natural aspect ratio and will auto-correct the node's dimensions if a mismatch is detected (this helps self-heal nodes created by older clients). When a correction is necessary the client persists the corrected `dimensions` and updated `aspectRatio` via the normal canvas state persistence flow (`onCanvasStateChange` / `commitCanvasState`).
 
-Resizing uses a stable diagonal-based calculation to preserve aspect ratio smoothly during diagonal drags and avoid axis-switching jumps that can cause jitter during resize. Resize handles are dynamically sized and positioned (computed from the current viewport zoom) so they remain a uniform screen-pixel size and precisely aligned to the image corners regardless of canvas zoom or image scale.
+Resizing uses a stable diagonal-based calculation to preserve aspect ratio smoothly during diagonal drags and avoid axis-switching jumps that can cause jitter during resize. Resize handles are dynamically sized and positioned (computed from the current viewport zoom) so they remain a uniform screen-pixel size and precisely aligned to the image corners regardless of canvas zoom or image scale. This zoom-compensated sizing is controlled by `useZoomCompensatedResizeHandleScaling` in `webUiSettings.ts` (default `true`).
 
 ### Image Generation Visual Feedback
 
@@ -224,6 +224,7 @@ Edges are stored in `canvasState.edges` and rendered using the existing infograp
 - Node DOM elements get left/right connection handles (target/source)
 - Edge direction follows the drag direction (arrow points toward the node you dragged TO)
 - **Proximity Connect**: Dragging a node near an AI Chat Thread shows a dashed ghost line; dropping creates the connection automatically (threshold configured via `webUiSettings.proximityConnectThreshold`)
+- **Zoom-compensated scaling**: Connector stroke width and arrowhead marker sizes can be inversely scaled based on zoom level so they appear at constant visual size. Controlled by `useZoomCompensatedConnectorScaling` in `webUiSettings.ts` (default `false` — connectors use fixed base sizes and scale naturally with the canvas zoom)
 - Clicking an edge selects it and shows a bubble menu below it with a Delete action
 - Deleting an edge updates `canvasState.edges` via the normal persistence flow
 

--- a/services/web-ui/src/infographics/workspace/WorkspaceCanvas.ts
+++ b/services/web-ui/src/infographics/workspace/WorkspaceCanvas.ts
@@ -2009,7 +2009,9 @@ export function createWorkspaceCanvas(options: WorkspaceCanvasOptions) {
 
     // Handle sizing/positioning of resize handles so they appear constant in screen pixels
     function applyHandleSizing(handle: HTMLElement, corner: ResizeCorner, zoom: number) {
-        const { size: sizePx, offset: offsetPx } = getResizeHandleScaledSizes(zoom)
+        const { size: sizePx, offset: offsetPx } = webUiSettings.useZoomCompensatedResizeHandleScaling
+            ? getResizeHandleScaledSizes(zoom)
+            : { size: 24, offset: 6 }
 
         handle.style.width = `${sizePx}px`
         handle.style.height = `${sizePx}px`

--- a/services/web-ui/src/infographics/workspace/WorkspaceConnectionManager.ts
+++ b/services/web-ui/src/infographics/workspace/WorkspaceConnectionManager.ts
@@ -950,7 +950,9 @@ export class WorkspaceConnectionManager {
 
 		// Calculate scaled sizes for edges
 		const { strokeWidth: scaledStrokeWidth, markerSize: scaledMarkerSize, markerOffset: scaledMarkerOffset } =
-			getEdgeScaledSizes(zoom)
+			webUiSettings.useZoomCompensatedConnectorScaling
+				? getEdgeScaledSizes(zoom)
+				: { strokeWidth: 2, markerSize: 16, markerOffset: { source: 6, target: 19 } }
 
 		// Compute spread-out t values for edges sharing the same node+side
 		// This prevents multiple edges from converging to the exact same point

--- a/services/web-ui/src/webUiSettings.ts
+++ b/services/web-ui/src/webUiSettings.ts
@@ -11,6 +11,8 @@ export type WebUiSettings = {
     aiChatThreadRailDragGrabWidth: number
     nodesConnectorLineCurve: WorkspaceEdgePathType
     nodesConnectorLineClickAreaWidth: number
+    useZoomCompensatedConnectorScaling: boolean
+    useZoomCompensatedResizeHandleScaling: boolean
 }
 
 export const webUiSettings: WebUiSettings = {
@@ -51,4 +53,11 @@ export const webUiSettings: WebUiSettings = {
     // Width (in pixels) of the invisible click area around connector lines.
     // Makes it easier to select thin lines.
     nodesConnectorLineClickAreaWidth: 24,
+    // When true, connector line stroke width and marker sizes are inversely scaled
+    // based on zoom level so they appear at constant visual size. When false, connectors
+    // use fixed base sizes and will shrink/grow naturally with the canvas zoom.
+    useZoomCompensatedConnectorScaling: false,
+    // When true, resize corner handles are inversely scaled based on zoom level so
+    // they appear at constant visual size. When false, handles use fixed base sizes.
+    useZoomCompensatedResizeHandleScaling: true,
 }


### PR DESCRIPTION
## Summary

Fixes #62

Connector lines on the workspace canvas appear disproportionately thick at low zoom levels due to constant inverse scaling (`baseSize / zoom`). This PR adds two independent settings flags to control zoom-compensated scaling separately for connectors and resize handles.

## Changes

### `webUiSettings.ts`
- Added `useZoomCompensatedConnectorScaling` (`false` by default) — connector lines now use fixed base sizes and scale naturally with the canvas zoom
- Added `useZoomCompensatedResizeHandleScaling` (`true` by default) — resize handles keep current zoom-compensated behavior

### `WorkspaceConnectionManager.ts`
- `getEdgeScaledSizes(zoom)` call is now gated behind `useZoomCompensatedConnectorScaling`. When `false`, falls back to fixed base values (strokeWidth: 2, markerSize: 16, markerOffset: { source: 6, target: 19 })

### `WorkspaceCanvas.ts`
- `getResizeHandleScaledSizes(zoom)` call in `applyHandleSizing()` is now gated behind `useZoomCompensatedResizeHandleScaling`. When `false`, falls back to fixed base values (size: 24, offset: 6)

### `README.md` (workspace)
- Documented both new flags in the Workspace Edges and resize handle sections