### PR TITLE
LIX-133 # Fix gpt-image-2 modalities and filter dated image snapshots

### DIFF
--- a/services/api/src/workloads/functions/ai-models-synchronization/ai-models-synchronization.ts
+++ b/services/api/src/workloads/functions/ai-models-synchronization/ai-models-synchronization.ts
@@ -287,6 +287,7 @@ export class AiModelsSync {
                 // O4 Mini Deep Research: 200k context, 100k max output (per page)
                 { prefix: 'o4-mini-deep-research', values: { contextWindow: 200000, maxCompletionSize: 100000, modalities: ['text'], pricing: { text: { measuringUnit: 'tokens', pricePer: '1000000', tiers: { default: { prompt: '2.00', completion: '8.00' } } } } } },
                 // GPT Image family: image generation models
+                { prefix: 'gpt-image-2', values: { modalities: ['text', 'image', 'image_generation'], pricing: { text: { measuringUnit: 'tokens', pricePer: '1000000', tiers: { default: { prompt: '5.00', completion: '10.00' } } }, image: { measuringUnit: 'tokens', pricePer: '1000000', prompt: '8.00', completion: '32.00' } } } },
                 { prefix: 'gpt-image-1.5', values: { modalities: ['text', 'image', 'image_generation'], pricing: { text: { measuringUnit: 'tokens', pricePer: '1000000', tiers: { default: { prompt: '5.00', completion: '10.00' } } }, image: { measuringUnit: 'tokens', pricePer: '1000000', prompt: '8.00', completion: '32.00' } } } },
                 { prefix: 'gpt-image-1-mini', values: { modalities: ['text', 'image', 'image_generation'], pricing: { text: { measuringUnit: 'tokens', pricePer: '1000000', tiers: { default: { prompt: '2.00', completion: '0.00' } } }, image: { measuringUnit: 'tokens', pricePer: '1000000', prompt: '2.50', completion: '8.00' } } } },
                 { prefix: 'gpt-image-1', values: { modalities: ['text', 'image', 'image_generation'], pricing: { text: { measuringUnit: 'tokens', pricePer: '1000000', tiers: { default: { prompt: '5.00', completion: '0.00' } } }, image: { measuringUnit: 'tokens', pricePer: '1000000', prompt: '10.00', completion: '40.00' } } } },
@@ -654,8 +655,11 @@ export class AiModelsSync {
             return models.filter((model: OpenAIModel) => {
                 const modelId = model.id
 
-                // GPT Image models are always allowed through (overrides -mini/-nano contains rules)
-                if (modelId.startsWith('gpt-image-')) return true
+                // GPT Image models are always allowed through (overrides -mini/-nano contains rules),
+                // but still drop dated snapshot versions (e.g. gpt-image-2-2026-04-21).
+                if (modelId.startsWith('gpt-image-')) {
+                    return !this.isMinorVersion(modelId)
+                }
 
                 // Check exact blacklist matches
                 if (blacklist.exact.includes(modelId)) {


### PR DESCRIPTION
## Summary

`gpt-image-2` was appearing in the **chat model selector** instead of the **image generation** list, and a dated snapshot (`gpt-image-2-2026-04-21`) was leaking into the picker as a duplicate row.

## Changes

In `services/api/src/workloads/functions/ai-models-synchronization/ai-models-synchronization.ts`:

1. Added a `gpt-image-2` entry to `MODELS_DEFAULTS.OpenAI.prefix` with `modalities: ['text', 'image', 'image_generation']`. Without it, `gpt-image-2` matched no prefix and fell through to the OpenAI `fallback`, which sets `modalities: ['text']` — that is why it was rendered as a chat model.
2. In `fetchOpenAIModels`, the early `return true` for any `gpt-image-*` id (added to bypass `-mini` / `-nano` `contains` blacklist rules) also short-circuited the `isMinorVersion` check. Changed it to `return !this.isMinorVersion(modelId)` so dated snapshots are dropped while the canonical alias still passes through.

## Notes

- Pricing for `gpt-image-2` is a placeholder copied from `gpt-image-1.5`. Update with official numbers once confirmed.
- After deploying this fix, the existing `AI_MODELS_LIST` rows for `gpt-image-2` (and the dated snapshot) may need to be deleted in DynamoDB so the next sync recreates them with the correct modalities.

Closes #133