### PR TITLE
LIX-120 # Fix dropdown value persistence across page refresh

### DIFF
--- a/services/web-ui/src/infographics/workspace/WorkspaceCanvas.ts
+++ b/services/web-ui/src/infographics/workspace/WorkspaceCanvas.ts
@@ -969,7 +969,7 @@ export function createWorkspaceCanvas(options: WorkspaceCanvasOptions) {
 
     // ---- Per-thread floating inputs (always visible for aiChatThread nodes) ----
 
-    function createThreadFloatingInput(node: AiChatThreadCanvasNode): void {
+    function createThreadFloatingInput(node: AiChatThreadCanvasNode, savedAttrs?: { aiModel?: string; aiImageModel?: string; imageGenerationSize?: string }): void {
         if (threadFloatingInputs.has(node.nodeId)) return
 
         const el = document.createElement('div')
@@ -1044,6 +1044,26 @@ export function createWorkspaceCanvas(options: WorkspaceCanvasOptions) {
             editor,
             gradient,
         })
+
+        // Restore saved dropdown attrs from the thread content
+        if (savedAttrs) {
+            const view = editor.editorView
+            let inputPos: number | undefined
+            view.state.doc.descendants((n: any, pos: number) => {
+                if (n.type.name === 'aiPromptInput' && inputPos === undefined) inputPos = pos
+            })
+            if (inputPos !== undefined) {
+                const node = view.state.doc.nodeAt(inputPos)
+                if (node) {
+                    const tr = view.state.tr.setNodeMarkup(inputPos, undefined, {
+                        ...node.attrs,
+                        ...savedAttrs,
+                    })
+                    tr.setMeta('skipDispatch', true)
+                    view.dispatch(tr)
+                }
+            }
+        }
     }
 
     // Returns the vertical offset from a thread node's top to where the floating
@@ -3190,8 +3210,20 @@ export function createWorkspaceCanvas(options: WorkspaceCanvasOptions) {
             hideThreadNode(nodeEl, node.nodeId)
         }
 
-        // Create the always-visible per-thread floating prompt input
-        createThreadFloatingInput(node)
+        // Create the always-visible per-thread floating prompt input.
+        // Extract saved dropdown attrs from thread content so the floating
+        // input restores the previously-selected model / image options.
+        const threadContentNode = thread?.content?.content?.find(
+            (n: any) => n.type === 'aiChatThread'
+        )
+        const savedDropdownAttrs = threadContentNode?.attrs
+            ? {
+                aiModel: threadContentNode.attrs.aiModel,
+                aiImageModel: threadContentNode.attrs.aiImageModel,
+                imageGenerationSize: threadContentNode.attrs.imageGenerationSize,
+            }
+            : undefined
+        createThreadFloatingInput(node, savedDropdownAttrs)
 
         // Create the vertical rail element (drag handle + connection proxy)
         createThreadRail(node)


### PR DESCRIPTION
## Summary

Fixes dropdown values (AI model, image model, aspect ratio/size) not persisting across page refresh for each AI chat thread.

## Root Cause

The per-thread floating prompt input editor was created with `initialVal: {}`, ignoring the thread's saved attrs (`aiModel`, `aiImageModel`, `imageGenerationSize`). Even though these values were correctly saved in DynamoDB as part of the ProseMirror content JSON, they were never restored to the floating input UI on load.

## Changes

**`WorkspaceCanvas.ts`**:
- `createThreadFloatingInput` now accepts an optional `savedAttrs` parameter
- After creating the floating input editor, dispatches a transaction to set the saved attrs on the `aiPromptInput` node
- `createAiChatThreadNode` extracts the saved dropdown attrs from the thread's ProseMirror content JSON and passes them to `createThreadFloatingInput`

Closes #120