### PR TITLE
LIX-126 # Fix canvas AI image streaming after canonical URL change

### DIFF
--- a/services/web-ui/src/infographics/workspace/WorkspaceCanvas.ts
+++ b/services/web-ui/src/infographics/workspace/WorkspaceCanvas.ts
@@ -3269,14 +3269,19 @@ export function createWorkspaceCanvas(options: WorkspaceCanvasOptions) {
         imgEl.alt = ''
         imgEl.draggable = false
 
-        // Build image URL from fileId + current workspaceId (kept in sync
-        // by render() on workspace switch).
+        // For data: URLs (streaming partials) and external URLs, use node.src
+        // directly. For NATS-stored images, build a canonical path from the
+        // current workspaceId (kept in sync by render()) to avoid stale refs.
         const API_BASE_URL = import.meta.env.VITE_API_URL || ''
-        const canonicalPath = `/api/images/${workspaceId}/${node.fileId}`
+        const strippedSrc = node.src.replace(/[?&]token=[^&]+/, '')
+        const isStoredImage = strippedSrc.startsWith('/api/') || (strippedSrc.startsWith('http') && strippedSrc.includes('/api/images/'))
+        const resolvedSrc = isStoredImage
+            ? `/api/images/${workspaceId}/${node.fileId}`
+            : strippedSrc
 
         let retried = false
         AuthService.getTokenSilently().then(token => {
-            imgEl.src = buildImageSrc(canonicalPath, API_BASE_URL, token)
+            imgEl.src = buildImageSrc(resolvedSrc, API_BASE_URL, token)
         }).catch(() => {
             showImageErrorPlaceholder(imgEl, nodeEl)
         })
@@ -3286,7 +3291,7 @@ export function createWorkspaceCanvas(options: WorkspaceCanvasOptions) {
                 retried = true
                 AuthService.getTokenSilently().then(token => {
                     if (token) {
-                        const freshSrc = buildImageSrc(canonicalPath, API_BASE_URL, token)
+                        const freshSrc = buildImageSrc(resolvedSrc, API_BASE_URL, token)
                         if (imgEl.src !== freshSrc) {
                             imgEl.src = freshSrc
                             return

--- a/services/web-ui/src/infographics/workspace/workspace-canvas.test.ts
+++ b/services/web-ui/src/infographics/workspace/workspace-canvas.test.ts
@@ -1034,26 +1034,43 @@ describe('Workspace canvas — selection interaction regression guards', () => {
 // Image loading — canonical URL from workspaceId + fileId
 // =============================================================================
 
-describe('Image loading — canonical URL construction', () => {
+describe('Image loading — URL resolution strategy', () => {
 	const ts = loadTs()
 
-	it('createImageNode builds canonicalPath from workspaceId and node.fileId, not from node.src', () => {
+	it('createImageNode uses canonical workspaceId path for stored API images', () => {
 		const fnMatch = ts.match(/function\s+createImageNode[\s\S]*?^    \}/m)
 		expect(fnMatch).not.toBeNull()
 		const fnBody = fnMatch![0]
 
 		expect(fnBody).toContain('`/api/images/${workspaceId}/${node.fileId}`')
-		expect(fnBody).not.toContain('node.src.replace')
 	})
 
-	it('createImageNode uses canonicalPath (not rawSrc) in both initial load and retry', () => {
+	it('createImageNode detects stored images via isStoredImage check', () => {
 		const fnMatch = ts.match(/function\s+createImageNode[\s\S]*?^    \}/m)
 		expect(fnMatch).not.toBeNull()
 		const fnBody = fnMatch![0]
 
-		const canonicalRefs = (fnBody.match(/canonicalPath/g) || []).length
-		expect(canonicalRefs).toBeGreaterThanOrEqual(2)
-		expect(fnBody).not.toContain('rawSrc')
+		expect(fnBody).toContain('isStoredImage')
+		expect(fnBody).toContain("strippedSrc.startsWith('/api/')")
+		expect(fnBody).toContain("strippedSrc.includes('/api/images/')")
+	})
+
+	it('createImageNode strips stale tokens from node.src before classifying', () => {
+		const fnMatch = ts.match(/function\s+createImageNode[\s\S]*?^    \}/m)
+		expect(fnMatch).not.toBeNull()
+		const fnBody = fnMatch![0]
+
+		expect(fnBody).toMatch(/node\.src\.replace\([^)]*token[^)]*\)/)
+	})
+
+	it('createImageNode passes through data: and external URLs via resolvedSrc', () => {
+		const fnMatch = ts.match(/function\s+createImageNode[\s\S]*?^    \}/m)
+		expect(fnMatch).not.toBeNull()
+		const fnBody = fnMatch![0]
+
+		expect(fnBody).toContain('resolvedSrc')
+		const resolvedRefs = (fnBody.match(/resolvedSrc/g) || []).length
+		expect(resolvedRefs).toBeGreaterThanOrEqual(3)
 	})
 
 	it('workspaceId is declared as let (mutable) so render() can update it', () => {


### PR DESCRIPTION
## Summary

`createImageNode` was always using `/api/images/{workspaceId}/{fileId}`, which is correct for persisted NATS images but wrong while AI generation is **streaming** partial frames as `data:` URLs on `node.src`. The first request 404’d and showed “Image unavailable” until refresh.

This PR restores a split path: **stored API images** → canonical URL with current `workspaceId`; **data / external URLs** → pass stripped `node.src` through `buildImageSrc`.

Closes #126

## Test plan

- [ ] Generate an image on the canvas; partial frames and final image appear without refresh
- [ ] Switch workspace in sidebar; persisted canvas images still load
- [ ] `docker exec lixpi-web-ui pnpm test:run -- src/infographics/workspace/workspace-canvas.test.ts`


Made with [Cursor](https://cursor.com)