### PR TITLE
LIX-105 # Workspace import and replace image on canvas

### DIFF
--- a/documentation/features/WORKSPACE-EXPORT.md
+++ b/documentation/features/WORKSPACE-EXPORT.md
@@ -1,6 +1,6 @@
-# Workspace Export
+# Workspace Export & Import
 
-Export a complete workspace backup as a downloadable ZIP archive. The export bundles all workspace data — canvas state, documents, AI chat threads, and image binaries — into a single file.
+Export a complete workspace backup as a downloadable ZIP archive, or import a previously exported archive to replace all content in an existing workspace.
 
 ## Overview
 
@@ -116,3 +116,127 @@ sequenceDiagram
 |---------|---------|
 | `archiver` | ZIP archive creation and streaming |
 | `@types/archiver` | TypeScript types (dev) |
+
+---
+
+# Workspace Import
+
+Import a previously exported ZIP archive into an existing workspace, replacing all current content. The import wipes documents, AI chat threads, and images, then restores everything from the archive — keeping workspace identity (ID, name, access list) intact.
+
+## Overview
+
+The import is triggered from the workspace dropdown menu in the sidebar. It opens a file picker for the user to select a `.zip` archive. The file is uploaded to the API, which validates the archive, wipes the workspace content, and restores from the manifest.
+
+**Endpoint**: `POST /api/workspaces/:workspaceId/import`
+**Route file**: `services/api/src/routes/workspace-export-routes.ts`
+**UI trigger**: "Import" item in `Sidebar.svelte` dropdown menu
+
+## Import Strategy
+
+The import follows a **validate-first, wipe, replace** approach:
+
+1. **Parse** — Extract the ZIP and read `manifest.json` entirely in memory
+2. **Validate** — Check export version, required fields, document/thread arrays. If invalid, return 400 — no data is touched
+3. **Wipe** — Delete all existing content in parallel: NATS Object Store bucket (all images), DynamoDB documents, DynamoDB AI chat threads
+4. **Restore** — Recreate images, documents, AI chat threads, and update workspace canvas state + files array from the manifest
+
+This ensures no garbage is left behind. The NATS bucket is deleted entirely (not individual objects), which guarantees a clean slate for images. Documents and threads are queried by `workspaceId` and each record is deleted individually.
+
+## Import Behavior
+
+- **Workspace identity preserved**: The workspace's ID, name, `accessType`, and `accessList` remain unchanged. Only content (canvas state, documents, threads, images) is replaced.
+- **Document IDs preserved**: Original document IDs from the export are reused so canvas node references (which store document IDs) remain valid without remapping.
+- **`workspaceId` overridden**: Documents and threads from the manifest receive the target workspace's ID — an export from one workspace can be imported into a different workspace.
+- **Cross-workspace import**: Since `workspaceId` is overridden, a user can export from workspace A and import into workspace B.
+
+## Import Flow
+
+```mermaid
+%%{init: {'theme': 'base', 'themeVariables': { 'noteBkgColor': '#82B2C0', 'noteTextColor': '#1a3a47', 'noteBorderColor': '#5a9aad', 'actorBkg': '#F6C7B3', 'actorBorder': '#d4956a', 'actorTextColor': '#5a3a2a', 'actorLineColor': '#d4956a', 'signalColor': '#d4956a', 'signalTextColor': '#5a3a2a', 'labelBoxBkgColor': '#F6C7B3', 'labelBoxBorderColor': '#d4956a', 'labelTextColor': '#5a3a2a', 'loopTextColor': '#5a3a2a', 'activationBorderColor': '#9DC49D', 'activationBkgColor': '#9DC49D', 'sequenceNumberColor': '#5a3a2a'}}}%%
+sequenceDiagram
+    participant User
+    participant Sidebar as Sidebar.svelte
+    participant Browser
+    participant API as /api/workspaces/:id/import
+    participant DB as DynamoDB
+    participant ObjStore as NATS Object Store
+    %% ═══════════════════════════════════════════════════════════════
+    %% PHASE 1: TRIGGER
+    %% ═══════════════════════════════════════════════════════════════
+    rect rgb(220, 236, 233)
+        Note over User, ObjStore: PHASE 1 - TRIGGER — User selects file
+        User->>Sidebar: Click "Import" in dropdown
+        activate Sidebar
+        Sidebar->>Browser: Open file picker (.zip)
+        User->>Browser: Select ZIP archive
+        Browser->>Sidebar: File selected
+        Sidebar->>API: POST multipart/form-data (ZIP file)
+        deactivate Sidebar
+    end
+    %% ═══════════════════════════════════════════════════════════════
+    %% PHASE 2: VALIDATE
+    %% ═══════════════════════════════════════════════════════════════
+    rect rgb(195, 222, 221)
+        Note over User, ObjStore: PHASE 2 - VALIDATE — Parse and verify archive
+        activate API
+        API->>API: authenticateRequest (verify JWT)
+        API->>API: validateWorkspaceAccess (check accessList)
+        API->>API: Extract ZIP with AdmZip
+        API->>API: Parse + validate manifest.json
+        Note right of API: If invalid → 400 error, no data touched
+    end
+    %% ═══════════════════════════════════════════════════════════════
+    %% PHASE 3: WIPE
+    %% ═══════════════════════════════════════════════════════════════
+    rect rgb(242, 234, 224)
+        Note over User, ObjStore: PHASE 3 - WIPE — Delete all existing content
+        API->>ObjStore: deleteObjectStore(bucketName)
+        API->>DB: deleteWorkspaceDocuments(workspaceId)
+        API->>DB: deleteWorkspaceAiChatThreads(workspaceId)
+        Note right of API: Parallel deletion
+    end
+    %% ═══════════════════════════════════════════════════════════════
+    %% PHASE 4: RESTORE
+    %% ═══════════════════════════════════════════════════════════════
+    rect rgb(246, 199, 179)
+        Note over User, ObjStore: PHASE 4 - RESTORE — Recreate content from archive
+        API->>ObjStore: ensureObjectStore(bucketName)
+        loop For each image in ZIP
+            API->>ObjStore: putObject(bucketName, fileId, data)
+        end
+        loop For each document in manifest
+            API->>DB: importDocument(doc)
+        end
+        loop For each AI chat thread in manifest
+            API->>DB: createAiChatThread(thread)
+        end
+        API->>DB: replaceWorkspaceContent(canvasState, files)
+        API-->>Browser: JSON response (success + counts)
+        deactivate API
+    end
+    %% ═══════════════════════════════════════════════════════════════
+    %% PHASE 5: RELOAD
+    %% ═══════════════════════════════════════════════════════════════
+    rect rgb(200, 220, 228)
+        Note over User, ObjStore: PHASE 5 - RELOAD — Refresh UI with imported content
+        Browser->>Browser: Reload workspace, documents, threads
+        Browser-->>User: Workspace displays imported content
+    end
+```
+
+## Implementation Details
+
+- **In-memory extraction**: The ZIP is buffered by `multer` and extracted with `adm-zip` — no temporary files on disk.
+- **Auth**: Uses `Authorization: Bearer` header (standard `fetch` POST, not `window.open`).
+- **Validation-first**: The archive is fully parsed and validated before any existing data is deleted. Invalid archives produce a 400 error with zero data loss.
+- **Bucket wipe**: The NATS Object Store bucket is deleted entirely via `deleteObjectStore()`, then recreated via `ensureObjectStore()`. This is faster than deleting individual objects and guarantees no orphans.
+- **File size**: Accepts uploads up to 1GB via multer memory storage.
+- **Post-import reload**: The frontend automatically reloads workspace data, documents, and AI chat threads if the imported workspace is currently open.
+
+## Dependencies
+
+| Package | Purpose |
+|---------|---------|
+| `adm-zip` | ZIP archive extraction in memory |
+| `@types/adm-zip` | TypeScript types (dev) |
+| `multer` | Multipart file upload handling (already used by image routes) |

--- a/services/api/package.json
+++ b/services/api/package.json
@@ -16,6 +16,7 @@
         "aws-login": "aws sso login --use-device-code --sso-session=lixpi"
     },
     "dependencies": {
+        "adm-zip": "*",
         "archiver": "*",
         "@lixpi/auth-service": "workspace:*",
         "@lixpi/constants": "workspace:*",
@@ -48,6 +49,7 @@
     },
     "devDependencies": {
         "nodemon": "latest",
+        "@types/adm-zip": "*",
         "@types/archiver": "*",
         "@types/node": "*",
         "@types/express": "*"

--- a/services/api/src/models/ai-chat-thread.ts
+++ b/services/api/src/models/ai-chat-thread.ts
@@ -119,5 +119,34 @@ export default {
         } catch (error) {
             throw error
         }
+    },
+
+    deleteWorkspaceAiChatThreads: async ({
+        workspaceId
+    }: { workspaceId: string }): Promise<number> => {
+        const threads = await dynamoDBService.queryItems({
+            tableName: getDynamoDbTableStageName('AI_CHAT_THREADS', ORG_NAME, STAGE),
+            keyConditions: { workspaceId },
+            fetchAllItems: true,
+            origin: 'deleteWorkspaceAiChatThreads:query'
+        })
+
+        const allThreads = threads?.items || []
+        let deletedCount = 0
+
+        for (const thread of allThreads) {
+            try {
+                await dynamoDBService.deleteItems({
+                    tableName: getDynamoDbTableStageName('AI_CHAT_THREADS', ORG_NAME, STAGE),
+                    key: { workspaceId, threadId: thread.threadId },
+                    origin: 'deleteWorkspaceAiChatThreads:thread'
+                })
+                deletedCount++
+            } catch (error) {
+                console.error(`Failed to delete AI chat thread ${thread.threadId}:`, error)
+            }
+        }
+
+        return deletedCount
     }
 }

--- a/services/api/src/models/document.ts
+++ b/services/api/src/models/document.ts
@@ -321,5 +321,89 @@ export default {
 		} catch (e) {
 			throw e
 		}
+	},
+
+	importDocument: async ({
+		documentId,
+		workspaceId,
+		title,
+		content,
+		createdAt,
+		updatedAt
+	}: Pick<Document, 'documentId' | 'workspaceId' | 'title' | 'content' | 'createdAt' | 'updatedAt'>): Promise<Document | undefined> => {
+		const documentData: Document = {
+			documentId,
+			workspaceId,
+			revision: 1,
+			title,
+			content,
+			prevRevision: 1,
+			createdAt,
+			updatedAt
+		}
+
+		try {
+			await dynamoDBService.putItem({
+				tableName: getDynamoDbTableStageName('DOCUMENTS', ORG_NAME, STAGE),
+				item: documentData,
+				origin: 'importDocument'
+			})
+
+			await dynamoDBService.putItem({
+				tableName: getDynamoDbTableStageName('DOCUMENTS_META', ORG_NAME, STAGE),
+				item: {
+					documentId,
+					workspaceId,
+					title,
+					tags: [],
+					createdAt,
+					updatedAt
+				},
+				origin: 'importDocument'
+			})
+
+			return documentData
+		} catch (error) {
+			console.error('Failed to import document:', error)
+		}
+	},
+
+	deleteWorkspaceDocuments: async ({
+		workspaceId
+	}: { workspaceId: string }): Promise<number> => {
+		const documents = await dynamoDBService.queryItems({
+			tableName: getDynamoDbTableStageName('DOCUMENTS', ORG_NAME, STAGE),
+			indexName: 'workspaceId',
+			keyConditions: { workspaceId },
+			fetchAllItems: true,
+			origin: 'deleteWorkspaceDocuments:query'
+		})
+
+		const allDocuments = documents?.items || []
+		let deletedCount = 0
+
+		for (const doc of allDocuments) {
+			try {
+				await dynamoDBService.deleteItems({
+					tableName: getDynamoDbTableStageName('DOCUMENTS', ORG_NAME, STAGE),
+					key: { documentId: doc.documentId, revision: doc.revision },
+					origin: 'deleteWorkspaceDocuments:document'
+				})
+
+				if (doc.revision === 1) {
+					await dynamoDBService.deleteItems({
+						tableName: getDynamoDbTableStageName('DOCUMENTS_META', ORG_NAME, STAGE),
+						key: { documentId: doc.documentId },
+						origin: 'deleteWorkspaceDocuments:meta'
+					})
+				}
+
+				deletedCount++
+			} catch (error) {
+				console.error(`Failed to delete document ${doc.documentId}:`, error)
+			}
+		}
+
+		return deletedCount
 	}
 }

--- a/services/api/src/models/workspace.ts
+++ b/services/api/src/models/workspace.ts
@@ -332,5 +332,38 @@ export default {
         return workspace as Workspace
     },
 
+    replaceWorkspaceContent: async ({
+        workspaceId,
+        canvasState,
+        files
+    }: { workspaceId: string; canvasState: CanvasState; files: DocumentFile[] }): Promise<void> => {
+        const currentDate = new Date().getTime()
+
+        try {
+            await dynamoDBService.updateItem({
+                tableName: getDynamoDbTableStageName('WORKSPACES', ORG_NAME, STAGE),
+                key: { workspaceId },
+                updates: {
+                    canvasState,
+                    files,
+                    updatedAt: currentDate
+                },
+                origin: 'replaceWorkspaceContent'
+            })
+
+            await dynamoDBService.updateItem({
+                tableName: getDynamoDbTableStageName('WORKSPACES_META', ORG_NAME, STAGE),
+                key: { workspaceId },
+                updates: {
+                    updatedAt: currentDate
+                },
+                origin: 'replaceWorkspaceContent:meta'
+            })
+        } catch (error) {
+            console.error('Failed to replace workspace content:', error)
+            throw error
+        }
+    },
+
     getBucketName: getWorkspaceBucketName
 }

--- a/services/api/src/routes/workspace-export-routes.ts
+++ b/services/api/src/routes/workspace-export-routes.ts
@@ -2,6 +2,8 @@
 
 import { Router } from 'express'
 import archiver from 'archiver'
+import AdmZip from 'adm-zip'
+import multer from 'multer'
 
 import NATS_Service from '@lixpi/nats-service'
 import { type DocumentFile } from '@lixpi/constants'
@@ -15,6 +17,21 @@ import AiChatThread from '../models/ai-chat-thread.ts'
 const router = Router()
 
 const getWorkspaceBucketName = (workspaceId: string) => `workspace-${workspaceId}-files`
+
+// Maximum import file size: 1GB
+const MAX_IMPORT_SIZE = 1024 * 1024 * 1024
+
+const importUpload = multer({
+    storage: multer.memoryStorage(),
+    limits: { fileSize: MAX_IMPORT_SIZE },
+    fileFilter: (req, file, cb) => {
+        if (file.mimetype === 'application/zip' || file.mimetype === 'application/x-zip-compressed' || file.originalname.endsWith('.zip')) {
+            cb(null, true)
+        } else {
+            cb(new Error('Invalid file type. Only ZIP files are accepted.'))
+        }
+    }
+})
 
 const getFileExtension = (mimeType?: string, filename?: string): string => {
     if (filename) {
@@ -170,6 +187,153 @@ router.get(
             if (!res.headersSent) {
                 res.status(500).json({ error: 'Export failed' })
             }
+        }
+    }
+)
+
+// POST /api/workspaces/:workspaceId/import
+// Imports a previously exported ZIP archive, replacing all workspace content
+router.post(
+    '/:workspaceId/import',
+    authenticateRequest,
+    validateWorkspaceAccess,
+    importUpload.single('file'),
+    async (req: any, res: any) => {
+        const { workspaceId } = req.params
+        const file = req.file
+
+        if (!file) {
+            return res.status(400).json({ error: 'No file provided' })
+        }
+
+        // ── Parse ZIP ──────────────────────────────────────────────
+        let zip: AdmZip
+        let manifest: any
+
+        try {
+            zip = new AdmZip(file.buffer)
+        } catch (e: any) {
+            return res.status(400).json({ error: 'Invalid ZIP file' })
+        }
+
+        const manifestEntry = zip.getEntry('manifest.json')
+        if (!manifestEntry) {
+            return res.status(400).json({ error: 'ZIP archive is missing manifest.json' })
+        }
+
+        try {
+            manifest = JSON.parse(manifestEntry.getData().toString('utf8'))
+        } catch (e: any) {
+            return res.status(400).json({ error: 'manifest.json contains invalid JSON' })
+        }
+
+        // ── Validate manifest ──────────────────────────────────────
+        if (manifest.exportVersion !== 1) {
+            return res.status(400).json({ error: `Unsupported export version: ${manifest.exportVersion}` })
+        }
+
+        if (!manifest.workspace?.canvasState) {
+            return res.status(400).json({ error: 'manifest.json is missing workspace.canvasState' })
+        }
+
+        if (!Array.isArray(manifest.documents)) {
+            return res.status(400).json({ error: 'manifest.json is missing documents array' })
+        }
+
+        if (!Array.isArray(manifest.aiChatThreads)) {
+            return res.status(400).json({ error: 'manifest.json is missing aiChatThreads array' })
+        }
+
+        // Collect image entries from ZIP before wiping anything
+        const imageEntries: { fileId: string; ext: string; data: Buffer }[] = []
+
+        for (const entry of zip.getEntries()) {
+            if (entry.entryName.startsWith('images/') && !entry.isDirectory) {
+                const filename = entry.entryName.slice('images/'.length)
+                const dotIndex = filename.lastIndexOf('.')
+                const fileId = dotIndex !== -1 ? filename.substring(0, dotIndex) : filename
+                const ext = dotIndex !== -1 ? filename.substring(dotIndex) : ''
+                imageEntries.push({ fileId, ext, data: entry.getData() })
+            }
+        }
+
+        // ── Wipe existing content ──────────────────────────────────
+        try {
+            const natsService = NATS_Service.getInstance()
+            const bucketName = getWorkspaceBucketName(workspaceId)
+
+            await Promise.all([
+                // Delete all images (wipe entire NATS object store bucket)
+                (async () => {
+                    if (natsService) {
+                        try {
+                            await natsService.deleteObjectStore(bucketName)
+                        } catch (e: any) {
+                            // Bucket may not exist — that's fine
+                        }
+                    }
+                })(),
+                // Delete all documents from DynamoDB
+                Document.deleteWorkspaceDocuments({ workspaceId }),
+                // Delete all AI chat threads from DynamoDB
+                AiChatThread.deleteWorkspaceAiChatThreads({ workspaceId })
+            ])
+
+            // ── Restore images ─────────────────────────────────────
+            if (imageEntries.length > 0 && natsService) {
+                await natsService.ensureObjectStore(bucketName)
+                for (const image of imageEntries) {
+                    await natsService.putObject(bucketName, image.fileId, image.data, {
+                        name: image.fileId,
+                        description: `${image.fileId}${image.ext}`
+                    })
+                }
+            }
+
+            // ── Restore documents ──────────────────────────────────
+            for (const doc of manifest.documents) {
+                await Document.importDocument({
+                    documentId: doc.documentId,
+                    workspaceId,
+                    title: doc.title,
+                    content: doc.content,
+                    createdAt: doc.createdAt,
+                    updatedAt: doc.updatedAt
+                })
+            }
+
+            // ── Restore AI chat threads ────────────────────────────
+            for (const thread of manifest.aiChatThreads) {
+                await AiChatThread.createAiChatThread({
+                    workspaceId,
+                    threadId: thread.threadId,
+                    content: thread.content,
+                    aiModel: thread.aiModel
+                })
+            }
+
+            // ── Update workspace canvas state and files ────────────
+            const files: DocumentFile[] = manifest.workspace.files || []
+            await Workspace.replaceWorkspaceContent({
+                workspaceId,
+                canvasState: manifest.workspace.canvasState,
+                files
+            })
+
+            info(`Workspace ${workspaceId} imported successfully (${manifest.documents.length} documents, ${manifest.aiChatThreads.length} threads, ${imageEntries.length} images)`)
+
+            res.json({
+                success: true,
+                workspaceId,
+                imported: {
+                    documents: manifest.documents.length,
+                    aiChatThreads: manifest.aiChatThreads.length,
+                    images: imageEntries.length
+                }
+            })
+        } catch (e: any) {
+            err('Workspace import failed:', e)
+            res.status(500).json({ error: 'Import failed' })
         }
     }
 )

--- a/services/web-ui/src/components/Sidebar.svelte
+++ b/services/web-ui/src/components/Sidebar.svelte
@@ -6,6 +6,7 @@
     import { routerStore } from '$src/stores/routerStore'
     import { workspacesStore } from '$src/stores/workspacesStore.ts'
     import { workspaceStore } from '$src/stores/workspaceStore.ts'
+    import { servicesStore } from '$src/stores/servicesStore.ts'
     import { authStore } from '$src/stores/authStore'
     import { popOutTransition } from '$src/constants/svelteAnimationTransitions'
     import { Button } from '$lib/registry/ui/button/index.ts'
@@ -18,6 +19,9 @@
 
     let currentWorkspaceId = $derived($routerStore.data.currentRoute.routeParams.workspaceId)
 
+    let importFileInput: HTMLInputElement
+    let importTargetWorkspaceId: string | null = null
+
     const onWorkspaceDeleteHandler = async (workspaceId: string) => {
         const workspaceService = new WorkspaceService()
         await workspaceService.deleteWorkspace({ workspaceId })
@@ -29,6 +33,54 @@
 
         const apiUrl = import.meta.env.VITE_API_URL
         window.open(`${apiUrl}/api/workspaces/${workspaceId}/export?token=${token}`, '_blank')
+    }
+
+    const onWorkspaceImportHandler = (workspaceId: string) => {
+        importTargetWorkspaceId = workspaceId
+        importFileInput.value = ''
+        importFileInput.click()
+    }
+
+    const onImportFileSelected = async (event: Event) => {
+        const input = event.target as HTMLInputElement
+        const file = input.files?.[0]
+        if (!file || !importTargetWorkspaceId) return
+
+        const workspaceId = importTargetWorkspaceId
+        importTargetWorkspaceId = null
+
+        const token = await AuthService.getTokenSilently()
+        if (!token) return
+
+        const apiUrl = import.meta.env.VITE_API_URL
+        const formData = new FormData()
+        formData.append('file', file)
+
+        try {
+            const response = await fetch(`${apiUrl}/api/workspaces/${workspaceId}/import`, {
+                method: 'POST',
+                headers: { Authorization: `Bearer ${token}` },
+                body: formData
+            })
+
+            if (!response.ok) {
+                const error = await response.json()
+                console.error('Workspace import failed:', error)
+                return
+            }
+
+            // Reload workspace data if the imported workspace is currently open
+            if (currentWorkspaceId === workspaceId) {
+                const workspaceService = new WorkspaceService()
+                await workspaceService.getWorkspace({ workspaceId })
+                await Promise.all([
+                    servicesStore.getData('documentService').getWorkspaceDocuments({ workspaceId }),
+                    servicesStore.getData('aiChatThreadService').getWorkspaceAiChatThreads({ workspaceId })
+                ])
+            }
+        } catch (error) {
+            console.error('Workspace import failed:', error)
+        }
     }
 
     const handleWorkspaceClick = (workspaceId: string) => {
@@ -54,6 +106,7 @@
             id: `workspace-menu-${workspaceId}`,
             selectedValue: { title: '' },
             options: [
+                { title: 'Import' },
                 { title: 'Export' },
                 { title: 'Delete' },
             ],
@@ -65,7 +118,9 @@
             renderIconForOptions: false,
             mountToBody: true,
             onSelect: (option) => {
-                if (option.title === 'Export') {
+                if (option.title === 'Import') {
+                    onWorkspaceImportHandler(workspaceId)
+                } else if (option.title === 'Export') {
                     onWorkspaceExportHandler(workspaceId)
                 } else if (option.title === 'Delete') {
                     onWorkspaceDeleteHandler(workspaceId)
@@ -86,6 +141,14 @@
     }
 </script>
 
+
+<input
+    type="file"
+    accept=".zip"
+    class="hidden"
+    bind:this={importFileInput}
+    onchange={onImportFileSelected}
+/>
 
 <aside class="bg-sidebar">
 

--- a/services/web-ui/src/infographics/workspace/WorkspaceCanvas.ts
+++ b/services/web-ui/src/infographics/workspace/WorkspaceCanvas.ts
@@ -245,6 +245,50 @@ export function createWorkspaceCanvas(options: WorkspaceCanvasOptions) {
                     downloadImage(imgEl.src, { getAuthToken: () => AuthService.getTokenSilently() })
                 }
             },
+            onReplaceImage: (nodeId) => {
+                const input = document.createElement('input')
+                input.type = 'file'
+                input.accept = 'image/*'
+                input.style.display = 'none'
+                input.addEventListener('change', async () => {
+                    const file = input.files?.[0]
+                    input.remove()
+                    if (!file || !file.type.startsWith('image/')) return
+
+                    const API_BASE_URL = import.meta.env.VITE_API_URL || ''
+                    const token = await AuthService.getTokenSilently()
+                    if (!token) return
+
+                    const formData = new FormData()
+                    formData.append('file', file)
+
+                    const response = await fetch(`${API_BASE_URL}/api/images/${workspaceId}`, {
+                        method: 'POST',
+                        headers: { 'Authorization': `Bearer ${token}` },
+                        body: formData
+                    })
+
+                    if (!response.ok) return
+
+                    const data = await response.json()
+                    const newSrc = `${API_BASE_URL}${data.url}?token=${encodeURIComponent(token)}`
+
+                    // Update DOM immediately
+                    const nodeEl = viewportEl?.querySelector(`[data-node-id="${nodeId}"]`) as HTMLElement | null
+                    const imgEl = nodeEl?.querySelector('img') as HTMLImageElement | null
+                    if (imgEl) imgEl.src = newSrc
+
+                    // Update canvas state
+                    if (!currentCanvasState) return
+                    const updatedNodes = currentCanvasState.nodes.map((n: CanvasNode) => {
+                        if (n.nodeId !== nodeId || n.type !== 'image') return n
+                        return { ...n, fileId: data.fileId, src: newSrc } as ImageCanvasNode
+                    })
+                    commitCanvasState({ ...currentCanvasState, nodes: updatedNodes })
+                })
+                document.body.appendChild(input)
+                input.click()
+            },
             onAskAi: async (nodeId) => {
                 const imageNode = currentCanvasState?.nodes.find((n: CanvasNode) => n.nodeId === nodeId)
                 if (!imageNode || imageNode.type !== 'image') return
@@ -1393,6 +1437,7 @@ export function createWorkspaceCanvas(options: WorkspaceCanvasOptions) {
         if (!imageUrl) return 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII='
         if (imageUrl.startsWith('data:')) return imageUrl
         if (imageUrl.startsWith('/api/')) return `${apiBaseUrl}${imageUrl}${token ? `?token=${token}` : ''}`
+        if (imageUrl.startsWith('http') && imageUrl.includes('/api/images/')) return `${imageUrl}${token ? `?token=${token}` : ''}`
         if (imageUrl.startsWith('http')) return imageUrl
         return `data:image/png;base64,${imageUrl}`
     }
@@ -3169,9 +3214,15 @@ export function createWorkspaceCanvas(options: WorkspaceCanvasOptions) {
         // Create the img element - fills the container
         const imgEl = document.createElement('img')
         imgEl.className = 'image-node-img'
-        imgEl.src = node.src
         imgEl.alt = ''
         imgEl.draggable = false
+
+        // Strip any stale token from src, then re-apply a fresh one via buildImageSrc
+        const rawSrc = node.src.replace(/[?&]token=[^&]+/, '')
+        const API_BASE_URL = import.meta.env.VITE_API_URL || ''
+        AuthService.getTokenSilently().then(token => {
+            imgEl.src = buildImageSrc(rawSrc, API_BASE_URL, token)
+        })
 
         // Once image loads, fix container dimensions to match actual aspect ratio
         imgEl.onload = () => {

--- a/services/web-ui/src/infographics/workspace/canvasBubbleMenuItems.ts
+++ b/services/web-ui/src/infographics/workspace/canvasBubbleMenuItems.ts
@@ -21,6 +21,7 @@ type CanvasBubbleMenuCallbacks = {
     onChangeConnectorCurve: (edgeId: string) => void
     onAskAi: (nodeId: string) => void
     onDownloadImage: (nodeId: string) => void
+    onReplaceImage: (nodeId: string) => void
     onTriggerConnection: (nodeId: string) => void
     onHide: () => void
 }
@@ -87,6 +88,20 @@ export function buildCanvasBubbleMenuItems(callbacks: CanvasBubbleMenuCallbacks)
         },
     })
 
+    const replaceButton = createCanvasButton({
+        icon: downloadIcon,
+        title: 'Replace image',
+        iconSize: 16,
+        onClick: () => {
+            if (activeNodeId) {
+                callbacks.onReplaceImage(activeNodeId)
+                callbacks.onHide()
+            }
+        },
+    })
+    const replaceSvg = replaceButton.querySelector('svg')
+    if (replaceSvg) replaceSvg.style.transform = 'rotate(180deg)'
+
     const connectButton = createEl('button', {
         className: 'bubble-menu-button',
         type: 'button',
@@ -145,6 +160,7 @@ export function buildCanvasBubbleMenuItems(callbacks: CanvasBubbleMenuCallbacks)
 
     const items: BubbleMenuItem[] = [
         { element: askAiButton, context: [CANVAS_IMAGE_CONTEXT] },
+        { element: replaceButton, context: [CANVAS_IMAGE_CONTEXT] },
         { element: downloadButton, context: [CANVAS_IMAGE_CONTEXT] },
         { element: connectButton, context: [CANVAS_IMAGE_CONTEXT] },
         { element: deleteButton, context: [CANVAS_IMAGE_CONTEXT] },


### PR DESCRIPTION
## Summary

Two features:

1. **Workspace Import** — Import a workspace from a previously exported ZIP, fully replacing current workspace content.
2. **Replace Image on Canvas** — Bubble menu action to replace any image on the canvas.

## Workspace Import

- `POST /:workspaceId/import` endpoint — accepts ZIP via multer, validates manifest, wipes existing data (documents, AI chat threads, NATS object store), restores from archive
- `importDocument()` and `deleteWorkspaceDocuments()` in document model
- `deleteWorkspaceAiChatThreads()` in AI chat thread model
- `replaceWorkspaceContent()` in workspace model
- Added `adm-zip` dependency
- Sidebar UI: "Import" menu item with file picker and upload handler
- Updated `WORKSPACE-EXPORT.md` documentation with import section

## Replace Image on Canvas

- Replace button (download icon rotated 180°) in image bubble menu
- `onReplaceImage` handler: file picker → upload → update DOM + canvas state

Closes #105