### PR TITLE
LIX-99 # Replace shadcn-svelte dropdown in sidebar with pureDropdown

### DIFF
--- a/.github/skills/github-workflow/SKILL.md
+++ b/.github/skills/github-workflow/SKILL.md
@@ -5,6 +5,8 @@ description: 'Manage GitHub branches, commits, issues, and pull requests for Lix
 
 # GitHub Workflow
 
+**Repository**: `Lixpi/lixpi` (https://github.com/Lixpi/lixpi.git)
+
 Lixpi uses a strict naming convention for branches, commits, and pull requests tied to GitHub issues.
 
 ## Branch Naming

--- a/services/web-ui/src/components/dropdown/_dropdown-mixins.scss
+++ b/services/web-ui/src/components/dropdown/_dropdown-mixins.scss
@@ -133,6 +133,13 @@
             }
         }
     }
+
+    // Optional: disable trigger hover background
+    &.no-trigger-hover .dots-dropdown-menu button {
+        &:before {
+            display: none;
+        }
+    }
 }
 
 // 2) Dropdown items structure — M3 list item layout

--- a/services/web-ui/src/components/dropdown/pureDropdown.ts
+++ b/services/web-ui/src/components/dropdown/pureDropdown.ts
@@ -36,6 +36,7 @@ type PureDropdownConfig = {
     availableTags?: string[]
     mountToBody?: boolean
     disableAutoPositioning?: boolean
+    disableTriggerHover?: boolean
     onSelect: (option: DropdownOption) => void
 }
 
@@ -54,6 +55,7 @@ export function createPureDropdown(config: PureDropdownConfig) {
         enableTagFilter = false,
         mountToBody = false,
         disableAutoPositioning = false,
+        disableTriggerHover = false,
         onSelect
     } = config
 
@@ -217,7 +219,7 @@ export function createPureDropdown(config: PureDropdownConfig) {
 
     // Build dropdown wrapper with button first
     const dom = html`
-        <div class="dropdown-menu-tag-pill-wrapper theme-${theme}" data-dropdown-id="${id}" data-arrow-side="top" contenteditable="false">
+        <div class="dropdown-menu-tag-pill-wrapper theme-${theme}${disableTriggerHover ? ' no-trigger-hover' : ''}" data-dropdown-id="${id}" data-arrow-side="top" contenteditable="false">
             <span class="dots-dropdown-menu">
                 <button
                     class="flex justify-between items-center"

--- a/services/web-ui/src/components/sidebar/Sidebar2.svelte
+++ b/services/web-ui/src/components/sidebar/Sidebar2.svelte
@@ -23,57 +23,21 @@
     import { popOutTransition } from '$src/constants/svelteAnimationTransitions'
 
     import { Button } from "$lib/registry/ui/button/index.ts";
-	import * as DropdownMenu from "$lib/registry/ui/dropdown-menu/index.ts";
-    import EllipsisIcon from "@lucide/svelte/icons/ellipsis";
-    import SquarePlusIcon from "@lucide/svelte/icons/square-plus";
     import FilePlus2Icon from "@lucide/svelte/icons/file-plus-2";
-    import FilePlusIcon from "@lucide/svelte/icons/file-plus";
-    // import { Separator } from "$lib/registry/ui/separator/index.js";
-
-	// import { mailStore } from "$src/components/store.js";
-	// import type { Mail } from "$src/components/data.js";
-	// import { formatTimeAgo } from "$src/components/utils.js";
+    import { createPureDropdown } from '$src/components/dropdown/index.ts'
 	import { cn } from "$lib/utils.ts";
-	import { Badge } from "$lib/registry/ui/badge/index.ts";
 	import { ScrollArea } from "$lib/registry/ui/scroll-area/index.ts";
 
-	// export let items: Mail[];
-
-    let scrollAreaRef: HTMLElement | null = null;
-
-    // Create a ref for our portal target
-    let portalTargetRef: HTMLElement;
-
-    // You can keep the scrollAreaRef if needed for other purposes
-    // let scrollAreaRef = $bindable(null);
-
-    console.log('DropdownMenu', DropdownMenu)
-
-	function get_badge_variant_from_label(label: string) {
-		if (["work"].includes(label.toLowerCase())) {
-			return "default";
-		}
-
-		if (["personal"].includes(label.toLowerCase())) {
-			return "outline";
-		}
-
-		return "secondary";
-	}
+    const ellipsisIcon = `<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="1"/><circle cx="19" cy="12" r="1"/><circle cx="5" cy="12" r="1"/></svg>`
 
     let currentWorkspaceId = $derived($routerStore.data.currentRoute.routeParams.workspaceId)
 
-    const onWorkspaceDeleteHandler = async (e, workspaceId) => {
-        e.stopPropagation()
-
+    const onWorkspaceDeleteHandler = async (workspaceId: string) => {
         const workspaceService = new WorkspaceService()
-        const deleteWorkspaceRes = await workspaceService.deleteWorkspace({ workspaceId })
-
+        await workspaceService.deleteWorkspace({ workspaceId })
     }
 
-    const onWorkspaceExportHandler = async (e, workspaceId) => {
-        e.stopPropagation()
-
+    const onWorkspaceExportHandler = async (workspaceId: string) => {
         const token = await AuthService.getTokenSilently()
         if (!token) return
 
@@ -81,32 +45,11 @@
         window.open(`${apiUrl}/api/workspaces/${workspaceId}/export?token=${token}`, '_blank')
     }
 
-
-    const labels = [
-        {
-            value: "bug",
-            label: "Bug",
-        },
-        {
-            value: "feature",
-            label: "Feature",
-        },
-        {
-            value: "documentation",
-            label: "Documentation",
-        },
-    ];
-
-
-
-
     // TODO: this is just a temp solution. I'm not sure how I want to approach setting default AI model, especially when there will be a multi-thread support in the documents.
     // I definitely don't want to bother to set it here
     let defaultAiModel = $derived($aiModelsStore.data.find(model => model.sortingPosition === 103))
 
-
-    const handleWorkspaceClick = workspaceId => {
-        console.log('workspaceId', workspaceId)
+    const handleWorkspaceClick = (workspaceId: string) => {
         workspaceStore.setMetaValues({
             loadingStatus: LoadingStatus.idle,
         })
@@ -118,12 +61,46 @@
 	}
 
     const handleCreateNewWorkspaceClick = async () => {
-
         const workspaceService = new WorkspaceService()
-
         await workspaceService.createWorkspace({
             name: 'New Workspace',
         })
+    }
+
+    function mountWorkspaceDropdown(node: HTMLElement, workspaceId: string) {
+        const dropdown = createPureDropdown({
+            id: `workspace-menu-${workspaceId}`,
+            selectedValue: { title: '' },
+            options: [
+                { title: 'Export' },
+                { title: 'Delete' },
+            ],
+            theme: 'dark',
+            buttonIcon: ellipsisIcon,
+            disableTriggerHover: true,
+            renderTitleForSelectedValue: false,
+            renderIconForSelectedValue: false,
+            renderIconForOptions: false,
+            mountToBody: true,
+            onSelect: (option) => {
+                if (option.title === 'Export') {
+                    onWorkspaceExportHandler(workspaceId)
+                } else if (option.title === 'Delete') {
+                    onWorkspaceDeleteHandler(workspaceId)
+                }
+            },
+        })
+
+        node.appendChild(dropdown.dom)
+
+        // Stop click propagation so workspace row doesn't navigate
+        dropdown.dom.addEventListener('click', (e) => e.stopPropagation())
+
+        return {
+            destroy() {
+                dropdown.destroy()
+            }
+        }
     }
 </script>
 
@@ -199,51 +176,7 @@
 							)}
 						>
 
-                            <DropdownMenu.Root>
-                                <DropdownMenu.Trigger>
-                                    {#snippet child({ props })}
-                                        <Button {...props} variant="muted" class="data-[state=open]:bg-ghost flex h-8 w-8 p-0" onclick={(e) => e.stopPropagation()}>
-                                            <EllipsisIcon class="h-4 w-4 "/>
-                                            <span class="sr-only">Open Menu</span>
-                                        </Button>
-                                    {/snippet}
-                                </DropdownMenu.Trigger>
-                                    <DropdownMenu.Content class="w-[160px]" align="end">
-                                        <DropdownMenu.Item>Edit</DropdownMenu.Item>
-                                        <DropdownMenu.Item>Make a copy</DropdownMenu.Item>
-                                        <DropdownMenu.Item>Favorite</DropdownMenu.Item>
-                                        <DropdownMenu.Item
-                                            onclick={(e) => {
-                                                onWorkspaceExportHandler(e, workspace.workspaceId)
-                                            }}
-                                        >
-                                            Export
-                                        </DropdownMenu.Item>
-                                        <DropdownMenu.Separator />
-                                        <DropdownMenu.Sub>
-                                            <DropdownMenu.SubTrigger>Labels</DropdownMenu.SubTrigger>
-                                            <DropdownMenu.SubContent>
-                                                <DropdownMenu.RadioGroup value={workspace.name}>
-                                                    {#each labels as label (label.value)}
-                                                        <DropdownMenu.RadioItem value={label.value}>
-                                                            {label.label}
-                                                        </DropdownMenu.RadioItem>
-                                                    {/each}
-                                                </DropdownMenu.RadioGroup>
-                                            </DropdownMenu.SubContent>
-                                        </DropdownMenu.Sub>
-                                        <DropdownMenu.Separator />
-                                        <DropdownMenu.Item
-                                            onclick={(e) => {
-                                                console.log('delete', workspace.workspaceId)
-                                                onWorkspaceDeleteHandler(e, workspace.workspaceId)
-                                            }}
-                                        >
-                                            Delete
-                                            <DropdownMenu.Shortcut>⌘⌫</DropdownMenu.Shortcut>
-                                        </DropdownMenu.Item>
-                                    </DropdownMenu.Content>
-                            </DropdownMenu.Root>
+                            <div use:mountWorkspaceDropdown={workspace.workspaceId}></div>
 						</div>
 					</div>
 					{#if workspace.tags?.length}


### PR DESCRIPTION
## Summary

Replace the shadcn-svelte `DropdownMenu` component in `Sidebar2.svelte` with the custom `pureDropdown` component.

## Changes

- **Sidebar2.svelte**: Removed shadcn-svelte dropdown (`DropdownMenu.*`, `EllipsisIcon`, `Badge`, unused icons). Replaced with `pureDropdown` mounted via Svelte `use:action`. Only kept working items (Export, Delete). Uses inline ellipsis SVG for trigger.
- **pureDropdown.ts**: Added `disableTriggerHover?: boolean` config option — adds `no-trigger-hover` class to suppress hover bg.
- **_dropdown-mixins.scss**: Added `.no-trigger-hover` rule to hide the trigger button's `:before` pseudo-element.
- **SKILL.md**: Added explicit repository info (`Lixpi/lixpi`) at the top of the github-workflow skill.

Closes #99