### PR TITLE
LIX-82 # Update GitHub workflow skill to use API instead of local Git CLI

### DIFF
--- a/.github/skills/github-workflow/SKILL.md
+++ b/.github/skills/github-workflow/SKILL.md
@@ -53,16 +53,24 @@ Include:
 ## Step-by-Step: Full Feature Workflow
 
 1. **Identify the issue** — Use GitHub MCP tools to read the issue and get its ID.
-2. **Create the branch** — `git checkout -b LIX-<id>/<description>`.
-3. **Implement the feature** — Make changes, commit with `LIX-<id> # <description>` format.
-4. **Push the branch** — `git push -u origin LIX-<id>/<description>`.
-5. **Open the PR** — Use GitHub MCP tools with the correct title format. Assign to current user.
-6. **Update the issue** — Add the PR link to the issue description body.
+2. **Create the branch from `main`** — Use `mcp_github_create_branch` with `from_branch: "main"`. Never use local `git checkout -b`.
+3. **Push changed files** — Use `mcp_github_push_files` to commit files directly to the branch via the API. Never use local `git add`, `git commit`, or `git push`.
+4. **Open the PR** — Use `mcp_github_create_pull_request` with the correct title format. Assign to current user.
+5. **Update the issue** — Add the PR link to the issue description body.
 
 ## Tools
 
-Use the GitHub MCP server tools for all GitHub operations:
-- Reading/searching issues and PRs
-- Creating branches and PRs
-- Adding comments and updating issue descriptions
-- Getting current user info for assignment
+Use the GitHub MCP server tools for **all** GitHub and Git operations. Never use local Git CLI commands (`git checkout`, `git add`, `git commit`, `git push`, `git stash`, etc.).
+
+Available MCP tools:
+- `mcp_github_get_me` — Get current user for assignment
+- `mcp_github_create_branch` — Create branches (always from `main`)
+- `mcp_github_push_files` — Push file contents to a branch (commit message format: `LIX-<id> # <description>`)
+- `mcp_github_create_pull_request` — Open PRs
+- `mcp_github_issue_write` — Create and update issues
+- `mcp_github_issue_read` — Read issue details
+- `mcp_github_update_pull_request` — Update PR metadata
+
+## Markdown Formatting in API Calls
+
+When passing markdown content (issue bodies, PR descriptions) to GitHub MCP tools, always use **real newlines** in the string — never literal `\n` escape sequences. The API expects actual line breaks, not escaped characters. Passing `\n` literally results in broken rendering on GitHub.


### PR DESCRIPTION
## Summary

Update the GitHub workflow agent skill to mandate using the GitHub MCP API for all Git operations instead of local CLI commands.

### Changes

- Replaced local Git CLI steps (`git checkout -b`, `git add`, `git commit`, `git push`) with API equivalents (`mcp_github_create_branch`, `mcp_github_push_files`)
- Added explicit list of available MCP tools with descriptions
- Added "Markdown Formatting in API Calls" section to prevent literal `\n` rendering issues in issue/PR descriptions

Closes #82