### PR TITLE
LIX-72 # configurable selection colors via webUiThemeSettings

### DIFF
--- a/services/web-ui/src/infographics/workspace/README.md
+++ b/services/web-ui/src/infographics/workspace/README.md
@@ -233,7 +233,7 @@ Single-target canvas UI stays single-target:
 - The single floating prompt input appears only when exactly one document node is selected
 - Per-thread floating inputs remain attached to AI chat thread nodes regardless of selection state
 
-When two or more nodes are selected, the canvas renders a persistent background overlay behind the selected range. A single selected AI chat thread also gets this overlay because the thread, its persistent floating input, and any anchored AI images are treated as one composite selection unit. This overlay makes the active selection obvious and also serves as an extra drag surface for moving the selected composite. Clicking outside the selected range clears the selection.
+When two or more nodes are selected, the canvas renders a persistent background overlay behind the selected range. A single selected AI chat thread also gets this overlay because the thread, its persistent floating input, and any anchored AI images are treated as one composite selection unit. Selection colors (marquee border/background, overlay border/background, thread-input outline) are configurable via `webUiThemeSettings` and applied as CSS custom properties on the pane element. Clicking outside the selected range clears the selection.
 
 During group drag, AI chat thread companion UI stays attached to the thread node:
 

--- a/services/web-ui/src/infographics/workspace/WorkspaceCanvas.ts
+++ b/services/web-ui/src/infographics/workspace/WorkspaceCanvas.ts
@@ -112,6 +112,11 @@ export function createWorkspaceCanvas(options: WorkspaceCanvasOptions) {
 
     paneEl.style.setProperty('--connector-line-default-color', webUiThemeSettings.nodesConnectorLineDefaultColor)
     paneEl.style.setProperty('--connector-line-focus-color', webUiThemeSettings.nodesConnectorLineFocusColor)
+    paneEl.style.setProperty('--selection-marquee-border-color', webUiThemeSettings.selectionMarqueeBorderColor)
+    paneEl.style.setProperty('--selection-marquee-background-color', webUiThemeSettings.selectionMarqueeBackgroundColor)
+    paneEl.style.setProperty('--selection-overlay-border-color', webUiThemeSettings.selectionOverlayBorderColor)
+    paneEl.style.setProperty('--selection-overlay-background-color', webUiThemeSettings.selectionOverlayBackgroundColor)
+    paneEl.style.setProperty('--selection-outline-color', webUiThemeSettings.selectionOutlineColor)
 
     let currentCanvasState: CanvasState | null = options.canvasState
     let currentDocuments: Document[] = options.documents

--- a/services/web-ui/src/infographics/workspace/workspace-canvas.scss
+++ b/services/web-ui/src/infographics/workspace/workspace-canvas.scss
@@ -229,8 +229,8 @@
     position: absolute;
     z-index: 10001;
     pointer-events: none;
-    border: 1px solid rgba(54, 92, 135, 0.85);
-    background: rgba(130, 178, 192, 0.18);
+    border: 1px solid var(--selection-marquee-border-color);
+    background: var(--selection-marquee-background-color);
     border-radius: 8px;
     box-sizing: border-box;
 }
@@ -239,8 +239,8 @@
     position: absolute;
     z-index: 10000;
     cursor: move;
-    border: 1px solid rgba(54, 92, 135, 0.52);
-    background: rgba(130, 178, 192, 0.22);
+    border: 1px solid var(--selection-overlay-border-color);
+    background: var(--selection-overlay-background-color);
     border-radius: 18px;
     box-sizing: border-box;
     backdrop-filter: blur(1px);
@@ -727,7 +727,7 @@
 // Bottom resize handles on the per-thread floating AI input
 .ai-prompt-input-thread-persistent {
     &.is-selected {
-        outline: 1px solid rgba(54, 92, 135, 0.58);
+        outline: 1px solid var(--selection-outline-color);
         outline-offset: 2px;
     }
 

--- a/services/web-ui/src/infographics/workspace/workspace-canvas.test.ts
+++ b/services/web-ui/src/infographics/workspace/workspace-canvas.test.ts
@@ -631,6 +631,17 @@ describe('Workspace canvas — multi-selection and group drag', () => {
 		expect(scss).toContain('.workspace-selection-rect')
 		expect(scss).toMatch(/\.workspace-selection-rect\s*\{[^}]*pointer-events:\s*none/s)
 		expect(scss).toMatch(/\.workspace-selection-rect\s*\{[^}]*z-index:\s*10001/s)
+		expect(scss).toMatch(/\.workspace-selection-rect\s*\{[^}]*var\(--selection-marquee-border-color/s)
+		expect(scss).toMatch(/\.workspace-selection-rect\s*\{[^}]*var\(--selection-marquee-background-color/s)
+	})
+
+	it('wires selection colors from webUiThemeSettings to CSS custom properties', () => {
+		expect(ts).toContain("paneEl.style.setProperty('--selection-marquee-border-color', webUiThemeSettings.selectionMarqueeBorderColor)")
+		expect(ts).toContain("paneEl.style.setProperty('--selection-marquee-background-color', webUiThemeSettings.selectionMarqueeBackgroundColor)")
+		expect(ts).toContain("paneEl.style.setProperty('--selection-overlay-border-color', webUiThemeSettings.selectionOverlayBorderColor)")
+		expect(ts).toContain("paneEl.style.setProperty('--selection-overlay-background-color', webUiThemeSettings.selectionOverlayBackgroundColor)")
+		expect(ts).toContain("paneEl.style.setProperty('--selection-outline-color', webUiThemeSettings.selectionOutlineColor)")
+		expect(scss).toMatch(/var\(--selection-outline-color/)
 	})
 
 	it('defines and styles a persistent selection overlay for multi-selection and single AI chat thread selection', () => {
@@ -644,6 +655,8 @@ describe('Workspace canvas — multi-selection and group drag', () => {
 		expect(ts).toContain('updateSelectionGroupOverlayElement()')
 		expect(scss).toContain('.workspace-selection-group-overlay')
 		expect(scss).toMatch(/\.workspace-selection-group-overlay\s*\{[^}]*z-index:\s*10000/s)
+		expect(scss).toMatch(/\.workspace-selection-group-overlay\s*\{[^}]*var\(--selection-overlay-border-color/s)
+		expect(scss).toMatch(/\.workspace-selection-group-overlay\s*\{[^}]*var\(--selection-overlay-background-color/s)
 	})
 
 	it('uses the selection overlay as a drag surface for the whole selected group or single AI chat thread composite', () => {

--- a/services/web-ui/src/webUiThemeSettings.ts
+++ b/services/web-ui/src/webUiThemeSettings.ts
@@ -10,6 +10,11 @@ export type WebUiThemeSettings = {
     aiChatThreadRailBoundaryCircleColors: [string, string, string]
     nodesConnectorLineDefaultColor: string
     nodesConnectorLineFocusColor: string
+    selectionMarqueeBorderColor: string
+    selectionMarqueeBackgroundColor: string
+    selectionOverlayBorderColor: string
+    selectionOverlayBackgroundColor: string
+    selectionOutlineColor: string
     // Four gradient colors used by the shifting gradient background and animated border
     // overlays (image generation border, document thread shape, context selection).
     // Hex strings. The shifting gradient renderer converts these to RGB internally.
@@ -53,6 +58,14 @@ export const webUiThemeSettings: WebUiThemeSettings = {
     nodesConnectorLineDefaultColor: brandColors.steelBlue,
     // Focus/selected color for connector lines between nodes.
     nodesConnectorLineFocusColor: '#000',
+    // Marquee selection rectangle (drag-to-select).
+    selectionMarqueeBorderColor: 'rgba(176, 173, 224, 0.88)',
+    selectionMarqueeBackgroundColor: 'rgba(230, 233, 246, 0.38)',
+    // Persistent selection group overlay (multi-select / single AI chat thread).
+    selectionOverlayBorderColor: 'rgba(197, 192, 238, 0.62)',
+    selectionOverlayBackgroundColor: 'rgba(230, 233, 246, 0.42)',
+    // Outline on the per-thread floating input when selected.
+    selectionOutlineColor: 'rgba(197, 192, 238, 0.75)',
     // Four gradient colors shared between the shifting gradient background and the
     // animated border overlays (image generation, document thread shape).
     // Dreamy sky pastel palette — whisper pink, lavender, periwinkle, orchid.


### PR DESCRIPTION
## What

Makes workspace selection colors (marquee, group overlay, thread-input outline) configurable via `webUiThemeSettings`, replacing hard-coded blue `rgba()` values with periwinkle/lavender tones from the existing theme palette.

## Changes

- **`webUiThemeSettings.ts`** — 5 new fields: `selectionMarqueeBorderColor`, `selectionMarqueeBackgroundColor`, `selectionOverlayBorderColor`, `selectionOverlayBackgroundColor`, `selectionOutlineColor`
- **`WorkspaceCanvas.ts`** — sets 5 CSS custom properties on `paneEl` at init
- **`workspace-canvas.scss`** — consumes `var(--selection-…)` with no fallback (single source of truth in theme settings)
- **`workspace-canvas.test.ts`** — regression test verifying the wiring
- **`README.md`** — updated docs

Closes #72