### PR TITLE
LIX-78 # Collapse sidebar by default

### DIFF
--- a/services/web-ui/src/views/layouts/layout.svelte
+++ b/services/web-ui/src/views/layouts/layout.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 
-    import { setContext, getContext } from 'svelte'
+    import { setContext, getContext, untrack, tick } from 'svelte'
     import { fade } from 'svelte/transition'
 
     import { PaymentProcessingStatus } from '@lixpi/constants'
@@ -77,12 +77,21 @@
 
 
     let sidebarPane: Resizable.Pane = $state(null!);
-    let isSidebarCollapsed = $state(false);
+    let isSidebarCollapsed = $state(true);
 
     let isUserInfoSidePanelOpen = $state(false);
+    let didInitialCollapse = false;
 
     $effect(() => {
-        // console.log('userStore', $userStore.data.balance);
+        if (sidebarPane && !didInitialCollapse) {
+            didInitialCollapse = true;
+            if (!layout) {
+                (async () => {
+                    await tick();
+                    untrack(() => sidebarPane.collapse());
+                })();
+            }
+        }
     })
 
     const triggerUserInfoSidePanel = () => {


### PR DESCRIPTION
## Summary

Collapse the sidebar by default on first load for a cleaner initial experience. When no saved layout cookie exists, the sidebar starts collapsed. Users can expand it normally, and PaneForge remembers the proper expanded width (14%).

### Changes

- Set `isSidebarCollapsed` to `true` by default
- Added a one-shot `$effect` that collapses the pane on mount when no layout cookie is present
- Used `untrack` + `tick()` to avoid reactive loops

Closes #78