### PR TITLE
LIX-114 # Fix shadcn-svelte submodule breaking web-ui with unresolvable deps

### DIFF
--- a/services/web-ui/src/shadcn-icon-stub.svelte
+++ b/services/web-ui/src/shadcn-icon-stub.svelte
@@ -1,0 +1,6 @@
+<!-- TEMP: stub replacing shadcn docs' icon-placeholder — may consider dropping shadcn-svelte entirely, too cumbersome to maintain -->
+<script lang="ts">
+	let { class: className }: Record<string, any> = $props();
+</script>
+
+<span class={className}></span>

--- a/services/web-ui/vite.config.ts
+++ b/services/web-ui/vite.config.ts
@@ -13,6 +13,9 @@ export default defineConfig({
         globals: true,
         include: ['src/**/*.test.ts'],
         alias: {
+            // TEMP: stub out shadcn docs' icon-placeholder — may consider dropping shadcn-svelte entirely, too cumbersome to maintain
+            '$lib/components/icon-placeholder/icon-placeholder.svelte': path.resolve("./src/shadcn-icon-stub.svelte"),
+            '$lib/components/icon-placeholder/icon-placeholder': path.resolve("./src/shadcn-icon-stub.svelte"),
             $src: path.resolve("./src"),
             $lib: path.resolve("./packages/shadcn-svelte/lib"),
         },
@@ -28,6 +31,9 @@ export default defineConfig({
     // mode:'development',
     resolve: {
         alias: {
+            // TEMP: stub out shadcn docs' icon-placeholder — may consider dropping shadcn-svelte entirely, too cumbersome to maintain
+            '$lib/components/icon-placeholder/icon-placeholder.svelte': path.resolve("./src/shadcn-icon-stub.svelte"),
+            '$lib/components/icon-placeholder/icon-placeholder': path.resolve("./src/shadcn-icon-stub.svelte"),
             $src: path.resolve("./src"),
             $lib: path.resolve("./packages/shadcn-svelte/lib"),
         },


### PR DESCRIPTION
## Summary

After shadcn-svelte was moved to a git submodule, the web-ui fails to start because Vite tries to resolve docs-site-only dependencies (`@hugeicons/svelte`, `runed`, `$app/environment`, `zod`, `shadcn-svelte/preset`, etc.) from the upstream `docs/src/lib` directory.

The root cause is the `icon-placeholder` component recently added upstream — it pulls in a multi-icon-library abstraction with design-system, hugeicons, and other deps we don't need. UI components like `dropdown-menu`, `dialog`, `sonner` transitively import it.

## Changes

- **`services/web-ui/src/shadcn-icon-stub.svelte`** — Empty `<span>` stub component replacing the icon-placeholder
- **`services/web-ui/vite.config.ts`** — Vite resolve alias redirecting `$lib/components/icon-placeholder/icon-placeholder` to the stub, cutting off the entire problematic dependency chain

No new dependencies added. No docker-compose or Dockerfile changes needed.

This is a temporary fix — we may consider dropping shadcn-svelte entirely as it's too cumbersome to maintain as a submodule.

Closes #114