### PR TITLE
LIX-66 # fix ai prompt collapse toggle

### DIFF
--- a/services/web-ui/src/components/proseMirror/plugins/aiChatThreadPlugin/README.md
+++ b/services/web-ui/src/components/proseMirror/plugins/aiChatThreadPlugin/README.md
@@ -219,6 +219,7 @@ sequenceDiagram
 - DOM: `details.ai-collapsible-block > summary + div.ai-collapsible-block-content`
 - Shows "Preparing image generation prompt" while streaming, "Image generation prompt" when done
 - Collapsed by default; spinner indicator while streaming
+- The NodeView handles summary `mousedown` and `click` directly so the thread-level focus handler does not swallow the toggle interaction
 - Content: Empty (atom node)
 - Attributes:
   - `imageData: string` - Image URL or base64 data

--- a/services/web-ui/src/components/proseMirror/plugins/aiChatThreadPlugin/aiCollapsibleBlockNode.test.ts
+++ b/services/web-ui/src/components/proseMirror/plugins/aiChatThreadPlugin/aiCollapsibleBlockNode.test.ts
@@ -1,0 +1,114 @@
+'use strict'
+
+import { describe, it, expect, vi } from 'vitest'
+import {
+    schema,
+} from '$src/components/proseMirror/plugins/testUtils/prosemirrorTestUtils.ts'
+import {
+    aiCollapsibleBlockNodeView,
+} from '$src/components/proseMirror/plugins/aiChatThreadPlugin/aiCollapsibleBlockNode.ts'
+
+function createCollapsibleNodeView(attrs: Record<string, unknown> = {}) {
+    const node = schema.nodes.aiCollapsibleBlock.create(
+        { title: 'Image generation prompt', isOpen: false, isStreaming: false, ...attrs },
+        schema.nodes.paragraph.create(null, schema.text('Prompt body')),
+    )
+
+    const transaction = {
+        setNodeMarkup: vi.fn().mockReturnThis(),
+    }
+
+    const mockView = {
+        state: {
+            tr: transaction,
+            doc: {
+                nodeAt: vi.fn(() => node),
+            },
+        },
+        dispatch: vi.fn(),
+    }
+
+    const getPos = vi.fn(() => 3)
+    const nodeView = aiCollapsibleBlockNodeView(node, mockView, getPos)
+
+    return { nodeView, mockView, transaction, getPos }
+}
+
+describe('aiCollapsibleBlockNodeView', () => {
+    it('toggles open state and syncs it back to the node on summary click', () => {
+        const { nodeView, mockView, transaction } = createCollapsibleNodeView()
+        const summary = nodeView.dom.querySelector('summary') as HTMLElement
+
+        summary.dispatchEvent(new MouseEvent('mousedown', { bubbles: true, cancelable: true }))
+        summary.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }))
+
+        expect((nodeView.dom as HTMLDetailsElement).open).toBe(true)
+        expect(transaction.setNodeMarkup).toHaveBeenCalledWith(
+            3,
+            undefined,
+            expect.objectContaining({ isOpen: true }),
+        )
+        expect(mockView.dispatch).toHaveBeenCalledWith(transaction)
+    })
+
+    it('stops summary mousedown from bubbling to ancestor DOM handlers', () => {
+        const { nodeView } = createCollapsibleNodeView()
+        const summary = nodeView.dom.querySelector('summary') as HTMLElement
+        const parent = document.createElement('div')
+        const ancestorMouseDownHandler = vi.fn()
+
+        parent.addEventListener('mousedown', ancestorMouseDownHandler)
+        parent.appendChild(nodeView.dom)
+
+        summary.dispatchEvent(new MouseEvent('mousedown', { bubbles: true, cancelable: true }))
+
+        expect(ancestorMouseDownHandler).not.toHaveBeenCalled()
+    })
+
+    it('ignores wrapper open attribute mutations from the manual toggle', () => {
+        const { nodeView } = createCollapsibleNodeView()
+
+        const mutation = {
+            type: 'attributes',
+            attributeName: 'open',
+            target: nodeView.dom,
+        } as unknown as MutationRecord
+
+        expect(nodeView.ignoreMutation!(mutation)).toBe(true)
+    })
+
+    it('stopEvent captures summary interactions but not content interactions', () => {
+        const { nodeView } = createCollapsibleNodeView()
+        const summary = nodeView.dom.querySelector('summary') as HTMLElement
+        const content = nodeView.contentDOM as HTMLElement
+
+        const summaryEvent = { target: summary } as unknown as Event
+        const contentEvent = { target: content } as unknown as Event
+
+        expect(nodeView.stopEvent!(summaryEvent)).toBe(true)
+        expect(nodeView.stopEvent!(contentEvent)).toBe(false)
+    })
+
+    it('update syncs the summary label, streaming class, and open state', () => {
+        const { nodeView } = createCollapsibleNodeView()
+        const updatedNode = schema.nodes.aiCollapsibleBlock.create(
+            { title: 'Revised prompt', isOpen: true, isStreaming: true },
+            schema.nodes.paragraph.create(null, schema.text('Updated prompt body')),
+        )
+
+        const result = nodeView.update!(updatedNode)
+        const summary = nodeView.dom.querySelector('summary') as HTMLElement
+
+        expect(result).toBe(true)
+        expect(summary.textContent).toBe('Preparing image generation prompt')
+        expect(nodeView.dom.classList.contains('is-streaming')).toBe(true)
+        expect((nodeView.dom as HTMLDetailsElement).open).toBe(true)
+    })
+
+    it('update returns false for a different node type', () => {
+        const { nodeView } = createCollapsibleNodeView()
+        const wrongNode = schema.nodes.paragraph.create(null, schema.text('Nope'))
+
+        expect(nodeView.update!(wrongNode)).toBe(false)
+    })
+})

--- a/services/web-ui/src/components/proseMirror/plugins/aiChatThreadPlugin/aiCollapsibleBlockNode.ts
+++ b/services/web-ui/src/components/proseMirror/plugins/aiChatThreadPlugin/aiCollapsibleBlockNode.ts
@@ -48,6 +48,29 @@ export const aiCollapsibleBlockNodeView = (node: any, view: any, getPos: () => n
     const summary = wrapper.querySelector('summary')!
     const contentDom = wrapper.querySelector('.ai-collapsible-block-content')!
 
+    const handleSummaryMouseDown = (event: MouseEvent) => {
+        // Prevent the parent thread's mousedown focus handler from stealing the interaction.
+        event.preventDefault()
+        event.stopPropagation()
+    }
+
+    const handleSummaryClick = (event: MouseEvent) => {
+        event.preventDefault()
+        event.stopPropagation()
+
+        const pos = getPos()
+        if (pos === undefined) return
+
+        const newOpen = !wrapper.open
+        wrapper.open = newOpen
+
+        const tr = view.state.tr.setNodeMarkup(pos, undefined, {
+            ...view.state.doc.nodeAt(pos)?.attrs,
+            isOpen: newOpen,
+        })
+        view.dispatch(tr)
+    }
+
     summary.textContent = node.attrs.isStreaming
         ? 'Preparing image generation prompt'
         : node.attrs.title
@@ -56,29 +79,19 @@ export const aiCollapsibleBlockNodeView = (node: any, view: any, getPos: () => n
         wrapper.open = true
     }
 
-    // Toggle open state on click — native <details> toggle is blocked by ProseMirror
-    summary.addEventListener('click', (e: MouseEvent) => {
-        e.preventDefault()
-        const pos = getPos()
-        if (pos === undefined) return
-
-        const newOpen = !wrapper.open
-        wrapper.open = newOpen
-
-        // Sync the isOpen attr back to the ProseMirror node
-        const tr = view.state.tr.setNodeMarkup(pos, undefined, {
-            ...view.state.doc.nodeAt(pos)?.attrs,
-            isOpen: newOpen,
-        })
-        view.dispatch(tr)
-    })
+    summary.addEventListener('mousedown', handleSummaryMouseDown)
+    summary.addEventListener('click', handleSummaryClick)
 
     return {
         dom: wrapper,
         contentDOM: contentDom,
         stopEvent(event: Event) {
-            // Let clicks on summary through so the toggle handler works
             return event.target === summary || summary.contains(event.target as Node)
+        },
+        ignoreMutation(mutation: MutationRecord) {
+            return mutation.type === 'attributes'
+                && mutation.attributeName === 'open'
+                && mutation.target === wrapper
         },
         update(updatedNode: any) {
             if (updatedNode.type.name !== aiCollapsibleBlockNodeType) return false
@@ -96,6 +109,10 @@ export const aiCollapsibleBlockNodeView = (node: any, view: any, getPos: () => n
             wrapper.open = !!updatedNode.attrs.isOpen
 
             return true
+        },
+        destroy() {
+            summary.removeEventListener('mousedown', handleSummaryMouseDown)
+            summary.removeEventListener('click', handleSummaryClick)
         },
     }
 }

--- a/services/web-ui/src/components/proseMirror/plugins/testUtils/testSchema.ts
+++ b/services/web-ui/src/components/proseMirror/plugins/testUtils/testSchema.ts
@@ -2,6 +2,7 @@ import { Schema } from 'prosemirror-model'
 import { nodes, marks } from '$src/components/proseMirror/components/schema.ts'
 import { aiGeneratedImageNodeSpec } from '$src/components/proseMirror/plugins/aiChatThreadPlugin/aiGeneratedImageNode.ts'
 import { aiChatThreadNodeSpec } from '$src/components/proseMirror/plugins/aiChatThreadPlugin/aiChatThreadNode.ts'
+import { aiCollapsibleBlockNodeSpec } from '$src/components/proseMirror/plugins/aiChatThreadPlugin/aiCollapsibleBlockNode.ts'
 import { aiResponseMessageNodeSpec } from '$src/components/proseMirror/plugins/aiChatThreadPlugin/aiResponseMessageNode.ts'
 import { aiUserMessageNodeSpec } from '$src/components/proseMirror/plugins/aiChatThreadPlugin/aiUserMessageNode.ts'
 import { aiUserInputNodeSpec } from '$src/components/proseMirror/plugins/aiChatThreadPlugin/aiUserInputNode.ts'
@@ -33,6 +34,7 @@ export const testSchema = new Schema({
 
         // AI-generated image node (used inside aiResponseMessage)
         aiGeneratedImage: aiGeneratedImageNodeSpec,
+        aiCollapsibleBlock: aiCollapsibleBlockNodeSpec,
 
         // AI chat thread nodes
         aiChatThread: aiChatThreadNodeSpec,


### PR DESCRIPTION
## Summary
- restore the AI image prompt collapse toggle inside chat threads
- stop thread-level mousedown handling from swallowing the summary interaction
- add focused regression tests for toggle behavior, event interception, and node view updates

## Root Cause
The collapsible prompt node view relied on the summary click path, but recent thread-level mouse handling changes could intercept the interaction before the details state and ProseMirror node attrs stayed in sync.

## Testing
- `docker compose exec lixpi-web-ui pnpm test:run src/components/proseMirror/plugins/aiChatThreadPlugin/aiCollapsibleBlockNode.test.ts`
- `docker compose exec lixpi-web-ui pnpm test:run src/components/proseMirror/plugins/aiChatThreadPlugin`

Closes #66