### PR TITLE
LIX-122 # Image resilience, silent auth refresh, and code style enforcement

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -113,6 +113,7 @@ services:
             DOMAIN_NAME: ${DOMAIN_NAME}
         volumes:
             - caddy-certs:/opt/nats/certs:ro  # Read-only certificates from Caddy
+            - nats-1-data:/data                # Persistent JetStream storage
         command: [
             "--config", "/opt/nats/nats-server.conf",
             "--routes", "nats://sys:${NATS_SYS_USER_PASSWORD}@lixpi-nats-1:6222,nats://sys:${NATS_SYS_USER_PASSWORD}@lixpi-nats-2:6222,nats://sys:${NATS_SYS_USER_PASSWORD}@lixpi-nats-3:6222"
@@ -158,6 +159,7 @@ services:
             DOMAIN_NAME: ${DOMAIN_NAME}
         volumes:
             - caddy-certs:/opt/nats/certs:ro  # Read-only certificates from Caddy
+            - nats-2-data:/data                # Persistent JetStream storage
         command: [
             "--config", "/opt/nats/nats-server.conf",
             "--routes", "nats://sys:${NATS_SYS_USER_PASSWORD}@lixpi-nats-1:6222,nats://sys:${NATS_SYS_USER_PASSWORD}@lixpi-nats-2:6222,nats://sys:${NATS_SYS_USER_PASSWORD}@lixpi-nats-3:6222"
@@ -203,6 +205,7 @@ services:
             DOMAIN_NAME: ${DOMAIN_NAME}
         volumes:
             - caddy-certs:/opt/nats/certs:ro  # Read-only certificates from Caddy
+            - nats-3-data:/data                # Persistent JetStream storage
         command: [
             "--config", "/opt/nats/nats-server.conf",
             "--routes", "nats://sys:${NATS_SYS_USER_PASSWORD}@lixpi-nats-1:6222,nats://sys:${NATS_SYS_USER_PASSWORD}@lixpi-nats-2:6222,nats://sys:${NATS_SYS_USER_PASSWORD}@lixpi-nats-3:6222"
@@ -598,6 +601,9 @@ volumes:
     caddy-certs:   # Shared volume for certificate storage
     dynamodb-data: # Persistent storage for DynamoDB Local
     localauth0-data: # Persistent storage for LocalAuth0 mock service
+    nats-1-data:   # Persistent JetStream storage for NATS node 1
+    nats-2-data:   # Persistent JetStream storage for NATS node 2
+    nats-3-data:   # Persistent JetStream storage for NATS node 3
 
 networks:
     nats:

--- a/documentation/coding-style-guides/TYPESCRIPT.md
+++ b/documentation/coding-style-guides/TYPESCRIPT.md
@@ -32,7 +32,18 @@ interface UserProfile {
 
 ## Comments
 
-- Never use JSDoc comments. No `/** */` blocks anywhere in the codebase.
+- Always use `//` single-line comments. For multi-line explanations, use multiple `//` lines.
+- Never use `/** */` or `/* */` block comments anywhere in the codebase.
+
+```typescript
+// Correct — single-line
+// This function handles token refresh by redirecting
+// through the browser-based login flow.
+
+// Wrong — never use block comments
+/** This function handles token refresh. */
+/* This function handles token refresh. */
+```
 
 ## Docker
 
@@ -53,6 +64,27 @@ const data = await fetchData()
 // Wrong — never use .then()
 fetchData().then((data) => { ... })
 ```
+
+### DOM Templating (web-ui)
+
+In all non-Svelte `.ts` files that create DOM elements — ProseMirror plugins and NodeViews, shared components like dropdowns and bubble menus, canvas code, and any utility that builds UI — always use the `html` tagged template from `domTemplates.ts`:
+
+```typescript
+import { html } from '$src/utils/domTemplates.ts'
+
+const el = html`
+    <div className="my-component" onclick=${handleClick}>
+        <span innerHTML=${someIcon}></span>
+        <span>Label</span>
+    </div>
+`
+```
+
+Never use `document.createElement` / `Object.assign(el.style, ...)` / manual `el.className = ...` / `el.setAttribute(...)` in these files. The `html` helper produces real DOM nodes (no VDOM) and handles `className`, `innerHTML`, inline `style` objects, `data` attributes, and `on*` event handlers.
+
+For SVG icons, import them from `$src/svgIcons/index.ts` and inject via `innerHTML` or string interpolation — never inline SVG markup in component code.
+
+The only exception is test files (`*.test.ts`) where minimal DOM setup for mocking is acceptable.
 
 ### Prefer Modern APIs Over Legacy Alternatives
 

--- a/services/api/src/routes/image-routes.ts
+++ b/services/api/src/routes/image-routes.ts
@@ -211,7 +211,18 @@ router.get(
             const fileInfo = workspace.files?.find((f: DocumentFile) => f.id === fileId)
 
             // Get file from Object Store
-            const data = await natsService.getObject(bucketName, fileId)
+            let data: Uint8Array | null = null
+            try {
+                data = await natsService.getObject(bucketName, fileId)
+            } catch (objErr: any) {
+                const msg = objErr?.message || String(objErr)
+                if (msg.includes('no stream') || msg.includes('not found') || msg.includes('bucket')) {
+                    err(`Object Store bucket missing for ${workspaceId}: ${msg}`)
+                    return res.status(404).json({ error: 'Image storage not found — data may have been lost' })
+                }
+                throw objErr
+            }
+
             if (!data) {
                 return res.status(404).json({ error: 'Image not found' })
             }

--- a/services/web-ui/src/components/proseMirror/ProseMirror.scss
+++ b/services/web-ui/src/components/proseMirror/ProseMirror.scss
@@ -274,6 +274,25 @@ img.ProseMirror-separator {
 // .ai-user-message, .ai-response-message, .ai-user-input styles removed
 
 
+.image-error-placeholder {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	justify-content: center;
+	gap: 8px;
+	width: 100%;
+	min-height: 60px;
+	color: #888;
+	font-size: 12px;
+	background-color: rgba(0, 0, 0, 0.05);
+	border-radius: 4px;
+
+	svg {
+		width: 48px;
+		height: 48px;
+	}
+}
+
 .ai-suggest-decorator {
 	&.visible {
 		opacity: 1;

--- a/services/web-ui/src/components/proseMirror/plugins/README.md
+++ b/services/web-ui/src/components/proseMirror/plugins/README.md
@@ -116,10 +116,9 @@ class MyNodeView implements NodeView {
   dropdown: { dom: HTMLElement; update: (v: string) => void; destroy: () => void }
 
   constructor(node: Node, view: EditorView, getPos: () => number) {
-    // Create container structure
-    this.dom = document.createElement('div')
-    this.controlsContainer = document.createElement('div')
-    this.dom.appendChild(this.controlsContainer)
+    // Build container structure with html template
+    this.controlsContainer = html`<div className="controls"></div>`
+    this.dom = html`<div className="node-wrapper">${this.controlsContainer}</div>`
 
     // Create dropdown outside document schema
     this.dropdown = createPureDropdown({
@@ -127,7 +126,6 @@ class MyNodeView implements NodeView {
       selectedValue: node.attrs.value,
       options: [...],
       onSelect: (value) => {
-        // Update node attrs via transaction
         const pos = getPos()
         view.dispatch(
           view.state.tr.setNodeMarkup(pos, null, { ...node.attrs, value })
@@ -298,7 +296,7 @@ return {
 
 ## Templating & NodeViews
 
-Import once and use everywhere:
+**All DOM creation in non-Svelte `.ts` files must use the `html` tagged template** from `$src/utils/domTemplates.ts`. This applies to ProseMirror NodeViews, plugins, shared components (dropdowns, bubble menus, loading placeholders, info bubbles), and canvas code. Never use `document.createElement` or manual attribute/style assignment for building UI.
 
 ```ts
 import { html } from '$src/utils/domTemplates.ts'
@@ -310,10 +308,12 @@ const el = html`
 `
 ```
 
-Rules of thumb:
-- Use `className` and `innerHTML` in templates.
+Rules:
+- Use `className` and `innerHTML` in templates (not `class`).
 - Event handlers: `onclick`, `onmouseenter`, etc. Keep handlers stable, avoid recreating closures in tight loops.
 - Styles: pass an object to `style=${{ ... }}` if needed. Keep it minimal; most styling belongs in SCSS.
+- SVG icons: always import from `$src/svgIcons/index.ts` and inject via `innerHTML` or string interpolation — never inline SVG markup in component files.
+- The only exception is test files (`*.test.ts`) where minimal DOM setup for mocking is acceptable.
 
 ## Decorations – the visual contract
 

--- a/services/web-ui/src/components/proseMirror/plugins/aiChatThreadPlugin/aiGeneratedImageNode.ts
+++ b/services/web-ui/src/components/proseMirror/plugins/aiChatThreadPlugin/aiGeneratedImageNode.ts
@@ -1,4 +1,4 @@
-import { gptAvatarIcon } from '$src/svgIcons/index.ts'
+import { gptAvatarIcon, brokenImageIcon } from '$src/svgIcons/index.ts'
 import { html } from '$src/utils/domTemplates.ts'
 import AuthService from '$src/services/auth-service.ts'
 import { NodeSelection } from 'prosemirror-state'
@@ -153,14 +153,19 @@ export const aiGeneratedImageNodeView = (node: any, view: any, getPos: () => num
         if (imageData.startsWith('data:')) {
             imageSrc = imageData
         } else if (imageData.startsWith('/api/')) {
-            // URL path - needs auth token appended as query param
             const token = await AuthService.getTokenSilently()
             const API_BASE_URL = import.meta.env.VITE_API_URL || ''
-            imageSrc = `${API_BASE_URL}${imageData}?token=${token}`
+            imageSrc = `${API_BASE_URL}${imageData}${token ? `?token=${token}` : ''}`
             console.log('🖼️ [IMAGE_NODE] built image URL:', imageSrc)
         } else if (imageData.startsWith('http')) {
-            // Full URL (already has token)
-            imageSrc = imageData
+            // Full URL — strip any stale token and re-apply a fresh one
+            const stripped = imageData.replace(/[?&]token=[^&]+/, '')
+            if (stripped.includes('/api/images/')) {
+                const token = await AuthService.getTokenSilently()
+                imageSrc = `${stripped}${token ? `?token=${token}` : ''}`
+            } else {
+                imageSrc = imageData
+            }
         } else {
             // Legacy base64 data
             imageSrc = `data:image/png;base64,${imageData}`
@@ -178,7 +183,16 @@ export const aiGeneratedImageNodeView = (node: any, view: any, getPos: () => num
         }
     }
 
-    updateDisplay()
+    imageElement.onerror = () => {
+        imageElement.style.display = 'none'
+        if (!container.querySelector('.image-error-placeholder')) {
+            container.appendChild(html`
+                <div className="image-error-placeholder">${brokenImageIcon}<span>Image unavailable</span></div>
+            `)
+        }
+    }
+
+    updateDisplay().catch(() => {})
 
     return {
         dom: wrapper,

--- a/services/web-ui/src/components/proseMirror/plugins/imageSelectionPlugin/imageNodeView.ts
+++ b/services/web-ui/src/components/proseMirror/plugins/imageSelectionPlugin/imageNodeView.ts
@@ -1,8 +1,9 @@
 import type { Node as ProseMirrorNode } from 'prosemirror-model'
 import type { EditorView, NodeView } from 'prosemirror-view'
 import { NodeSelection } from 'prosemirror-state'
-import { imageResizeCornerIcon } from '$src/svgIcons/index.ts'
+import { imageResizeCornerIcon, brokenImageIcon } from '$src/svgIcons/index.ts'
 import AuthService from '$src/services/auth-service.ts'
+import { html } from '$src/utils/domTemplates.ts'
 
 type ImageAlignment = 'left' | 'center' | 'right'
 type TextWrap = 'none' | 'left' | 'right'
@@ -28,16 +29,18 @@ async function buildImageSrc(src: string): Promise<string> {
         return src
     }
 
-    // Full URLs that already have tokens
-    if (src.startsWith('http') && src.includes('token=')) {
-        return src
-    }
-
     // API paths need auth token
     if (src.startsWith('/api/')) {
         const token = await AuthService.getTokenSilently()
         const API_BASE_URL = import.meta.env.VITE_API_URL || ''
-        return `${API_BASE_URL}${src}?token=${encodeURIComponent(token)}`
+        return `${API_BASE_URL}${src}${token ? `?token=${encodeURIComponent(token)}` : ''}`
+    }
+
+    // Full URLs pointing to /api/images/ — strip stale token and re-apply fresh one
+    if (src.startsWith('http') && src.includes('/api/images/')) {
+        const stripped = src.replace(/[?&]token=[^&]+/, '')
+        const token = await AuthService.getTokenSilently()
+        return `${stripped}${token ? `?token=${encodeURIComponent(token)}` : ''}`
     }
 
     // External URLs or already full URLs
@@ -108,6 +111,15 @@ export class ImageNodeView implements NodeView {
         // Store aspect ratio when image loads
         this.img.addEventListener('load', this.handleImageLoad)
 
+        this.img.addEventListener('error', () => {
+            this.img.style.display = 'none'
+            if (!this.figure.querySelector('.image-error-placeholder')) {
+                this.figure.appendChild(html`
+                    <div className="image-error-placeholder">${brokenImageIcon}<span>Image unavailable</span></div>
+                `)
+            }
+        })
+
         // Handle selection on click
         this.figure.addEventListener('click', this.handleClick)
 
@@ -116,12 +128,16 @@ export class ImageNodeView implements NodeView {
 
     private async updateImageSrc(src: string): Promise<void> {
         if (src === this.currentSrcAttr && this.img.src) {
-            return // No change needed
+            return
         }
         this.currentSrcAttr = src
-        const resolvedSrc = await buildImageSrc(src)
-        if (this.img.src !== resolvedSrc) {
-            this.img.src = resolvedSrc
+        try {
+            const resolvedSrc = await buildImageSrc(src)
+            if (this.img.src !== resolvedSrc) {
+                this.img.src = resolvedSrc
+            }
+        } catch (error) {
+            console.error('[ImageNodeView] Failed to resolve image src:', error)
         }
     }
 

--- a/services/web-ui/src/infographics/workspace/WorkspaceCanvas.ts
+++ b/services/web-ui/src/infographics/workspace/WorkspaceCanvas.ts
@@ -20,12 +20,13 @@ import {
 import { ProseMirrorEditor } from '$src/components/proseMirror/components/editor.js'
 import { setAiGeneratedImageCallbacks } from '$src/components/proseMirror/plugins/aiChatThreadPlugin/index.ts'
 import AiInteractionService from '$src/services/ai-interaction-service.ts'
-import { imageResizeCornerIcon, aiChatThreadRailBoundaryCircle, claudeIcon, gptAvatarIcon, geminiIcon, stabilityIcon } from '$src/svgIcons/index.ts'
+import { imageResizeCornerIcon, aiChatThreadRailBoundaryCircle, claudeIcon, gptAvatarIcon, geminiIcon, stabilityIcon, brokenImageIcon } from '$src/svgIcons/index.ts'
 import { type Document } from '$src/stores/documentStore.ts'
 import { createCanvasImageLifecycleTracker } from '$src/infographics/workspace/canvasImageLifecycle.ts'
 import { createLoadingPlaceholder, createErrorPlaceholder } from '$src/components/proseMirror/plugins/primitives/loadingPlaceholder/index.ts'
 import { WorkspaceConnectionManager } from '$src/infographics/workspace/WorkspaceConnectionManager.ts'
 import { getResizeHandleScaledSizes } from '$src/infographics/utils/zoomScaling.ts'
+import { html } from '$src/utils/domTemplates.ts'
 import { resolveCollisions } from '$src/infographics/utils/resolveCollisions.ts'
 import { computeImagePositionNextToThread, computeImagePositionOverlappingThread, countExistingImagesForThread, OVERLAP_PADDING_X, OVERLAP_GAP_Y, OVERLAP_WIDTH_RATIO } from '$src/infographics/workspace/imagePositioning.ts'
 import { createNodeLayerManager } from '$src/infographics/workspace/nodeLayering.ts'
@@ -1464,6 +1465,18 @@ export function createWorkspaceCanvas(options: WorkspaceCanvasOptions) {
         if (imageUrl.startsWith('http') && imageUrl.includes('/api/images/')) return `${imageUrl}${token ? `?token=${token}` : ''}`
         if (imageUrl.startsWith('http')) return imageUrl
         return `data:image/png;base64,${imageUrl}`
+    }
+
+    function showImageErrorPlaceholder(imgEl: HTMLImageElement, nodeEl: HTMLElement): void {
+        imgEl.style.display = 'none'
+        if (nodeEl.querySelector('.image-error-placeholder')) return
+
+        nodeEl.appendChild(html`
+            <div className="image-error-placeholder">
+                ${brokenImageIcon}
+                <span>Image unavailable</span>
+            </div>
+        `)
     }
 
     // Append an image node to the DOM directly without a full renderNodes() cycle.
@@ -3258,9 +3271,31 @@ export function createWorkspaceCanvas(options: WorkspaceCanvasOptions) {
         // Strip any stale token from src, then re-apply a fresh one via buildImageSrc
         const rawSrc = node.src.replace(/[?&]token=[^&]+/, '')
         const API_BASE_URL = import.meta.env.VITE_API_URL || ''
+
+        let retried = false
         AuthService.getTokenSilently().then(token => {
             imgEl.src = buildImageSrc(rawSrc, API_BASE_URL, token)
+        }).catch(() => {
+            showImageErrorPlaceholder(imgEl, nodeEl)
         })
+
+        imgEl.onerror = () => {
+            if (!retried) {
+                retried = true
+                AuthService.getTokenSilently().then(token => {
+                    if (token) {
+                        const freshSrc = buildImageSrc(rawSrc, API_BASE_URL, token)
+                        if (imgEl.src !== freshSrc) {
+                            imgEl.src = freshSrc
+                            return
+                        }
+                    }
+                    showImageErrorPlaceholder(imgEl, nodeEl)
+                }).catch(() => showImageErrorPlaceholder(imgEl, nodeEl))
+            } else {
+                showImageErrorPlaceholder(imgEl, nodeEl)
+            }
+        }
 
         // Once image loads, fix container dimensions to match actual aspect ratio
         imgEl.onload = () => {

--- a/services/web-ui/src/infographics/workspace/workspace-canvas.scss
+++ b/services/web-ui/src/infographics/workspace/workspace-canvas.scss
@@ -844,6 +844,26 @@
     left: 100%;
 }
 
+.image-error-placeholder {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    width: 100%;
+    height: 100%;
+    min-height: 60px;
+    color: #888;
+    font-size: 12px;
+    background-color: rgba(0, 0, 0, 0.05);
+    border-radius: 4px;
+
+    svg {
+        width: 48px;
+        height: 48px;
+    }
+}
+
 // Show handles on hover for all node types
 .workspace-document-node:hover .workspace-handle,
 .workspace-image-node:hover .workspace-handle,

--- a/services/web-ui/src/services/auth0-mock-service.ts
+++ b/services/web-ui/src/services/auth0-mock-service.ts
@@ -44,10 +44,10 @@ class Auth0MockService {
                 }
             }
 
-            // Check if we have a token
+            // Check if we have a non-expired token
             const token = localStorage.getItem('localauth0_token')
 
-            if (token) {
+            if (token && !this.isTokenExpired(token)) {
                 // Mock user object matching Auth0 format
                 const user = {
                     userId: 'local|test-user-001',
@@ -105,54 +105,93 @@ class Auth0MockService {
         }
     }
 
-    private async refreshMockToken(): Promise<string> {
-        // Get a fresh token from LocalAuth0
-        const authUrl = `http://${AUTH0_DOMAIN}/authorize?` + new URLSearchParams({
-            client_id: AUTH0_CLIENT_ID,
-            audience: AUTH0_AUDIENCE,
-            redirect_uri: AUTH0_REDIRECT_URI,
-            scope: 'openid profile email',
-            response_type: 'token',
-            bypass: 'true'
-        }).toString()
+    // Silent token refresh via hidden iframe. LocalAuth0's /authorize?bypass=true
+    // auto-approves and redirects back with #access_token=... which we read out.
+    // The iframe fires `load` once for the WASM SPA page, then again when it
+    // redirects to our callback. We resolve/reject based on load events alone.
+    private refreshTokenViaIframe(): Promise<string> {
+        return new Promise((resolve, reject) => {
+            const iframe = document.createElement('iframe')
+            iframe.style.display = 'none'
 
-        // Fetch the token directly without redirect
-        const response = await fetch(authUrl, { redirect: 'manual' })
-        const redirectUrl = response.headers.get('Location')
+            const callbackPath = new URL(AUTH0_REDIRECT_URI).pathname
+            let loadCount = 0
 
-        if (redirectUrl) {
-            const hash = redirectUrl.split('#')[1]
-            if (hash) {
-                const params = new URLSearchParams(hash)
-                const accessToken = params.get('access_token')
-                if (accessToken) {
-                    localStorage.setItem('localauth0_token', accessToken)
-                    return accessToken
+            const cleanup = () => iframe.remove()
+
+            iframe.addEventListener('load', () => {
+                loadCount++
+
+                try {
+                    const iframeUrl = iframe.contentWindow?.location.href ?? ''
+
+                    if (!iframeUrl.includes(callbackPath)) {
+                        if (loadCount > 1) {
+                            cleanup()
+                            reject(new Error('Iframe navigated without reaching callback'))
+                        }
+                        return
+                    }
+
+                    const hash = iframe.contentWindow?.location.hash?.substring(1)
+                    if (!hash) {
+                        cleanup()
+                        reject(new Error('No hash fragment in iframe redirect'))
+                        return
+                    }
+
+                    const params = new URLSearchParams(hash)
+                    const accessToken = params.get('access_token')
+                    cleanup()
+
+                    if (accessToken) {
+                        localStorage.setItem('localauth0_token', accessToken)
+                        resolve(accessToken)
+                    } else {
+                        reject(new Error('No access_token in iframe response'))
+                    }
+                } catch {
+                    // Cross-origin read error — expected on the initial WASM page load
+                    // before LocalAuth0 redirects back to our origin.
+                    if (loadCount > 1) {
+                        cleanup()
+                        reject(new Error('Cannot read iframe after multiple loads'))
+                    }
                 }
-            }
-        }
+            })
 
-        throw new Error('Failed to refresh mock token')
+            iframe.addEventListener('error', () => {
+                cleanup()
+                reject(new Error('Iframe failed to load'))
+            })
+
+            const authUrl = `http://${AUTH0_DOMAIN}/authorize?` + new URLSearchParams({
+                client_id: AUTH0_CLIENT_ID,
+                audience: AUTH0_AUDIENCE,
+                redirect_uri: AUTH0_REDIRECT_URI,
+                scope: 'openid profile email',
+                response_type: 'token',
+                bypass: 'true',
+                prompt: 'none',
+            }).toString()
+
+            document.body.appendChild(iframe)
+            iframe.src = authUrl
+        })
     }
 
     public async getTokenSilently(): Promise<string | false> {
-        try {
-            let token = localStorage.getItem('localauth0_token')
-
-            // Check if token is expired or missing
-            if (!token || this.isTokenExpired(token)) {
-                console.log('Mock token expired or missing, refreshing...')
-                try {
-                    token = await this.refreshMockToken()
-                } catch (error) {
-                    console.error('Failed to refresh mock token:', error)
-                    await this.login()
-                    return false
-                }
-            }
-
+        const token = localStorage.getItem('localauth0_token')
+        if (token && !this.isTokenExpired(token)) {
             return token
-        } catch (error) {
+        }
+
+        // Try silent refresh via hidden iframe first (no page reload)
+        try {
+            return await this.refreshTokenViaIframe()
+        } catch {
+            // Iframe approach failed — fall back to full-page redirect
+            console.warn('Silent token refresh failed, redirecting to LocalAuth0...')
             await this.login()
             return false
         }

--- a/services/web-ui/src/svgIcons/index.ts
+++ b/services/web-ui/src/svgIcons/index.ts
@@ -141,3 +141,5 @@ export const aiChatBubbleIcon = '<svg xmlns="http://www.w3.org/2000/svg" viewBox
 // https://www.flaticon.com/free-icon/connection_9248763
 // By icon wind
 export const changeNodesConnectorLineCurve = '<svg id="Layer_1" enable-background="new 0 0 24 24" height="512" viewBox="0 0 24 24" width="512" xmlns="http://www.w3.org/2000/svg"><path d="m22.9 19.1c-.1-.1-.1-.2-.2-.3l-2.5-2.5c-.4-.4-1-.4-1.4 0s-.4 1 0 1.4l.8.8h-5.6c-.6 0-1-.4-1-1v-11.5c0-1.7-1.3-3-3-3h-3.2c-.4-1.2-1.5-2-2.8-2-1.7 0-3 1.3-3 3s1.3 3 3 3c1.3 0 2.4-.8 2.8-2h3.2c.6 0 1 .4 1 1v11.5c0 1.7 1.3 3 3 3h5.6l-.8.8c-.4.4-.4 1 0 1.4.2.2.5.3.7.3s.5-.1.7-.3l2.5-2.5c.1-.1.2-.2.2-.3.1-.3.1-.5 0-.8zm-18.9-14.1c-.6 0-1-.4-1-1s.4-1 1-1 1 .4 1 1-.4 1-1 1z"/></svg>'
+
+export const brokenImageIcon = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="18" height="18" rx="2" ry="2"/><line x1="9" y1="9" x2="15" y2="15"/><line x1="15" y1="9" x2="9" y2="15"/></svg>'


### PR DESCRIPTION
Closes #122

## Summary

- **NATS persistence**: Add named Docker volumes (`nats-1-data`, `nats-2-data`, `nats-3-data`) so JetStream data survives container restarts
- **Graceful image API errors**: Catch missing Object Store buckets in the image GET endpoint and return 404 with a clear message instead of crashing with 500
- **Image error placeholders**: Show a styled "Image unavailable" placeholder (with `brokenImageIcon` from `svgIcons/index.ts`) when images fail to load in WorkspaceCanvas, imageNodeView, and aiGeneratedImageNode — with a one-shot auth token retry before giving up
- **Silent auth refresh**: Rewrite `Auth0MockService.getTokenSilently()` to refresh tokens via a hidden iframe pointed at LocalAuth0's `/authorize?bypass=true`, avoiding full-page redirects; falls back to redirect only if the iframe fails
- **DOM templating rule**: Add a hard rule to `TYPESCRIPT.md` requiring `html` from `$src/utils/domTemplates.ts` for all DOM creation in non-Svelte `.ts` files; update ProseMirror plugins README accordingly and fix `document.createElement` in its code examples
- **Comment style guide**: Expand the Comments section in `TYPESCRIPT.md` with explicit examples of correct `//` comments and forbidden `/** */` / `/* */` block comments
- **SVG icon consolidation**: Add `brokenImageIcon` to `svgIcons/index.ts`; remove all inline SVG from component files

## Test plan

- [ ] Restart NATS containers and verify JetStream data persists across restarts
- [ ] Load a workspace with missing/deleted images and confirm the placeholder UI appears (not broken img tags or console errors)
- [ ] Let the auth token expire during an active session and verify silent iframe refresh renews it without a page reload
- [ ] If iframe refresh fails (e.g., LocalAuth0 is down), confirm it falls back to a full redirect gracefully
- [ ] Verify image loading still works normally for valid images with fresh tokens
- [ ] Check that `.image-error-placeholder` renders correctly in both canvas and ProseMirror contexts


Made with [Cursor](https://cursor.com)