### PR TITLE
LIX-79 # Add modern JS / ES modules conventions to TypeScript style guide

### DIFF
--- a/documentation/coding-style-guides/TYPESCRIPT.md
+++ b/documentation/coding-style-guides/TYPESCRIPT.md
@@ -37,3 +37,33 @@ interface UserProfile {
 ## Docker
 
 Every service runs inside its own Docker container. All commands (tests, builds, linters, etc.) must be executed inside the relevant container using `docker exec`. Never run service commands on the host machine.
+
+## Modern JavaScript / ES Modules
+
+All projects use `"type": "module"` and target the latest ECMAScript releases. Always use modern language features — never legacy patterns.
+
+### Async / Await
+
+Always use `async`/`await`. Never use `.then()` / `.catch()` chains.
+
+```typescript
+// Correct
+const data = await fetchData()
+
+// Wrong — never use .then()
+fetchData().then((data) => { ... })
+```
+
+### Prefer Modern APIs Over Legacy Alternatives
+
+| Use | Instead of |
+|-----|------------|
+| `async` / `await` | `.then()` / `.catch()` / callbacks |
+| `for...of` | `.forEach()` when `await` or `break` is needed |
+| `structuredClone()` | `JSON.parse(JSON.stringify())` |
+| `Object.hasOwn(obj, key)` | `obj.hasOwnProperty(key)` |
+| `Array.at(-1)` | `arr[arr.length - 1]` |
+| Template literals | String concatenation with `+` |
+| Optional chaining `?.` | Manual null checks |
+| Nullish coalescing `??` | `\|\|` for default values |
+| `using` / `await using` | Manual resource cleanup (when supported) |


### PR DESCRIPTION
## Summary

Add a "Modern JavaScript / ES Modules" section to the TypeScript coding style guide documenting that all projects use `"type": "module"`, target the latest ECMAScript releases, and must use modern language features exclusively.

### Changes

- Added mandatory `async`/`await` rule (`.then()` / `.catch()` chains banned)
- Added reference table: modern APIs vs legacy alternatives (`structuredClone`, `Object.hasOwn`, `Array.at`, optional chaining, nullish coalescing, etc.)

Closes #79