### PR TITLE
LIX-143 # use PIXI.js as a rendering engine

### DIFF
--- a/documentation/features/CANVAS-ENGINE.md
+++ b/documentation/features/CANVAS-ENGINE.md
@@ -27,7 +27,7 @@ The active canvas implementation lives in `services/web-ui/src/infographics/`. K
 - `connectors/renderer.ts` — SVG connector rendering
 - `utils/zoomScaling.ts` — zoom-compensated handle scaling
 
-The abandoned full-replacement PIXI attempt is quarantined under `services/web-ui/.legacy-canvas/pixi-full-replacement-attempt/` and is not part of the build.
+Do not follow the historical full-replacement PIXI notes in `documentation/memory/pixi-refactoring.md` as an implementation recipe. The active migration path is incremental: preserve the existing `infographics/workspace` entrypoint, harden the PIXI media layer, and move one renderer responsibility at a time only after parity checks pass.
 
 ### @xyflow/system reference
 

--- a/documentation/features/CANVAS-ENGINE.md
+++ b/documentation/features/CANVAS-ENGINE.md
@@ -2,7 +2,7 @@
 
 The workspace canvas is a **DOM/SVG interaction renderer with a PIXI v8 media layer**. The proven `services/web-ui/src/infographics/workspace/WorkspaceCanvas.ts` stack still owns all user interaction and rich UI: ProseMirror, AI chat threads, prompt inputs, bubble menus, resize/drag/selection, context regions, and SVG connectors. PIXI v8 (WebGPU with WebGL fallback) is introduced through `services/web-ui/src/infographics/workspace/pixiMediaLayer.ts` to own image pixel rendering.
 
-The canonical architecture document is `documentation/knowledge/RENDERING-ARCHITECTURE-FOR-MEDIA-HEAVY-CANVAS.md`. Its Phase 2 guidance is important: introduce PIXI for **media nodes first**, while document/chat-thread DOM and SVG connectors remain until profiling proves they need migration.
+The canonical architectural rationale lives in `documentation/knowledge/RENDERING-ARCHITECTURE-FOR-MEDIA-HEAVY-CANVAS.md`. Its Phase 2 guidance is the path being implemented: PIXI takes over media nodes first, while document/chat-thread DOM and SVG connectors remain until profiling proves they need migration.
 
 ## Why This Matters
 
@@ -21,11 +21,19 @@ For the workspace feature itself — node types, stores, services, data flow, ar
 
 The active canvas implementation lives in `services/web-ui/src/infographics/`. Key files:
 
-- `workspace/WorkspaceCanvas.ts` — main canvas orchestrator, DOM nodes, ProseMirror integration, drag/resize/selection, and PIXI media-layer sync points
-- `workspace/pixiMediaLayer.ts` — PIXI v8 media layer for image pixels only
-- `workspace/WorkspaceConnectionManager.ts` — edge creation, proximity connect, candidate detection
-- `connectors/renderer.ts` — SVG connector rendering
-- `utils/zoomScaling.ts` — zoom-compensated handle scaling
+| File | Purpose |
+|------|---------|
+| `workspace/WorkspaceCanvas.ts` | Main canvas orchestrator: DOM nodes, ProseMirror integration, drag/resize/selection, viewport, and PIXI media-layer sync points |
+| `workspace/pixiMediaLayer.ts` | PIXI v8 media layer for image pixels — sprite registry, texture cache, LoD-tier loader, visibility scanner, prefetch scheduler |
+| `workspace/pixiMediaLayerLogic.ts` | Pure helpers: tier ranking, world-position math, src URL building, LoD-size param injection, world-rect math |
+| `workspace/pixiImageDecoder.ts` | Six-worker decode pool: round-robin dispatch with per-worker request tracking |
+| `workspace/pixiImageDecodeWorker.ts` | Worker body: `fetch` → `createImageBitmap` and post the bitmap back |
+| `workspace/rendering/pixiEdgeRenderer.ts` | PIXI edge renderer (diffed; reuses `Graphics`) |
+| `workspace/rendering/viewportBridge.ts` | Single call site that applies a viewport to both DOM CSS and PIXI |
+| `workspace/rendering/mediaNodeRegistry.ts` | Extension point for future non-image media handlers (video, audio) |
+| `workspace/WorkspaceConnectionManager.ts` | Edge creation, proximity connect, candidate detection, and the data feed for `pixiEdgeRenderer` |
+| `connectors/renderer.ts` | SVG connector rendering (still authoritative for hit testing) |
+| `utils/zoomScaling.ts` | Zoom-compensated handle scaling |
 
 Do not follow the historical full-replacement PIXI notes in `documentation/memory/pixi-refactoring.md` as an implementation recipe. The active migration path is incremental: preserve the existing `infographics/workspace` entrypoint, harden the PIXI media layer, and move one renderer responsibility at a time only after parity checks pass.
 
@@ -46,4 +54,376 @@ documentation/vendor-documentation/xyflow/
     ├── dom-contract.md          — CSS classes, DOM structure, z-index layers, theming
     ├── types-and-constants.md   — Type hierarchies, coordinate spaces, error IDs
     └── utilities.md             — Coordinate conversion, spatial math, node adoption
+```
+
+---
+
+## Rendering Architecture
+
+### Layer Stack
+
+```mermaid
+%%{init: {'theme': 'base', 'themeVariables': { 'primaryColor': '#F6C7B3', 'primaryTextColor': '#5a3a2a', 'primaryBorderColor': '#d4956a', 'secondaryColor': '#C3DEDD', 'secondaryTextColor': '#1a3a47', 'secondaryBorderColor': '#4a8a9d', 'tertiaryColor': '#DCECE9', 'tertiaryTextColor': '#1a3a47', 'tertiaryBorderColor': '#82B2C0', 'lineColor': '#d4956a', 'textColor': '#5a3a2a'}}}%%
+flowchart TB
+    subgraph Pane[".workspace-pane"]
+        subgraph Viewport[".workspace-viewport (z-index 1, CSS-transformed)"]
+            DOC[Document Nodes]
+            THR[AI Chat Thread Nodes]
+            IMG_DOM[Image Node DOM shells<br/>data-node-id only,<br/>img.src is empty when PIXI healthy]
+            EDGE_SVG[SVG Edges layer<br/>opacity 0, hit-testing only]
+            HANDLE[Handles, drag overlays, resize handles]
+        end
+        subgraph PixiCanvas[".workspace-pixi-media-layer (z-index 2, PIXI canvas)"]
+            WORLD[Pixi world Container<br/>scale = viewport.zoom<br/>position = viewport.x, y]
+            EDGE_PIXI[edgeLayer: PIXI Graphics edges]
+            IMG_SPR[image sprites + colorRect placeholders]
+            FG[fgLayer: selection outlines, marquee, group overlay]
+        end
+    end
+
+    Viewport --> PixiCanvas
+    WORLD --> EDGE_PIXI
+    WORLD --> IMG_SPR
+    WORLD --> FG
+```
+
+The PIXI canvas sits **above** the DOM viewport. Image-node DOM elements are kept (`<div data-node-id>` plus `<img class="image-node-img">`) for two reasons:
+
+1. They host all interaction chrome — drag overlay, resize handles, badges, generation spinner, partial-streaming `<img>` for AI image generation.
+2. They are the DOM fallback if PIXI fails to initialize.
+
+When PIXI is healthy, the DOM `<img>` element has **no `src` attribute** for stored images, so the browser never makes a redundant network request for pixels that PIXI is already rendering. The `workspace-image-node--pixi-owned` class (added on every PIXI sync) sets `opacity: 0` on the DOM `<img>` so the PIXI sprite is the only visible surface.
+
+### Viewport Bridge
+
+Pan/zoom flows through a single call site:
+
+```mermaid
+%%{init: {'theme': 'base', 'themeVariables': { 'primaryColor': '#F6C7B3', 'primaryTextColor': '#5a3a2a', 'primaryBorderColor': '#d4956a', 'secondaryColor': '#C3DEDD', 'secondaryTextColor': '#1a3a47', 'secondaryBorderColor': '#4a8a9d', 'tertiaryColor': '#DCECE9', 'tertiaryTextColor': '#1a3a47', 'tertiaryBorderColor': '#82B2C0', 'lineColor': '#d4956a', 'textColor': '#5a3a2a'}}}%%
+flowchart LR
+    XY[XYPanZoom<br/>onTransformChange] --> CB[onTransformChange callback<br/>WorkspaceCanvas.ts]
+    CB --> VB[viewportBridge.applyViewport]
+    VB --> CSS[viewport CSS transform<br/>translate + scale]
+    VB --> PIXI[pixiMediaLayer.setViewport]
+    PIXI --> WORLD[world.position / world.scale]
+    PIXI --> VIS[scheduleVisibilityUpdate<br/>rAF-coalesced]
+    PIXI --> PRE[schedulePrefetch<br/>idle-coalesced]
+    PIXI --> RND[scheduleRender<br/>rAF-coalesced]
+```
+
+This gives DOM and PIXI a single, consistent transform every frame. There is no second `app.render()` call from elsewhere in the codebase.
+
+### Sync Pipeline
+
+`pixiMediaLayer.sync(canvasState)` is called exactly once per state commit (in `commitCanvasState`). Each sync:
+
+1. Refreshes the per-sync DOM element cache (`viewportEl.querySelectorAll('[data-node-id]')`) so subsequent ownership-class toggles are O(1) lookups instead of repeated DOM queries.
+2. Toggles `workspace-image-node--pixi-owned` on/off only for nodes whose ownership changed (uses `pixiOwnedNodeIds` Set as the source of truth).
+3. Removes deleted entries: `releaseTexture` → `spatialIndex.remove` → destroys sprite + colorRect.
+4. Calls `upsertAllEntries` → for each image node, `upsertEntry` updates only what actually changed:
+   - **Sprite transform** (position + width/height): always updated; cheap matrix update.
+   - **Color-rect geometry** (`Graphics.clear()` + `roundRect()` + `fill()`): rebuilt only when width or height changed since last upsert.
+   - **Spatial index entry**: removed and re-inserted only when the world rect actually changed.
+   - **`pixi-owned` class**: toggled only when the node was not already in `pixiOwnedNodeIds`.
+5. Single `updateVisibleImages()` pass to mark renderable flags and fire texture loads for newly-visible entries.
+6. Schedules an idle prefetch tick.
+7. Schedules a render via rAF.
+
+### Render Scheduling
+
+PIXI's auto-ticker is **disabled** (`autoStart: false` + `app.ticker.stop()`). Every render goes through `scheduleRender()`, which coalesces multiple call sites into one `requestAnimationFrame(() => app.render())`. This gives the canvas zero GPU/CPU cost when idle.
+
+`updateVisibleImages` is also rAF-coalesced (`scheduleVisibilityUpdate`), so a 60 Hz wheel-zoom that triggers `setViewport` on every tick performs the spatial-index scan + entry iteration **once per frame**, not 60 times.
+
+---
+
+## Image Rendering Pipeline
+
+### LoD Tiers
+
+Zoom level maps to a level-of-detail tier:
+
+| Zoom range | Tier | What it loads |
+|------------|------|---------------|
+| `< 0.1` | `color` | Just a tinted `Graphics` rect — no texture |
+| `0.1 – 0.4` | `thumb-256` | URL with `?size=256` |
+| `0.4 – 1.0` | `thumb-1024` | URL with `?size=1024` |
+| `≥ 1.0` | `full` | Full-resolution URL |
+
+`tierRank()` orders the tiers (`color < thumb-256 < thumb-1024 < full`).
+
+### Texture Loading Rules
+
+The `ensureTextureForEntry(entry, desiredTier)` function is idempotent and follows three cardinal rules:
+
+```mermaid
+%%{init: {'theme': 'base', 'themeVariables': { 'primaryColor': '#F6C7B3', 'primaryTextColor': '#5a3a2a', 'primaryBorderColor': '#d4956a', 'secondaryColor': '#C3DEDD', 'lineColor': '#d4956a', 'textColor': '#5a3a2a'}}}%%
+flowchart TB
+    START[ensureTextureForEntry<br/>entry, desiredTier] --> R0{desiredTier<br/>== color?}
+    R0 -->|yes| COLOR[show colorRect placeholder<br/>keep cached texture for zoom-in]
+    R0 -->|no| R1{loadedTier<br/>>= desiredTier?}
+    R1 -->|yes| REUSE[Rule 1 — reuse existing texture<br/>mipmaps downsample for free]
+    R1 -->|no| R2{requestedTier<br/>set?}
+    R2 -->|>= desired| WAIT1[Rule 2a — in-flight covers it]
+    R2 -->|< desired| UPGRADE[Rule 2b — schedule idle upgrade<br/>let in-flight thumb-256 finish first]
+    R2 -->|null| R3{loadedTier == null<br/>AND<br/>desired != thumb-256?}
+    R3 -->|yes| FETCH256[Rule 3 — progressive<br/>fetch thumb-256 first<br/>schedule upgrade]
+    R3 -->|no| FETCHDIRECT[fetch desiredTier directly]
+```
+
+**Rule 1 — never downgrade.** Mipmaps make a `full`-resolution texture render perfectly at any zoom level; refetching `thumb-256` when `full` is already on the GPU is pure waste and was the root cause of zoom-out lag.
+
+**Rule 2 — never duplicate in-flight.** If a request is already in flight that covers our needs, do nothing. If it's a lower tier (the progressive thumb-256 first step), schedule an idle upgrade and let the in-flight request finish.
+
+**Rule 3 — progressive thumb-256 first.** When an entry has nothing loaded yet and the desired tier is bigger than `thumb-256`, load `thumb-256` first for instant visual feedback, then schedule a background upgrade to the desired tier in idle time.
+
+### Visibility-Driven Loading
+
+Texture fetches are gated by visibility. `updateVisibleImages()`:
+
+1. Computes the visible world rect with a `VISIBILITY_MARGIN = 1200` world-unit ring.
+2. Searches the RBush spatial index for entries whose rects intersect.
+3. For each entry:
+   - If visibility transitioned (true ↔ false), updates `sprite.renderable` and `colorRect.renderable`.
+   - If visible, calls `ensureTextureForEntry(entry, currentTier)` (idempotent — no-op if already loaded).
+
+Non-visible entries keep any cached texture they have. They will get their textures evicted only under genuine cache pressure (see Cache Eviction below).
+
+### Idle Prefetch
+
+`schedulePrefetch()` runs in `requestIdleCallback` slots (with a `setTimeout` fallback) and prefetches `thumb-256` for **all** unloaded entries in the workspace, sorted by world-distance from viewport centre. A `PREFETCH_BATCH_SIZE = 20` cap means each idle tick processes only the 20 nearest unloaded entries; if more remain, the next idle slot picks them up.
+
+This gives the canvas an "always-warm" cache: panning around the workspace reveals images that already have a texture on the GPU, so there is no progressive-fetch flash.
+
+### Decode Pool
+
+Decoding goes through `pixiImageDecoder.ts`, which lazily spawns up to **6 web workers** in a round-robin pool. Six matches the typical browser per-origin connection limit so every available TCP slot is used for image fetching while multiple CPU cores handle the (CPU-bound) `createImageBitmap` step in parallel.
+
+A single shared auth-token promise is reused across all concurrent `resolveImageSrc` calls in a 30-second window so 200 in-flight image loads don't each invoke `getTokenSilently()` independently.
+
+### Texture Cache
+
+`textureCache: Map<url, { texture, bytes, refCount, lastUsed }>` deduplicates GPU uploads by URL. Each `acquireTexture(url)` either returns the cached entry (bumping `refCount` + `lastUsed`) or decodes and creates a new texture.
+
+Limits: **2000 textures** OR **768 MB**. When either ceiling is exceeded, `evictTextures()` runs in two passes:
+
+1. **Idle eviction (LRU)**: drop textures with `refCount == 0` (already detached from any sprite), oldest first.
+2. **Pressure eviction**: under genuine memory pressure, detach textures from **non-visible** sprites (LRU first), so their cache slot can be reclaimed. The sprite reverts to its color placeholder; visibility re-fetches the right tier on demand. **Visible sprites are never evicted from under the user.**
+
+### Mipmaps
+
+Every texture is created with `texture.source.autoGenerateMipmaps = true` before its first GPU upload. Without mipmaps, a 1024 px texture rendered at 10 px (zoom 0.01×) forces the GPU to sample the full 1 MB texel buffer for each output pixel — catastrophic with hundreds of images visible. With mipmaps, the GPU selects the pre-computed 8 × 8 or 16 × 16 MIP level and texture-cache pressure drops by ~4 orders of magnitude.
+
+### Edge Renderer
+
+`pixiEdgeRenderer.ts` reuses `Graphics` objects across renders. Each edge is keyed by `id` and has a fingerprint (`svgPath | strokeColor | strokeWidth | arrows`); the `Graphics` is only repainted when the fingerprint changes. Removed edges are destroyed; new ones are allocated. This eliminates the original O(edges) destroy + alloc + GPU-upload cycle on every `scheduleEdgesRender` call.
+
+---
+
+## Performance: What Has Been Optimized
+
+The PIXI media layer has gone through several rounds of perf hardening. The current state:
+
+| Optimization | What it does |
+|-------------|--------------|
+| **Six-worker decode pool** | Replaces a single decode worker. Image fetch + decode runs on up to 6 CPU cores simultaneously, saturating the browser's per-origin connection limit instead of serializing every decode behind a single message handler. |
+| **Mipmaps on every texture** | `autoGenerateMipmaps: true` so zoom-out doesn't sample full-resolution texels. |
+| **Shared auth token** | All concurrent `resolveImageSrc` calls share one `getTokenSilently()` promise (refreshed every 30 s) so 200 in-flight loads don't each await an independent auth round-trip. |
+| **Auto-ticker disabled** | `autoStart: false` + `app.ticker.stop()`. All renders are rAF-coalesced via `scheduleRender()` so an idle canvas costs zero GPU. |
+| **rAF-coalesced visibility scan** | 60 Hz wheel-zoom triggers one `updateVisibleImages()` per frame, not 60. |
+| **Lazy texture loads (visibility-driven)** | Textures are loaded only for sprites whose world rects intersect the visible margin; non-visible sprites cost zero network. |
+| **Never-downgrade tier policy** | Once a higher-tier texture is on the GPU, zoom-out never re-fetches a lower tier — mipmaps handle downsampling for free. |
+| **Progressive `thumb-256`-first** | First-paint loads tiny thumbnails for visible sprites; full-tier upgrades happen in idle. |
+| **Idle prefetch (capped)** | Up to 20 unloaded entries per idle tick get pre-cached at `thumb-256`, sorted by viewport distance. Pan reveals already-loaded images. |
+| **DOM `<img>` double-fetch eliminated** | Stored-image `<img>` elements have no `src` attribute while PIXI is healthy. Backfilled on PIXI failure as the fallback path. |
+| **Single PIXI `sync()` per state commit** | The `renderNodes()`-side duplicate sync was removed. Each `commitCanvasState` runs the pipeline exactly once. |
+| **Incremental RBush** | The spatial index is updated per-node (`remove` + `insert`) only when geometry actually changed. Used to be wiped + rebuilt on every sync. |
+| **`drawColorRect` skip-when-unchanged** | Placeholder geometry is only rebuilt when the node's width or height actually changed; transform updates are matrix-only. |
+| **`syncDomOwnership` skip when no-op** | `classList.toggle` only runs for nodes whose ownership state actually changed. |
+| **PIXI edge renderer diff** | `Graphics` objects are reused across renders; geometry is only repainted when the edge fingerprint changes. |
+
+---
+
+## Known Performance Issues and Improvement Opportunities
+
+These are the issues a future round of work should tackle. Listed in priority order — biggest gains first.
+
+### 1. The API does not actually serve resized thumbnails
+
+**This is the biggest unrealized win in the entire LoD system.**
+
+`pixiMediaLayerLogic.addPixiLodSizeParam()` appends `?size=256` or `?size=1024` to the image URL. The API handler at `services/api/src/routes/image-routes.ts` (`GET /:workspaceId/:fileId`) **ignores those query params completely** and serves the full-resolution object back from NATS Object Store. The `?size=` value only changes the URL string, not the bytes.
+
+Consequences:
+
+- **`thumb-256` and `thumb-1024` requests download the same bytes as `full`.** The progressive `thumb-256`-first strategy currently doesn't make first-paint faster on the network side; it only helps because the GPU upload is smaller after decode (since `createImageBitmap` decodes the original size).
+- **Browser cache is fragmented by URL.** A `thumb-256` and a `full` request for the same image are two separate cache entries with the same bytes. Effective cache hit rate for stored images is much lower than it should be.
+- **Idle prefetch downloads full-size payloads.** Caching the entire workspace at "thumb-256" is, today, caching the workspace at full resolution.
+
+**Fix options, in increasing complexity:**
+
+1. **Resize on the API.** Add a `?size=` aware handler that pipes the NATS object through `sharp` (or equivalent) into a 256 / 1024 resized buffer. Store resized variants in a small in-memory or on-disk cache keyed by `(fileId, size)`. This is a small backend change with very large frontend impact.
+2. **Server-side proxies generated at upload time.** When an image is uploaded, also store `fileId.thumb-256.webp` and `fileId.thumb-1024.webp` in NATS Object Store. The GET handler picks the right key based on the size param. No on-request resize cost.
+3. **Client-side resize on first decode.** After decoding the full bitmap, downscale to the tier dimensions inside the decode worker and only upload the smaller texture to the GPU. Saves GPU memory and PCIe upload bandwidth, but doesn't save network or main-thread decode CPU.
+
+**Recommended: option 2.** Generate `thumb-256.webp` and `thumb-1024.webp` at upload time, both in NATS Object Store. Adds at most ~20 % storage but gives instant LoD payloads for every viewport size. WebP at 75 % quality for a 256 × 256 image is typically ~10 KB, so the entire workspace cache fits comfortably in RAM.
+
+### 2. SVG edge layer + PIXI edge layer rendered in parallel
+
+`WorkspaceConnectionManager.render()` produces both an SVG layer (in DOM, opacity 0 — used for hit-testing via `isPointInStroke`) and the data feed for `pixiEdgeRenderer`. Hit-testing is the only reason the SVG is still there; it is duplicate work on every edge change.
+
+**Fix options:**
+
+1. **Replace SVG hit-testing with PIXI ray-casting** against the PIXI edge `Graphics` objects (use `getBounds()` for a rough check, then per-pixel sample the rendered surface for fine hit). Drops the entire SVG layer.
+2. **Implement geometric hit-testing on the edge data** (distance-to-bezier-curve / distance-to-orthogonal-segments). Requires no rendered surface at all and works on raw `PixiEdgeRenderDatum` data.
+
+Option 2 is the cleanest and removes a whole layer.
+
+### 3. `getComputedStyle` on every edge render
+
+`WorkspaceConnectionManager.render()` reads `--connector-line-default-color` and `--connector-line-focus-color` via `getComputedStyle(paneEl)` on every render. `getComputedStyle` can force a style flush.
+
+**Fix:** cache the resolved CSS variable values once at construction and on a `MutationObserver` for `<html>` class changes (theme toggle).
+
+### 4. `selectEdge` triggers a synchronous, non-coalesced render
+
+`WorkspaceConnectionManager.selectEdge()` calls `this.render()` synchronously — it does not go through the `scheduleEdgesRender()` rAF coalescer. For a graph with hundreds of edges, clicking to select one runs a full edge-data rebuild + PIXI repaint outside the frame loop.
+
+**Fix:** route `selectEdge` through `scheduleEdgesRender()`. Selection ID is mutated synchronously; render is deferred.
+
+### 5. Selection / marquee / group overlay `Graphics.clear()` per update
+
+`setSelectedImageNodes`, `setMarqueeRect`, and `setSelectionOverlayBounds` always call `g.clear()` and rebuild geometry, even when the bounds and zoom-dependent stroke width haven't changed within an epsilon. Less impactful than the image-side `drawColorRect` skip but the same shape of optimization.
+
+**Fix:** mirror the `colorRectW / colorRectH` skip pattern in those three functions.
+
+### 6. Workspace-switch full sprite teardown
+
+When the user switches workspaces, every PIXI sprite + `Graphics` is destroyed and re-created. For users moving between two image-heavy workspaces back-to-back, this flushes both texture and sprite caches.
+
+**Fix:** key the texture cache by `(workspaceId, fileId, tier)` (it already is, via `acquireTexture(url)` URLs) but **don't** call `destroy()` on every sprite during workspace switch — keep them parked in a pool keyed by `nodeId`, and reuse the pool when the user comes back. A LRU on the pool prevents unbounded memory.
+
+This is a bigger refactor (multi-workspace sprite lifecycle) and only worth doing if profiling shows the pattern is common.
+
+### 7. PIXI v8 VRAM regression for large texture counts
+
+PIXI v8 (any 8.x version) has a known regression where `Texture.from(bitmap)` uses ~2× the GPU memory of v7 because the WebGPU upload path internally converts ImageBitmap → canvas, doubling the allocation (see [pixijs/pixijs#11331](https://github.com/pixijs/pixijs/issues/11331)). The fix landed in a PR merged ~May 2025 and Lixpi pins `^8.14.0` to pick it up. **Verify with `pnpm why pixi.js` that the resolved version is ≥ 8.14.0** — if a transitive dependency pins an older 8.x, the regression returns and Safari iOS will crash on workspaces with dozens of images.
+
+### 8. Decode worker pool has no priority
+
+The 6-worker decode pool is round-robin. There is no notion of "the user is looking at this region right now, prioritize it over background prefetch." If the user opens a large workspace and immediately starts panning, prefetch decodes still occupy worker slots even though visibility-driven decodes for the focus area should jump the queue.
+
+**Fix:** add an `urgent: boolean` flag to `decodeImageInWorker(url, urgent)`. Maintain two queues per worker; drain `urgent` before `normal`. `ensureTextureForEntry` calls from `updateVisibleImages` set `urgent: true`; calls from `schedulePrefetch` set `urgent: false`.
+
+### 9. No connection-aware backoff
+
+If the API is slow or returning errors, the PIXI layer keeps retrying indefinitely (each visibility pass calls `ensureTextureForEntry` which fires a new fetch on every error path). With hundreds of nodes this can hammer a struggling backend.
+
+**Fix:** track per-entry retry count + last error timestamp. On error, set a cooldown (`Math.min(2 ** retries, 30) * 1000` ms) before another fetch is allowed for that entry. Reset on success.
+
+### 10. `isPointInStroke` for edge hit-testing
+
+`WorkspaceConnectionManager.attachEdgeInteractionHandlers` walks every edge SVG path on every `mousemove` to update the hover cursor, calling `path.isPointInStroke(point)` per edge. For a graph with hundreds of edges, this is a significant per-frame cost during pure mouse movement.
+
+**Fix:** spatial index the edges (RBush, like the images) keyed by their bounding box. On `mousemove` only test edges whose bounding box contains the cursor.
+
+---
+
+## Performance Tuning Constants
+
+When tuning, these are the knobs that exist today (all in `pixiMediaLayer.ts` unless noted):
+
+| Constant | Default | What it does | When to change |
+|----------|---------|--------------|----------------|
+| `VISIBILITY_MARGIN` | `1200` | World-unit margin past the viewport. Sprites within this band are eligible for texture loading. | Increase for smoother pan reveal at the cost of more in-flight loads. |
+| `PREFETCH_MARGIN` | `4000` | Margin used by the prefetch ring (currently unused since prefetch loops over all entries; legacy). | Re-introduce as a hard cap if prefetch becomes too aggressive on huge workspaces. |
+| `PREFETCH_BATCH_SIZE` | `20` | Max entries processed per idle prefetch tick. | Lower if idle decoding starves urgent visibility loads; raise if first-screen prefetch is too slow. |
+| `MAX_TEXTURES` | `2000` | Hard count limit for the texture cache. | Lower on memory-constrained devices (iPad, mobile). |
+| `MAX_TEXTURE_BYTES` | `768 MB` | Hard byte limit for the texture cache. | Lower for low-VRAM devices. WebGL on iPad has ~256 MB practical ceiling. |
+| `POOL_SIZE` (`pixiImageDecoder.ts`) | `6` | Decode worker pool size. | Match to typical browser per-origin connection limit; do not exceed it. |
+| Token re-resolve window | `30_000` ms | How long the shared auth token is reused before re-fetching. | Lower if tokens have a shorter TTL than 30 s. |
+
+---
+
+## Health and Fallback
+
+`createPixiMediaLayer` accepts an `onHealthChange(health)` callback. Health states: `initializing → ready` (success) or `initializing → failed` (init error).
+
+`WorkspaceCanvas.ts` subscribes:
+
+- **`ready`**: do nothing — image-node DOM `<img>` elements stay empty (no `src`), PIXI draws.
+- **`failed`**: call `backfillDomImageSrcs()` which iterates every tracked image node and sets its `<img>.src` to the resolved API URL. The DOM falls back to the legacy renderer.
+
+This means **PIXI failure is non-fatal**. The user sees images either way; only the rendering quality / large-canvas performance degrades.
+
+The DOM image-element registry in `WorkspaceCanvas.ts` (`imageElByNodeId`, `imageResolvedSrcByNodeId` Maps) is populated in `createImageNode` and cleared in `renderNodes` when DOM is rebuilt.
+
+---
+
+## Source-of-Truth Diagram
+
+```mermaid
+%%{init: {'theme': 'base', 'themeVariables': { 'noteBkgColor': '#82B2C0', 'noteTextColor': '#1a3a47', 'noteBorderColor': '#5a9aad', 'actorBkg': '#F6C7B3', 'actorBorder': '#d4956a', 'actorTextColor': '#5a3a2a', 'actorLineColor': '#d4956a', 'signalColor': '#d4956a', 'signalTextColor': '#5a3a2a', 'labelBoxBkgColor': '#F6C7B3', 'labelBoxBorderColor': '#d4956a', 'labelTextColor': '#5a3a2a', 'loopTextColor': '#5a3a2a', 'activationBorderColor': '#9DC49D', 'activationBkgColor': '#9DC49D', 'sequenceNumberColor': '#5a3a2a'}}}%%
+sequenceDiagram
+    participant User
+    participant XY as XYPanZoom
+    participant WC as WorkspaceCanvas.ts
+    participant VB as viewportBridge
+    participant PIXI as pixiMediaLayer
+    participant Pool as Decode Pool (6 workers)
+    participant API as Image API
+
+    %% ═══════════════════════════════════════════════════════════════
+    %% PHASE 1: PAN OR ZOOM
+    %% ═══════════════════════════════════════════════════════════════
+    rect rgb(220, 236, 233)
+        Note over User, API: PHASE 1 - PAN OR ZOOM
+        User->>XY: wheel / drag / pinch
+        activate XY
+        XY->>WC: onTransformChange(transform)
+        activate WC
+        WC->>VB: applyViewport(viewport)
+        activate VB
+        VB->>VB: viewportEl.style.transform
+        VB->>PIXI: setViewport(viewport)
+        deactivate VB
+        deactivate WC
+        deactivate XY
+    end
+
+    %% ═══════════════════════════════════════════════════════════════
+    %% PHASE 2: COALESCED VISIBILITY + RENDER
+    %% ═══════════════════════════════════════════════════════════════
+    rect rgb(195, 222, 221)
+        Note over User, API: PHASE 2 - COALESCED VISIBILITY + RENDER (one rAF)
+        activate PIXI
+        PIXI->>PIXI: world.position / world.scale
+        PIXI->>PIXI: scheduleVisibilityUpdate (rAF)
+        PIXI->>PIXI: updateVisibleImages — RBush search
+        PIXI->>PIXI: ensureTextureForEntry per visible
+        PIXI->>PIXI: schedulePrefetch (idle, capped 20)
+        PIXI->>PIXI: scheduleRender (rAF)
+        PIXI->>PIXI: app.render()
+        deactivate PIXI
+    end
+
+    %% ═══════════════════════════════════════════════════════════════
+    %% PHASE 3: TEXTURE FETCH (only for entries that need a higher tier)
+    %% ═══════════════════════════════════════════════════════════════
+    rect rgb(242, 234, 224)
+        Note over User, API: PHASE 3 - TEXTURE FETCH
+        activate PIXI
+        PIXI->>Pool: decodeImageInWorker(url)
+        activate Pool
+        Pool->>API: GET /api/images/:workspaceId/:fileId?size=...
+        activate API
+        API-->>Pool: image bytes
+        deactivate API
+        Pool->>Pool: createImageBitmap
+        Pool-->>PIXI: ImageBitmap (transferred)
+        deactivate Pool
+        PIXI->>PIXI: Texture.from(bitmap)<br/>autoGenerateMipmaps = true
+        PIXI->>PIXI: sprite.texture = texture<br/>scheduleRender
+        deactivate PIXI
+    end
 ```

--- a/documentation/features/CANVAS-ENGINE.md
+++ b/documentation/features/CANVAS-ENGINE.md
@@ -1,10 +1,15 @@
 # Canvas Engine
 
-The workspace canvas is built directly on top of `@xyflow/system` — the framework-agnostic core package. It does **not** use `@xyflow/svelte` or `@xyflow/react`. All pan/zoom, drag, resize, and connection logic is wired manually to vanilla TypeScript classes that receive DOM elements and callbacks.
+The workspace canvas is a **DOM/SVG interaction renderer with a PIXI v8 media layer**. The proven `services/web-ui/src/infographics/workspace/WorkspaceCanvas.ts` stack still owns all user interaction and rich UI: ProseMirror, AI chat threads, prompt inputs, bubble menus, resize/drag/selection, context regions, and SVG connectors. PIXI v8 (WebGPU with WebGL fallback) is introduced through `services/web-ui/src/infographics/workspace/pixiMediaLayer.ts` to own image pixel rendering.
+
+The canonical architecture document is `documentation/knowledge/RENDERING-ARCHITECTURE-FOR-MEDIA-HEAVY-CANVAS.md`. Its Phase 2 guidance is important: introduce PIXI for **media nodes first**, while document/chat-thread DOM and SVG connectors remain until profiling proves they need migration.
 
 ## Why This Matters
 
-When working on canvas code, you must understand `@xyflow/system` directly — not the Svelte or React wrapper APIs. The Svelte layer (`WorkspaceCanvas.svelte`) is a thin binding that passes DOM elements into the framework-agnostic engine.
+When working on canvas code, you need to know two libraries:
+
+1. **`@xyflow/system`** for pan/zoom and connection math (no Svelte/React wrappers). The Svelte layer (`WorkspaceCanvas.svelte`) is a thin binding.
+2. **PIXI v8** for the media layer (`Application`, `Container`, `Sprite`, `Texture`). The PIXI documentation is the source of truth: <https://pixijs.com/8.x/guides/components/application>.
 
 ## Documentation Navigation
 
@@ -12,9 +17,21 @@ When working on canvas code, you must understand `@xyflow/system` directly — n
 
 For the workspace feature itself — node types, stores, services, data flow, architecture diagrams — see `documentation/features/WORKSPACE-FEATURE.md`.
 
+### Canvas implementation code
+
+The active canvas implementation lives in `services/web-ui/src/infographics/`. Key files:
+
+- `workspace/WorkspaceCanvas.ts` — main canvas orchestrator, DOM nodes, ProseMirror integration, drag/resize/selection, and PIXI media-layer sync points
+- `workspace/pixiMediaLayer.ts` — PIXI v8 media layer for image pixels only
+- `workspace/WorkspaceConnectionManager.ts` — edge creation, proximity connect, candidate detection
+- `connectors/renderer.ts` — SVG connector rendering
+- `utils/zoomScaling.ts` — zoom-compensated handle scaling
+
+The abandoned full-replacement PIXI attempt is quarantined under `services/web-ui/.legacy-canvas/pixi-full-replacement-attempt/` and is not part of the build.
+
 ### @xyflow/system reference
 
-The vendored `@xyflow/system` package has its own documentation set stored in `documentation/vendor-documentation/xyflow/` (persistent, not inside the vendored submodule). Start from the top-level guide and follow its links to per-module docs:
+The vendored `@xyflow/system` package has its own documentation set stored in `documentation/vendor-documentation/xyflow/`. Start from the top-level guide and follow its links to per-module docs:
 
 ```
 documentation/vendor-documentation/xyflow/
@@ -30,11 +47,3 @@ documentation/vendor-documentation/xyflow/
     ├── types-and-constants.md   — Type hierarchies, coordinate spaces, error IDs
     └── utilities.md             — Coordinate conversion, spatial math, node adoption
 ```
-
-### Canvas implementation code
-
-The framework-agnostic canvas engine lives in `services/web-ui/src/infographics/`. Key files:
-
-- `WorkspaceCanvas.ts` — Main canvas class, wires `@xyflow/system` primitives
-- `WorkspaceConnectionManager.ts` — Edge creation, proximity connect, candidate detection
-- `ConnectorRenderer.ts` — Edge/connector SVG rendering

--- a/documentation/features/WORKSPACE-FEATURE.md
+++ b/documentation/features/WORKSPACE-FEATURE.md
@@ -2,6 +2,8 @@
 
 A workspace is the primary container where users organize and edit their documents and images. Think of it as an infinite canvas where cards float, can be arranged freely, resized, and edited in place.
 
+> **Renderer migration note (2026-05-05).** The active workspace canvas remains the proven `services/web-ui/src/infographics/workspace/WorkspaceCanvas.ts` stack. Phase 2 now adds PIXI v8 only as a **media layer for image pixels** through `services/web-ui/src/infographics/workspace/pixiMediaLayer.ts`; document nodes, AI chat thread nodes, prompt inputs, bubble menus, resize/drag/selection, and SVG connectors stay in the existing DOM/SVG implementation. The abandoned full-replacement experiment is quarantined under `services/web-ui/.legacy-canvas/pixi-full-replacement-attempt/` and is not part of the build.
+
 ## Core Concepts
 
 **Workspace** — A named container owned by a user. Has a canvas state (viewport position, zoom level, and node positions) plus references to documents, AI chat threads, and uploaded files.

--- a/documentation/features/WORKSPACE-FEATURE.md
+++ b/documentation/features/WORKSPACE-FEATURE.md
@@ -2,7 +2,9 @@
 
 A workspace is the primary container where users organize and edit their documents and images. Think of it as an infinite canvas where cards float, can be arranged freely, resized, and edited in place.
 
-> **Renderer migration note (2026-05-05).** The active workspace canvas remains the proven `services/web-ui/src/infographics/workspace/WorkspaceCanvas.ts` stack. Phase 2 now adds PIXI v8 only as a **media layer for image pixels** through `services/web-ui/src/infographics/workspace/pixiMediaLayer.ts`; document nodes, AI chat thread nodes, prompt inputs, bubble menus, resize/drag/selection, and SVG connectors stay in the existing DOM/SVG implementation. Historical full-replacement notes in `documentation/memory/pixi-refactoring.md` are background context, not the active implementation path.
+> **Renderer migration note (2026-05-07).** The active workspace canvas remains the proven `services/web-ui/src/infographics/workspace/WorkspaceCanvas.ts` stack. Phase 2 now ships PIXI v8 (WebGPU with WebGL fallback) as a **media layer for image pixels** through `services/web-ui/src/infographics/workspace/pixiMediaLayer.ts`; document nodes, AI chat thread nodes, prompt inputs, bubble menus, resize/drag/selection, and SVG connectors stay in the existing DOM/SVG implementation. Image-node DOM `<img>` elements are kept as interaction chrome and as a fallback path when PIXI fails to initialize, but their `src` is left empty while PIXI is healthy so the browser does not double-fetch the same pixels.
+>
+> For the rendering pipeline, LoD strategy, texture cache, decode pool, edge diffing, and the list of remaining performance issues, see [CANVAS-ENGINE.md](CANVAS-ENGINE.md). Historical full-replacement notes in `documentation/memory/pixi-refactoring.md` are background context, not the active implementation path.
 
 ## Core Concepts
 
@@ -581,20 +583,27 @@ flowchart LR
         CR[ConnectorRenderer]
     end
 
-    subgraph DOM
+    subgraph DOM["DOM (z-index 1)"]
         VP[.workspace-viewport]
-        EDGES[.workspace-edges-layer SVG]
+        EDGES[.workspace-edges-layer SVG<br/>opacity 0, hit-testing only]
         DOCNODES[.workspace-document-node]
-        IMGNODES[.workspace-image-node]
+        IMGNODES[.workspace-image-node<br/>img.src empty when PIXI healthy]
         THREADNODES[.workspace-ai-chat-thread-node]
         HANDLES[.workspace-handle]
         ED[.document-node-editor]
         TED[.ai-chat-thread-node-editor]
-        IMG[img element]
+    end
+
+    subgraph PIXI["PIXI v8 (z-index 2)"]
+        PML[pixiMediaLayer.sync]
+        SPR[Image sprites + colorRect placeholders]
+        PEDG[Pixi edge Graphics — diffed]
+        FG[Selection outlines, marquee, group overlay]
     end
 
     CS --> RN
     CS --> WCM
+    CS --> PML
     DOCS --> RN
     THREADS --> RN
     RN --> CDN
@@ -612,12 +621,18 @@ flowchart LR
     THREADNODES --> VP
     WCM --> XYH
     WCM --> CR
+    WCM --> PEDG
     CR --> EDGES
     EDGES --> VP
     PM --> ED
     PM --> TED
-    CIN --> IMG
+    PML --> SPR
+    PML --> FG
 ```
+
+The DOM viewport hosts every interactive element. PIXI sits on top as a transparent overlay and owns image pixels, image-node selection outlines, marquee rectangles, group-overlay highlights, and edge stroke geometry. Both layers are kept perfectly aligned by `viewportBridge.applyViewport()`, which is the single call site that updates both the DOM CSS transform and the PIXI world container in the same tick.
+
+For the texture cache, LoD-tier loader, decode worker pool, eviction strategy, and the list of remaining performance issues (notably: the API does not actually serve resized thumbnails today), see [CANVAS-ENGINE.md](CANVAS-ENGINE.md).
 
 ## Persistence Strategy
 

--- a/documentation/features/WORKSPACE-FEATURE.md
+++ b/documentation/features/WORKSPACE-FEATURE.md
@@ -2,7 +2,7 @@
 
 A workspace is the primary container where users organize and edit their documents and images. Think of it as an infinite canvas where cards float, can be arranged freely, resized, and edited in place.
 
-> **Renderer migration note (2026-05-05).** The active workspace canvas remains the proven `services/web-ui/src/infographics/workspace/WorkspaceCanvas.ts` stack. Phase 2 now adds PIXI v8 only as a **media layer for image pixels** through `services/web-ui/src/infographics/workspace/pixiMediaLayer.ts`; document nodes, AI chat thread nodes, prompt inputs, bubble menus, resize/drag/selection, and SVG connectors stay in the existing DOM/SVG implementation. The abandoned full-replacement experiment is quarantined under `services/web-ui/.legacy-canvas/pixi-full-replacement-attempt/` and is not part of the build.
+> **Renderer migration note (2026-05-05).** The active workspace canvas remains the proven `services/web-ui/src/infographics/workspace/WorkspaceCanvas.ts` stack. Phase 2 now adds PIXI v8 only as a **media layer for image pixels** through `services/web-ui/src/infographics/workspace/pixiMediaLayer.ts`; document nodes, AI chat thread nodes, prompt inputs, bubble menus, resize/drag/selection, and SVG connectors stay in the existing DOM/SVG implementation. Historical full-replacement notes in `documentation/memory/pixi-refactoring.md` are background context, not the active implementation path.
 
 ## Core Concepts
 

--- a/services/web-ui/package.json
+++ b/services/web-ui/package.json
@@ -56,9 +56,9 @@
     "dependencies": {
         "@lixpi/constants": "workspace:*",
         "@lixpi/nats-service": "workspace:*",
-        "pixi.js": "^8.5.0",
-        "rbush": "^4.0.1",
-        "@types/rbush": "^4.0.0",
+        "pixi.js": "^8.14.0",
+        "rbush": "*",
+        "@types/rbush": "*",
         "elkjs": "*",
         "@auth0/auth0-spa-js": "*",
         "@codemirror/autocomplete": "*",

--- a/services/web-ui/package.json
+++ b/services/web-ui/package.json
@@ -56,6 +56,9 @@
     "dependencies": {
         "@lixpi/constants": "workspace:*",
         "@lixpi/nats-service": "workspace:*",
+        "pixi.js": "^8.5.0",
+        "rbush": "^4.0.1",
+        "@types/rbush": "^4.0.0",
         "elkjs": "*",
         "@auth0/auth0-spa-js": "*",
         "@codemirror/autocomplete": "*",

--- a/services/web-ui/src/infographics/workspace/README.md
+++ b/services/web-ui/src/infographics/workspace/README.md
@@ -2,6 +2,12 @@
 
 This module renders the main workspace view—a zoomable, pannable canvas where documents, images, and AI chat threads appear as draggable, resizable cards.
 
+> **Where to look first.**
+>
+> - For the rendering architecture (DOM/SVG interaction layer + PIXI v8 media layer), the LoD-tier loader, the texture cache, the 6-worker decode pool, and the list of remaining performance issues, read [`documentation/features/CANVAS-ENGINE.md`](../../../../../documentation/features/CANVAS-ENGINE.md). That document is the source of truth for any rendering or perf work.
+> - For workspace data flow (stores, services, NATS subjects, AI chat context extraction, image generation), read [`documentation/features/WORKSPACE-FEATURE.md`](../../../../../documentation/features/WORKSPACE-FEATURE.md).
+> - This README documents the local code shape — file roles, DOM structure, click and selection rules, AI chat thread layout, edge connection UX.
+
 ## What It Does
 
 When you open a workspace, you see a canvas. On that canvas are nodes (documents, images, or AI chat threads). You can:
@@ -177,13 +183,16 @@ Image nodes have a simpler structure:
 
 ```
 ┌─────────────────────────────────────────┐
-│                                         │
-│  .image-node-content                    │
-│  (contains img element)                 │
-│                                         │
+│  img.image-node-img                     │
+│   ─ src is empty when PIXI is healthy   │
+│   ─ opacity:0 via .pixi-owned class     │
+│   ─ src is set as a fallback if         │
+│     PIXI fails to initialize            │
 │  .image-drag-overlay                    │
-│  (covers entire image for dragging)     │
-│                                         │
+│   (covers entire image for dragging)    │
+│  .image-model-badge (when generated)    │
+│  .image-generating-spinner (during gen) │
+│  .image-generating-border (during gen)  │
 └─────────────────────────────────────────┘
   ↖ resize     resize ↗
   handle       handle
@@ -191,6 +200,8 @@ Image nodes have a simpler structure:
   ↙ resize     resize ↘
   handle       handle
 ```
+
+The visible pixels are drawn by **PIXI** (see `pixiMediaLayer.ts` and [CANVAS-ENGINE.md](../../../../../documentation/features/CANVAS-ENGINE.md)). The DOM `<img>` is kept as the legacy fallback path and as the surface that streams partial pixels during AI image generation (the partial-streaming code path sets `imgEl.src` directly via `querySelector`; once the image is committed to canvas state, PIXI takes over and the DOM `<img>` is hidden via the `workspace-image-node--pixi-owned` class).
 
 Image resize always preserves aspect ratio using the `aspectRatio` value stored when the image was uploaded.
 
@@ -384,9 +395,16 @@ Menu items are defined in `canvasBubbleMenuItems.ts`. The core `BubbleMenu` clas
 
 | File | Purpose |
 |------|---------|
-| `WorkspaceCanvas.ts` | Core logic: pan/zoom setup, node creation, drag/resize handlers, bubble menu integration |
-| `WorkspaceConnectionManager.ts` | Edge connection logic: XYHandle integration, edge rendering, selection/deletion |
-| `workspace-canvas.scss` | All styles for canvas, nodes, handles, edges, editors |
+| `WorkspaceCanvas.ts` | Core logic: pan/zoom setup, node creation, drag/resize handlers, bubble menu integration, PIXI media layer wiring, fallback path on PIXI failure |
+| `WorkspaceConnectionManager.ts` | Edge connection logic: XYHandle integration, SVG edge rendering for hit-testing, PIXI edge data feed, selection/deletion |
+| `pixiMediaLayer.ts` | PIXI v8 media layer for image pixels: sprite registry, texture cache, LoD-tier loader, RBush-based visibility scanner, idle prefetch scheduler, mipmap config |
+| `pixiMediaLayerLogic.ts` | Pure helpers used by the PIXI layer: tier ranking (`tierRank`), world-position math, source URL building, LoD `?size=` injection, world-rect computation |
+| `pixiImageDecoder.ts` | Six-worker decode pool. Round-robin dispatch with per-worker request tracking so a single worker crash does not nuke all in-flight requests |
+| `pixiImageDecodeWorker.ts` | Web Worker body: `fetch` → `createImageBitmap` → transfer the bitmap back to the main thread |
+| `rendering/pixiEdgeRenderer.ts` | Diffed PIXI edge renderer: reuses `Graphics` objects across renders; only repaints when an edge's path/colour/arrow fingerprint changes |
+| `rendering/viewportBridge.ts` | Single call site that applies a viewport change to both the DOM CSS transform and the PIXI world (keeps DOM and PIXI perfectly aligned) |
+| `rendering/mediaNodeRegistry.ts` | Extension point for future non-image media handlers (video, audio). Image nodes are handled directly by `pixiMediaLayer`; the registry exists so video/audio handlers can plug in without touching the core |
+| `workspace-canvas.scss` | All styles for canvas, nodes, handles, edges, editors, and the `workspace-image-node--pixi-owned` opacity rule |
 | `canvasImageLifecycle.ts` | Tracks image nodes and deletes orphaned images from storage |
 | `canvasBubbleMenuItems.ts` | Bubble menu item definitions for canvas elements (image and edge actions) |
 | `imagePositioning.ts` | Computes image placement positions (next-to-thread and overlapping-thread modes) |
@@ -409,8 +427,8 @@ Menu items are defined in `canvasBubbleMenuItems.ts`. The core `BubbleMenu` clas
 | `.image-drag-overlay` | Full-area overlay for dragging images |
 | `.document-node-editor` | ProseMirror container for documents |
 | `.ai-chat-thread-node-editor` | ProseMirror container for AI chat threads |
-| `.image-node-content` | Image container |
-| `.image-node-img` | The actual img element |
+| `.image-node-img` | The DOM `<img>` element (kept as PIXI-failure fallback and as the surface for partial-streaming during AI image generation; `src` is empty while PIXI is healthy) |
+| `.workspace-image-node--pixi-owned` | Class added by `pixiMediaLayer` while PIXI is rendering this image. Sets `opacity: 0` on `.image-node-img` so the PIXI sprite is the only visible surface |
 | `.workspace-image-node--anchored` | Image node overlapping its AI chat thread (anchored mode) |
 | `.workspace-image-node--context-region-child` | Image node contained by a context region, with the region-only off-white frame |
 | `.workspace-thread-rail` | Vertical rail outer container spanning thread + gap + floating input (drag handle, connection proxy) |

--- a/services/web-ui/src/infographics/workspace/WorkspaceCanvas.ts
+++ b/services/web-ui/src/infographics/workspace/WorkspaceCanvas.ts
@@ -2849,6 +2849,9 @@ export function createWorkspaceCanvas(options: WorkspaceCanvasOptions) {
                 }
             },
             isContextRegionNode: isContextRegionCanvasNode,
+            onPixiEdgesReady: (edges) => {
+                pixiMediaLayer?.setPixiEdges(edges)
+            },
         })
 
         if (currentCanvasState) {
@@ -3396,13 +3399,12 @@ export function createWorkspaceCanvas(options: WorkspaceCanvasOptions) {
         const node = currentCanvasState.nodes.find((n: CanvasNode) => n.nodeId === nodeId)
         const isImageNode = node?.type === 'image'
 
-        // For images, get aspect ratio from the actual img element (more reliable than stored data)
+        // PIXI owns image pixels; the hidden DOM <img> can finish loading after
+        // workspace switches, so do not derive resize behavior from DOM natural
+        // dimensions. Use the persisted canvas-node aspect ratio instead.
         let aspectRatio: number | null = null
         if (isImageNode) {
-            const imgEl = nodeEl.querySelector('img') as HTMLImageElement
-            if (imgEl && imgEl.naturalWidth && imgEl.naturalHeight) {
-                aspectRatio = imgEl.naturalWidth / imgEl.naturalHeight
-            }
+            aspectRatio = node.aspectRatio || null
         }
 
         resizingNodeId = nodeId
@@ -3858,33 +3860,11 @@ export function createWorkspaceCanvas(options: WorkspaceCanvasOptions) {
             }
         }
 
-        // Once image loads, fix container dimensions to match actual aspect ratio
+        // PIXI owns image pixels. The hidden DOM <img> exists only as a legacy
+        // DOM child for interaction chrome compatibility; it must never mutate
+        // canvas state after async load, especially across workspace switches.
         imgEl.onload = () => {
-            const naturalAspect = imgEl.naturalWidth / imgEl.naturalHeight
-            const storedAspect = node.dimensions.width / node.dimensions.height
-
-            // If aspect ratios don't match, fix and persist
-            if (Math.abs(naturalAspect - storedAspect) > 0.01) {
-                const correctedHeight = node.dimensions.width / naturalAspect
-                nodeEl.style.height = `${correctedHeight}px`
-
-                // Persist the corrected dimensions
-                if (currentCanvasState && onCanvasStateChange) {
-                    const updatedNodes = currentCanvasState.nodes.map((n: CanvasNode) => {
-                        if (n.nodeId === node.nodeId && n.type === 'image') {
-                            return {
-                                ...n,
-                                dimensions: { width: node.dimensions.width, height: correctedHeight },
-                                aspectRatio: naturalAspect
-                            }
-                        }
-                        return n
-                    })
-                    const newState: CanvasState = { ...currentCanvasState, nodes: expandRegionsToFitChildren(updatedNodes) }
-                    currentCanvasState = newState
-                    onCanvasStateChange(newState)
-                }
-            }
+            return
         }
 
         nodeEl.appendChild(imgEl)
@@ -4399,27 +4379,34 @@ export function createWorkspaceCanvas(options: WorkspaceCanvasOptions) {
             currentAiChatThreads = newAiChatThreads
             syncActiveAiChatPanelFromState()
 
-            // Rebuild DOM first so image nodes exist when PIXI syncs DOM ownership.
+            // 1. Rebuild DOM first so image nodes exist when PIXI syncs DOM ownership.
             if (needsRerender) {
                 renderNodes()
                 lastDocumentsKey = getDocumentsKey(newDocuments)
                 lastThreadsKey = getAiChatThreadsKey(newAiChatThreads)
             }
 
-            // Apply viewport before PIXI sync so the world transform and culling
-            // rect are current before sprites are positioned or made renderable.
-            if (viewportChanged && newCanvasState?.viewport) {
-                const vp = newCanvasState.viewport
-                syncViewportInteractionState(vp)
-                viewportBridge?.applyViewport(vp)
-                panZoom?.syncViewport(vp)
-            }
-
+            // 2. Sync PIXI state BEFORE applying the viewport. This ensures
+            //    `lastState` inside the PIXI layer is already the new workspace's
+            //    canvas state when `setViewport` fires. Without this ordering, a
+            //    zoom-tier change during workspace switch would call
+            //    `upsertAllImages(OLD_STATE)`, spawning async texture fetches for
+            //    the old workspace's images that arrive and overwrite new sprites.
             if (currentCanvasState && connectionManager) {
                 connectionManager.syncNodes(currentCanvasState.nodes)
                 connectionManager.syncEdges(currentCanvasState.edges)
                 scheduleEdgesRender()
                 pixiMediaLayer?.sync(currentCanvasState)
+            }
+
+            // 3. Apply viewport after PIXI sync. `setViewport` may trigger
+            //    `upsertAllImages(lastState)` on a tier change, but `lastState`
+            //    is now the new workspace state, so no old sprites are created.
+            if (viewportChanged && newCanvasState?.viewport) {
+                const vp = newCanvasState.viewport
+                syncViewportInteractionState(vp)
+                viewportBridge?.applyViewport(vp)
+                panZoom?.syncViewport(vp)
             }
         },
         destroy() {

--- a/services/web-ui/src/infographics/workspace/WorkspaceCanvas.ts
+++ b/services/web-ui/src/infographics/workspace/WorkspaceCanvas.ts
@@ -138,6 +138,21 @@ export function createWorkspaceCanvas(options: WorkspaceCanvasOptions) {
     let pixiMediaLayer: PixiMediaLayer | null = null
     let viewportBridge: ViewportBridge | null = null
 
+    // Health of the PIXI renderer. Image nodes' DOM `<img>` elements stay
+    // empty (no `src`) while PIXI is healthy so the browser never makes a
+    // second, redundant network round-trip for the same pixels PIXI is
+    // already drawing. If PIXI fails to initialize (e.g. WebGL/WebGPU
+    // unavailable), `pixiHealth` flips to `'failed'` and we backfill src
+    // attributes so the DOM fallback takes over.
+    let pixiHealth: 'initializing' | 'ready' | 'failed' | 'destroyed' = 'initializing'
+    // Per-image-node DOM <img> element registry, keyed by node id. Lets us
+    // assign src in O(1) on PIXI failure without a viewport-wide
+    // querySelector.
+    const imageElByNodeId: Map<string, HTMLImageElement> = new Map()
+    // The resolved (token-less) API path for each image node, captured at
+    // node-creation time. Used to backfill `<img>.src` when PIXI fails.
+    const imageResolvedSrcByNodeId: Map<string, string> = new Map()
+
     const liveNodeOverrides: Map<string, { position?: { x: number; y: number }; dimensions?: { width: number; height: number } }> = new Map()
     let edgesRaf: number | null = null
     let transformSideEffectsRaf: number | null = null
@@ -192,6 +207,15 @@ export function createWorkspaceCanvas(options: WorkspaceCanvasOptions) {
         viewportEl,
         getWorkspaceId: () => workspaceId,
         selectionColors: pixiSelectionColors,
+        onHealthChange: (next) => {
+            pixiHealth = next
+            if (next === 'failed') {
+                // PIXI gave up — every image node falls back to the DOM
+                // <img> renderer. Set `src` on each tracked image element
+                // so the browser starts the (previously skipped) fetch.
+                void backfillDomImageSrcs()
+            }
+        },
     })
     viewportBridge = createViewportBridge({
         viewportEl,
@@ -1984,6 +2008,27 @@ export function createWorkspaceCanvas(options: WorkspaceCanvasOptions) {
         if (imageUrl.startsWith('http') && imageUrl.includes('/api/images/')) return `${imageUrl}${token ? `?token=${token}` : ''}`
         if (imageUrl.startsWith('http')) return imageUrl
         return `data:image/png;base64,${imageUrl}`
+    }
+
+    // Last-resort fallback when PIXI fails to initialize. Iterates every
+    // tracked image node and sets `<img>.src` so the (CSS-hidden) DOM
+    // `<img>` tag becomes the renderer for that node. This is a one-time
+    // cost per failed init — the canvas keeps working, just on the slower
+    // DOM path used before PIXI was introduced.
+    async function backfillDomImageSrcs(): Promise<void> {
+        if (imageResolvedSrcByNodeId.size === 0) return
+        const API_BASE_URL = import.meta.env.VITE_API_URL || ''
+        let token: string | false = false
+        try {
+            token = await AuthService.getTokenSilently()
+        } catch {
+            // proceed without token; public images still work
+        }
+        for (const [nodeId, resolvedSrc] of imageResolvedSrcByNodeId) {
+            const imgEl = imageElByNodeId.get(nodeId)
+            if (!imgEl || imgEl.src) continue
+            imgEl.src = buildImageSrc(resolvedSrc, API_BASE_URL, token)
+        }
     }
 
     function showImageErrorPlaceholder(imgEl: HTMLImageElement, nodeEl: HTMLElement): void {
@@ -3829,15 +3874,37 @@ export function createWorkspaceCanvas(options: WorkspaceCanvasOptions) {
             ? `/api/images/${workspaceId}/${node.fileId}`
             : strippedSrc
 
+        // Track this <img> + its resolved API path. Used by the PIXI
+        // health-failure fallback to backfill `src` only on stored images,
+        // and the partial-streaming code path to update src in place.
+        imageElByNodeId.set(node.nodeId, imgEl)
+        if (isStoredImage) imageResolvedSrcByNodeId.set(node.nodeId, resolvedSrc)
+
         let retried = false
-        ;(async () => {
+        const assignSrc = async () => {
             try {
                 const token = await AuthService.getTokenSilently()
                 imgEl.src = buildImageSrc(resolvedSrc, API_BASE_URL, token)
             } catch {
                 showImageErrorPlaceholder(imgEl, nodeEl)
             }
-        })()
+        }
+
+        // CRITICAL: stored images are rendered by PIXI. Setting `<img>.src`
+        // here would double-fetch every image — once for the (hidden,
+        // opacity:0) DOM `<img>` and once for the PIXI worker. With hundreds
+        // of images that doubles network round-trips and makes the page
+        // crawl through the browser's per-origin HTTP queue.
+        //
+        // For stored images we leave the `<img>` empty until/unless PIXI
+        // signals failure (see `backfillDomImageSrcs`). Data: URLs (in-
+        // progress generations) and external URLs continue to load
+        // immediately, since PIXI only handles stored canvas images.
+        if (!isStoredImage) {
+            void assignSrc()
+        } else if (pixiHealth === 'failed') {
+            void assignSrc()
+        }
 
         imgEl.onerror = async () => {
             if (!retried) {
@@ -4125,6 +4192,8 @@ export function createWorkspaceCanvas(options: WorkspaceCanvasOptions) {
         loadedNodeIds.clear()
         hiddenEmptyThreadNodeIds.clear()
         anchoredImageManager.clear()
+        imageElByNodeId.clear()
+        imageResolvedSrcByNodeId.clear()
 
         // Clean up per-region gradients (will be recreated for each region node)
         for (const [, g] of regionGradients) g.destroy()

--- a/services/web-ui/src/infographics/workspace/WorkspaceCanvas.ts
+++ b/services/web-ui/src/infographics/workspace/WorkspaceCanvas.ts
@@ -42,7 +42,7 @@ import { buildCanvasBubbleMenuItems, CANVAS_IMAGE_CONTEXT, CANVAS_EDGE_CONTEXT }
 import { downloadImage } from '$src/utils/downloadImage.ts'
 import { AiPromptInputController } from '$src/services/ai-prompt-input-controller.ts'
 import { createGenericAiModelDropdown, createGenericSubmitButton, createGenericImageSizeDropdown, createGenericImageModelDropdown } from '$src/components/proseMirror/plugins/primitives/aiControls/index.ts'
-import { createPixiMediaLayer, type PixiMediaLayer } from '$src/infographics/workspace/pixiMediaLayer.ts'
+import { createPixiMediaLayer, type PixiMediaLayer, type SelectionColors } from '$src/infographics/workspace/pixiMediaLayer.ts'
 import { createViewportBridge, type ViewportBridge } from '$src/infographics/workspace/rendering/viewportBridge.ts'
 
 import { select } from 'd3-selection'
@@ -180,10 +180,18 @@ export function createWorkspaceCanvas(options: WorkspaceCanvasOptions) {
     // Anchored image manager - tracks images overlapping their AI chat thread nodes
     const anchoredImageManager = createAnchoredImageManager()
 
+    const pixiSelectionColors: SelectionColors = {
+        nodeOutline: webUiThemeSettings.selectionOutlineColor,
+        marqueeStroke: webUiThemeSettings.selectionMarqueeBorderColor,
+        marqueeFill: webUiThemeSettings.selectionMarqueeBackgroundColor,
+        groupOverlayStroke: webUiThemeSettings.selectionOverlayBorderColor,
+        groupOverlayFill: webUiThemeSettings.selectionOverlayBackgroundColor,
+    }
     pixiMediaLayer = createPixiMediaLayer({
         paneEl,
         viewportEl,
-        getWorkspaceId: () => workspaceId
+        getWorkspaceId: () => workspaceId,
+        selectionColors: pixiSelectionColors,
     })
     viewportBridge = createViewportBridge({
         viewportEl,
@@ -754,20 +762,31 @@ export function createWorkspaceCanvas(options: WorkspaceCanvasOptions) {
     function updateSelectionRectElement(): void {
         if (!marqueeSelection) return
 
-        const rectEl = ensureSelectionRectElement()
-        if (!rectEl) return
-
         const rect = getCanvasRectFromSelection(marqueeSelection)
-        applyStyle(rectEl, {
-            display: marqueeSelection.moved ? 'block' : 'none',
-            left: `${rect.x}px`,
-            top: `${rect.y}px`,
-            width: `${rect.width}px`,
-            height: `${rect.height}px`,
-        })
+
+        if (marqueeSelection.moved) {
+            pixiMediaLayer?.setMarqueeRect(rect)
+
+            // DOM rect only for non-PIXI contexts (document/thread nodes);
+            // PIXI draws it for image nodes but DOM fallback keeps it working everywhere.
+            const rectEl = ensureSelectionRectElement()
+            if (rectEl) {
+                applyStyle(rectEl, {
+                    display: 'block',
+                    left: `${rect.x}px`,
+                    top: `${rect.y}px`,
+                    width: `${rect.width}px`,
+                    height: `${rect.height}px`,
+                })
+            }
+        } else {
+            pixiMediaLayer?.setMarqueeRect(null)
+            if (selectionRectEl) selectionRectEl.style.display = 'none'
+        }
     }
 
     function hideSelectionRectElement(): void {
+        pixiMediaLayer?.setMarqueeRect(null)
         if (selectionRectEl) {
             selectionRectEl.style.display = 'none'
         }
@@ -812,10 +831,16 @@ export function createWorkspaceCanvas(options: WorkspaceCanvasOptions) {
     }
 
     function updateSelectionGroupOverlayElement(): void {
+        const bounds = getSelectionOverlayBounds()
+
+        // PIXI draws the visible selection overlay for image nodes.
+        pixiMediaLayer?.setSelectionOverlayBounds(bounds)
+
+        // The DOM element is kept invisible but in place as a drag hit target.
+        // Its background/border are stripped in the SCSS so PIXI owns the visual.
         const overlayEl = ensureSelectionGroupOverlayElement()
         if (!overlayEl) return
 
-        const bounds = getSelectionOverlayBounds()
         if (!bounds) {
             overlayEl.style.display = 'none'
             return
@@ -905,6 +930,7 @@ export function createWorkspaceCanvas(options: WorkspaceCanvasOptions) {
         updateNodeSelectionClasses(prevSelectedNodeIds, selectedNodeIds)
         updateSelectionGroupOverlayElement()
         updateSelectionDrivenUi()
+        pixiMediaLayer?.setSelectedImageNodes(nextSelectedNodeIds)
     }
 
     function toggleNodeSelection(nodeId: string): void {
@@ -3131,6 +3157,7 @@ export function createWorkspaceCanvas(options: WorkspaceCanvasOptions) {
             scheduleEdgesRender()
             repositionCanvasBubbleMenu()
             updateSelectionGroupOverlayElement()
+            pixiMediaLayer?.setSelectedImageNodes(selectedNodeIds)
         }
 
         const handleMouseUp = (upEvent: MouseEvent) => {
@@ -3197,6 +3224,15 @@ export function createWorkspaceCanvas(options: WorkspaceCanvasOptions) {
 
                 if (isContextRegionCanvasNode(node)) {
                     return { ...node, position: finalWorldPosition }
+                }
+
+                if (node.parentId && finalDraggedPositions.has(node.parentId)) {
+                    // Parent and child moved together as one selected group. The
+                    // live DOM/PIXI positions are world coordinates, but persisted
+                    // child positions remain parent-relative. Keep the existing
+                    // relative position so the parent's movement carries the child
+                    // exactly once after the state commit.
+                    return node
                 }
 
                 const draggedRect: Rect = {
@@ -3465,13 +3501,21 @@ export function createWorkspaceCanvas(options: WorkspaceCanvasOptions) {
             })
 
             pixiMediaLayer?.setNodeLiveTransform(nodeId, liveResizePosition, liveResizeDimensions)
+            pixiMediaLayer?.setSelectedImageNodes(selectedNodeIds)
+            pixiMediaLayer?.setSelectionOverlayBounds(getSelectionOverlayBounds())
 
-            // If resizing a region child, visibly grow the region in real-time
+            // If resizing a region child, visibly grow the region in real-time.
+            // `nodeEl.style.left/top` is in world coordinates; convert to parent-
+            // relative before computing the needed region dimensions.
             if (node?.parentId) {
                 const regionEl = viewportEl?.querySelector(`[data-node-id="${node.parentId}"]`) as HTMLElement | null
                 if (regionEl) {
-                    const relativeLeft = parseFloat(nodeEl.style.left) || 0
-                    const relativeTop = parseFloat(nodeEl.style.top) || 0
+                    const worldLeft = parseFloat(nodeEl.style.left) || 0
+                    const worldTop = parseFloat(nodeEl.style.top) || 0
+                    const regionWorldLeft = parseFloat(regionEl.style.left) || 0
+                    const regionWorldTop = parseFloat(regionEl.style.top) || 0
+                    const relativeLeft = worldLeft - regionWorldLeft
+                    const relativeTop = worldTop - regionWorldTop
                     const neededWidth = relativeLeft + newWidth + 48
                     const neededHeight = relativeTop + newHeight + 48
                     const currentRegionWidth = parseFloat(regionEl.style.width) || 200
@@ -3552,10 +3596,18 @@ export function createWorkspaceCanvas(options: WorkspaceCanvasOptions) {
                 height: nodeEl.offsetHeight
             }
 
-            const newPosition = {
+            // `nodeEl.style.left/top` is always in viewport-relative world
+            // coordinates (set by `createBaseNodeElement` via `getNodeWorldPosition`).
+            // Context-region children persist `position` as parent-relative, so
+            // convert back before committing.
+            const newWorldPosition = {
                 x: parseFloat(nodeEl.style.left),
                 y: parseFloat(nodeEl.style.top)
             }
+            const resizingNode = currentCanvasState.nodes.find((n: CanvasNode) => n.nodeId === nodeId)
+            const newPosition = resizingNode?.parentId
+                ? toParentRelativePosition(newWorldPosition, resizingNode.parentId, getCanvasNodesById())
+                : newWorldPosition
 
             let updatedNodes = currentCanvasState.nodes.map((n: CanvasNode) =>
                 n.nodeId === nodeId ? { ...n, dimensions: newDimensions, position: newPosition } : n

--- a/services/web-ui/src/infographics/workspace/WorkspaceCanvas.ts
+++ b/services/web-ui/src/infographics/workspace/WorkspaceCanvas.ts
@@ -43,6 +43,7 @@ import { downloadImage } from '$src/utils/downloadImage.ts'
 import { AiPromptInputController } from '$src/services/ai-prompt-input-controller.ts'
 import { createGenericAiModelDropdown, createGenericSubmitButton, createGenericImageSizeDropdown, createGenericImageModelDropdown } from '$src/components/proseMirror/plugins/primitives/aiControls/index.ts'
 import { createPixiMediaLayer, type PixiMediaLayer } from '$src/infographics/workspace/pixiMediaLayer.ts'
+import { createViewportBridge, type ViewportBridge } from '$src/infographics/workspace/rendering/viewportBridge.ts'
 
 import { select } from 'd3-selection'
 
@@ -135,6 +136,7 @@ export function createWorkspaceCanvas(options: WorkspaceCanvasOptions) {
     let connectionManager: WorkspaceConnectionManager | null = null
     let edgesLayerEl: HTMLDivElement | null = null
     let pixiMediaLayer: PixiMediaLayer | null = null
+    let viewportBridge: ViewportBridge | null = null
 
     const liveNodeOverrides: Map<string, { position?: { x: number; y: number }; dimensions?: { width: number; height: number } }> = new Map()
     let edgesRaf: number | null = null
@@ -183,8 +185,12 @@ export function createWorkspaceCanvas(options: WorkspaceCanvasOptions) {
         viewportEl,
         getWorkspaceId: () => workspaceId
     })
+    viewportBridge = createViewportBridge({
+        viewportEl,
+        getPixiLayer: () => pixiMediaLayer,
+    })
     if (currentCanvasState?.viewport) {
-        pixiMediaLayer.setViewport(currentCanvasState.viewport)
+        viewportBridge.applyViewport(currentCanvasState.viewport)
     }
     pixiMediaLayer.sync(currentCanvasState)
 
@@ -2628,10 +2634,7 @@ export function createWorkspaceCanvas(options: WorkspaceCanvasOptions) {
             // Any other DOM mutation (custom properties, style writes, querySelectorAll)
             // invalidates the compositor layer cache and forces a full re-rasterization
             // of every image/text in the viewport, causing visible flickering.
-            if (viewportEl) {
-                viewportEl.style.transform = `translate(${vp.x}px, ${vp.y}px) scale(${vp.zoom})`
-            }
-            pixiMediaLayer?.setViewport(vp)
+            viewportBridge?.applyViewport(vp)
             if (zoomChanged) {
                 if (webUiSettings.useZoomCompensatedResizeHandleScaling) {
                     pendingHandleZoom = vp.zoom
@@ -4253,8 +4256,7 @@ export function createWorkspaceCanvas(options: WorkspaceCanvasOptions) {
         if (currentCanvasState?.viewport) {
             const vp = currentCanvasState.viewport
             syncViewportInteractionState(vp)
-            viewportEl.style.transform = `translate(${vp.x}px, ${vp.y}px) scale(${vp.zoom})`
-            pixiMediaLayer?.setViewport(vp)
+            viewportBridge?.applyViewport(vp)
             // Ensure handles match initial zoom
             updateResizeHandles(vp.zoom)
             updateRegionTitleBars(vp.zoom)
@@ -4315,10 +4317,22 @@ export function createWorkspaceCanvas(options: WorkspaceCanvasOptions) {
 
     return {
         render(newCanvasState: CanvasState | null, newDocuments: Document[], newAiChatThreads: AiChatThread[] = [], newWorkspaceId?: string) {
+            const workspaceChanged = Boolean(newWorkspaceId && newWorkspaceId !== workspaceId)
             if (newWorkspaceId) workspaceId = newWorkspaceId
+
+            // Stale drag/resize positions from a previous workspace would corrupt
+            // getNodeWorldPosition for the new workspace's nodes.
+            if (workspaceChanged) {
+                liveNodeOverrides.clear()
+                selectedNodeIds = new Set()
+                selectedEdgeId = null
+                draggingNodeId = null
+                resizingNodeId = null
+            }
+
             // Only do a full re-render if node structure or documents/threads changed
             // Position/dimension updates are handled directly in DOM during drag/resize
-            const needsRerender = shouldRerender(newCanvasState, newDocuments, newAiChatThreads)
+            const needsRerender = shouldRerender(newCanvasState, newDocuments, newAiChatThreads) || workspaceChanged
 
             // Check if viewport actually changed (not just nodes)
             const oldViewport = currentCanvasState?.viewport
@@ -4333,27 +4347,27 @@ export function createWorkspaceCanvas(options: WorkspaceCanvasOptions) {
             currentAiChatThreads = newAiChatThreads
             syncActiveAiChatPanelFromState()
 
-            if (currentCanvasState && connectionManager) {
-                connectionManager.syncNodes(currentCanvasState.nodes)
-                connectionManager.syncEdges(currentCanvasState.edges)
-                scheduleEdgesRender()
-                pixiMediaLayer?.sync(currentCanvasState)
-            }
-
+            // Rebuild DOM first so image nodes exist when PIXI syncs DOM ownership.
             if (needsRerender) {
                 renderNodes()
                 lastDocumentsKey = getDocumentsKey(newDocuments)
                 lastThreadsKey = getAiChatThreadsKey(newAiChatThreads)
             }
 
-            // Only sync viewport if it actually changed from external source
-            // Don't reset viewport just because node dimensions were corrected
+            // Apply viewport before PIXI sync so the world transform and culling
+            // rect are current before sprites are positioned or made renderable.
             if (viewportChanged && newCanvasState?.viewport) {
                 const vp = newCanvasState.viewport
                 syncViewportInteractionState(vp)
-                viewportEl.style.transform = `translate(${vp.x}px, ${vp.y}px) scale(${vp.zoom})`
-                pixiMediaLayer?.setViewport(vp)
+                viewportBridge?.applyViewport(vp)
                 panZoom?.syncViewport(vp)
+            }
+
+            if (currentCanvasState && connectionManager) {
+                connectionManager.syncNodes(currentCanvasState.nodes)
+                connectionManager.syncEdges(currentCanvasState.edges)
+                scheduleEdgesRender()
+                pixiMediaLayer?.sync(currentCanvasState)
             }
         },
         destroy() {
@@ -4381,6 +4395,8 @@ export function createWorkspaceCanvas(options: WorkspaceCanvasOptions) {
             hiddenEmptyThreadNodeIds.clear()
             connectionManager?.destroy()
             connectionManager = null
+            viewportBridge?.destroy()
+            viewportBridge = null
             pixiMediaLayer?.destroy()
             pixiMediaLayer = null
             if (panZoom) {

--- a/services/web-ui/src/infographics/workspace/WorkspaceCanvas.ts
+++ b/services/web-ui/src/infographics/workspace/WorkspaceCanvas.ts
@@ -4311,9 +4311,9 @@ export function createWorkspaceCanvas(options: WorkspaceCanvasOptions) {
             }
         }
 
-        // The chat editor now lives in the singleton canvas panel; context
-        // regions grow only when children require more room.
-        pixiMediaLayer?.sync(currentCanvasState)
+        // PIXI sync is driven by the caller (render() / commitCanvasState),
+        // not here — avoids a duplicate sync when renderNodes() is called
+        // from render() which syncs PIXI immediately afterwards.
     }
 
     function getDocumentsKey(docs: Document[]): string {

--- a/services/web-ui/src/infographics/workspace/WorkspaceCanvas.ts
+++ b/services/web-ui/src/infographics/workspace/WorkspaceCanvas.ts
@@ -42,6 +42,7 @@ import { buildCanvasBubbleMenuItems, CANVAS_IMAGE_CONTEXT, CANVAS_EDGE_CONTEXT }
 import { downloadImage } from '$src/utils/downloadImage.ts'
 import { AiPromptInputController } from '$src/services/ai-prompt-input-controller.ts'
 import { createGenericAiModelDropdown, createGenericSubmitButton, createGenericImageSizeDropdown, createGenericImageModelDropdown } from '$src/components/proseMirror/plugins/primitives/aiControls/index.ts'
+import { createPixiMediaLayer, type PixiMediaLayer } from '$src/infographics/workspace/pixiMediaLayer.ts'
 
 import { select } from 'd3-selection'
 
@@ -133,6 +134,7 @@ export function createWorkspaceCanvas(options: WorkspaceCanvasOptions) {
 
     let connectionManager: WorkspaceConnectionManager | null = null
     let edgesLayerEl: HTMLDivElement | null = null
+    let pixiMediaLayer: PixiMediaLayer | null = null
 
     const liveNodeOverrides: Map<string, { position?: { x: number; y: number }; dimensions?: { width: number; height: number } }> = new Map()
     let edgesRaf: number | null = null
@@ -175,6 +177,16 @@ export function createWorkspaceCanvas(options: WorkspaceCanvasOptions) {
 
     // Anchored image manager - tracks images overlapping their AI chat thread nodes
     const anchoredImageManager = createAnchoredImageManager()
+
+    pixiMediaLayer = createPixiMediaLayer({
+        paneEl,
+        viewportEl,
+        getWorkspaceId: () => workspaceId
+    })
+    if (currentCanvasState?.viewport) {
+        pixiMediaLayer.setViewport(currentCanvasState.viewport)
+    }
+    pixiMediaLayer.sync(currentCanvasState)
 
     // Canvas bubble menu for image nodes (delete, create variant)
     let canvasBubbleMenu: BubbleMenu | null = null
@@ -1960,6 +1972,7 @@ export function createWorkspaceCanvas(options: WorkspaceCanvasOptions) {
         const nodeEl = createImageNode(imageNode)
         viewportEl.appendChild(nodeEl)
         connectionManager?.registerNodeElement(imageNode.nodeId, nodeEl as HTMLDivElement)
+        pixiMediaLayer?.sync(currentCanvasState)
     }
 
     // Persist canvas state without triggering a full re-render.
@@ -2618,6 +2631,7 @@ export function createWorkspaceCanvas(options: WorkspaceCanvasOptions) {
             if (viewportEl) {
                 viewportEl.style.transform = `translate(${vp.x}px, ${vp.y}px) scale(${vp.zoom})`
             }
+            pixiMediaLayer?.setViewport(vp)
             if (zoomChanged) {
                 if (webUiSettings.useZoomCompensatedResizeHandleScaling) {
                     pendingHandleZoom = vp.zoom
@@ -2725,6 +2739,7 @@ export function createWorkspaceCanvas(options: WorkspaceCanvasOptions) {
         connectionManager?.syncEdges(nextState.edges)
         connectionManager?.syncNodes(nextState.nodes)
         scheduleEdgesRender()
+        pixiMediaLayer?.sync(nextState)
     }
 
     function scheduleTransformSideEffects() {
@@ -4184,6 +4199,7 @@ export function createWorkspaceCanvas(options: WorkspaceCanvasOptions) {
 
         // The chat editor now lives in the singleton canvas panel; context
         // regions grow only when children require more room.
+        pixiMediaLayer?.sync(currentCanvasState)
     }
 
     function getDocumentsKey(docs: Document[]): string {
@@ -4228,6 +4244,7 @@ export function createWorkspaceCanvas(options: WorkspaceCanvasOptions) {
             const vp = currentCanvasState.viewport
             syncViewportInteractionState(vp)
             viewportEl.style.transform = `translate(${vp.x}px, ${vp.y}px) scale(${vp.zoom})`
+            pixiMediaLayer?.setViewport(vp)
             // Ensure handles match initial zoom
             updateResizeHandles(vp.zoom)
             updateRegionTitleBars(vp.zoom)
@@ -4310,6 +4327,7 @@ export function createWorkspaceCanvas(options: WorkspaceCanvasOptions) {
                 connectionManager.syncNodes(currentCanvasState.nodes)
                 connectionManager.syncEdges(currentCanvasState.edges)
                 scheduleEdgesRender()
+                pixiMediaLayer?.sync(currentCanvasState)
             }
 
             if (needsRerender) {
@@ -4324,6 +4342,7 @@ export function createWorkspaceCanvas(options: WorkspaceCanvasOptions) {
                 const vp = newCanvasState.viewport
                 syncViewportInteractionState(vp)
                 viewportEl.style.transform = `translate(${vp.x}px, ${vp.y}px) scale(${vp.zoom})`
+                pixiMediaLayer?.setViewport(vp)
                 panZoom?.syncViewport(vp)
             }
         },
@@ -4352,6 +4371,8 @@ export function createWorkspaceCanvas(options: WorkspaceCanvasOptions) {
             hiddenEmptyThreadNodeIds.clear()
             connectionManager?.destroy()
             connectionManager = null
+            pixiMediaLayer?.destroy()
+            pixiMediaLayer = null
             if (panZoom) {
                 panZoom.destroy()
             }

--- a/services/web-ui/src/infographics/workspace/WorkspaceCanvas.ts
+++ b/services/web-ui/src/infographics/workspace/WorkspaceCanvas.ts
@@ -3069,6 +3069,8 @@ export function createWorkspaceCanvas(options: WorkspaceCanvasOptions) {
                     dimensions: currentDims,
                 })
 
+                pixiMediaLayer?.setNodeLiveTransform(draggedNodeId, currentPos, currentDims)
+
                 if (floatingInputEl && floatingInputEl.style.display !== 'none' && draggedNodeId === singleSelectedNodeId) {
                     applyStyle(floatingInputEl, {
                         left: `${currentPos.x}px`,
@@ -3113,11 +3115,13 @@ export function createWorkspaceCanvas(options: WorkspaceCanvasOptions) {
                 if (anchoredEl) {
                     const newX = startPos.x + deltaX
                     const newY = startPos.y + deltaY
+                    const newDims = { width: anchoredEl.offsetWidth, height: anchoredEl.offsetHeight }
                     applyStyle(anchoredEl, { left: `${newX}px`, top: `${newY}px` })
                     liveNodeOverrides.set(imgId, {
                         position: { x: newX, y: newY },
-                        dimensions: { width: anchoredEl.offsetWidth, height: anchoredEl.offsetHeight },
+                        dimensions: newDims,
                     })
+                    pixiMediaLayer?.setNodeLiveTransform(imgId, { x: newX, y: newY }, newDims)
                 }
             }
 
@@ -3248,6 +3252,7 @@ export function createWorkspaceCanvas(options: WorkspaceCanvasOptions) {
                         applyStyle(nodeEl, { left: `${snappedWorld.x}px`, top: `${snappedWorld.y}px` })
                         syncContextRegionImageFrame(nodeEl, { ...node, parentId: containingRegion.nodeId }, currentCanvasState.nodes)
                     }
+                    pixiMediaLayer?.setNodeLiveTransform(node.nodeId, snappedWorld, node.dimensions)
 
                     return {
                         ...node,
@@ -3311,6 +3316,7 @@ export function createWorkspaceCanvas(options: WorkspaceCanvasOptions) {
                             if (movedNodeEl) {
                                 applyStyle(movedNodeEl, { left: `${newPos.x}px`, top: `${newPos.y}px` })
                             }
+                            pixiMediaLayer?.setNodeLiveTransform(n.nodeId, newPos, n.dimensions)
                             const nextPosition = n.parentId
                                 ? toParentRelativePosition(newPos, n.parentId, getCanvasNodesById(updatedNodes))
                                 : newPos
@@ -3442,16 +3448,20 @@ export function createWorkspaceCanvas(options: WorkspaceCanvasOptions) {
                 nodeEl.style.top = `${startTop - heightDiff}px`
             }
 
+            const liveResizePosition = {
+                x: parseFloat(nodeEl.style.left),
+                y: parseFloat(nodeEl.style.top)
+            }
+            const liveResizeDimensions = {
+                width: newWidth,
+                height: newHeight
+            }
             liveNodeOverrides.set(nodeId, {
-                position: {
-                    x: parseFloat(nodeEl.style.left),
-                    y: parseFloat(nodeEl.style.top)
-                },
-                dimensions: {
-                    width: newWidth,
-                    height: newHeight
-                }
+                position: liveResizePosition,
+                dimensions: liveResizeDimensions,
             })
+
+            pixiMediaLayer?.setNodeLiveTransform(nodeId, liveResizePosition, liveResizeDimensions)
 
             // If resizing a region child, visibly grow the region in real-time
             if (node?.parentId) {

--- a/services/web-ui/src/infographics/workspace/WorkspaceConnectionManager.ts
+++ b/services/web-ui/src/infographics/workspace/WorkspaceConnectionManager.ts
@@ -19,11 +19,15 @@ import {
 
 import {
 	createConnectorRenderer,
+	computePath,
+	applyOffset,
 	type ConnectorRenderer,
 	type EdgeConfig,
 	type NodeConfig,
 	type PathType,
+	type AnchorPosition,
 } from '$src/infographics/connectors/index.ts'
+import type { PixiEdgeRenderDatum, PixiEdgeArrow } from '$src/infographics/workspace/pixiMediaLayerLogic.ts'
 
 import { getEdgeScaledSizes } from '$src/infographics/utils/zoomScaling.ts'
 import { applyStyle } from '$src/utils/domTemplates.ts'
@@ -64,6 +68,7 @@ type ConnectionManagerConfig = {
 	onSelectedEdgeChange?: (edgeId: string | null) => void
 	isContextRegionNode?: (node: CanvasNode) => boolean
 	railOffset?: number
+	onPixiEdgesReady?: (edges: PixiEdgeRenderDatum[]) => void
 }
 
 type RenderBounds = {
@@ -82,6 +87,129 @@ function toRendererPoint(point: { x: number; y: number }, transform: Transform) 
 	return {
 		x: (point.x - transform[0]) / transform[2],
 		y: (point.y - transform[1]) / transform[2]
+	}
+}
+
+// =============================================================================
+// PIXI edge data helpers — compute world-coordinate edge paths for the GPU renderer
+// =============================================================================
+
+function computeWorldAnchorPoint(
+	position: AnchorPosition,
+	t: number,
+	node: NodeConfig
+): { x: number; y: number } {
+	const { x, y, width, height } = node
+	switch (position) {
+		case 'left':   return { x, y: y + height * t }
+		case 'right':  return { x: x + width, y: y + height * t }
+		case 'top':    return { x: x + width * t, y }
+		case 'bottom': return { x: x + width * t, y: y + height }
+		default:       return { x: x + width / 2, y: y + height / 2 }
+	}
+}
+
+function anchorArrowAngle(position: AnchorPosition): number {
+	// Angle = direction the arrowhead tip points (into the node).
+	// left anchor  → edge arrives from the left going rightward  → tip points RIGHT (0)
+	// right anchor → edge arrives from the right going leftward  → tip points LEFT  (π)
+	// top anchor   → edge arrives from above going downward      → tip points DOWN  (π/2)
+	// bottom anchor→ edge arrives from below going upward        → tip points UP    (-π/2)
+	switch (position) {
+		case 'left':   return 0
+		case 'right':  return Math.PI
+		case 'top':    return Math.PI / 2
+		case 'bottom': return -Math.PI / 2
+		default:       return 0
+	}
+}
+
+function computePixiEdgeDatum(
+	edgeConfig: EdgeConfig,
+	worldNodeMap: Map<string, NodeConfig>,
+	isSelected: boolean,
+	defaultColor: string,
+	focusColor: string,
+	markerSize: number,
+	markerOffset: { source: number; target: number }
+): PixiEdgeRenderDatum | null {
+	const {
+		id,
+		source,
+		target,
+		pathType = 'bezier',
+		marker = 'none',
+		markerStart,
+		strokeWidth = 1.2,
+		curvature = 0.25,
+		borderRadius = 24,
+		laneIndex = 0,
+		laneCount = 1,
+		bendPoints,
+	} = edgeConfig
+
+	const sourceNode = worldNodeMap.get(source.nodeId)
+	const targetNode = worldNodeMap.get(target.nodeId)
+	if (!sourceNode || !targetNode) return null
+
+	const srcT = source.t ?? 0.5
+	const tgtT = target.t ?? 0.5
+
+	const rawSrcAnchor = computeWorldAnchorPoint(source.position, srcT, sourceNode)
+	const rawTgtAnchor = computeWorldAnchorPoint(target.position, tgtT, targetNode)
+
+	let srcCoords = applyOffset(rawSrcAnchor.x, rawSrcAnchor.y, source.offset)
+	let tgtCoords = applyOffset(rawTgtAnchor.x, rawTgtAnchor.y, target.offset)
+
+	const srcOff = markerOffset.source ?? 5
+	const tgtOff = markerOffset.target ?? 5
+
+	switch (source.position) {
+		case 'right':  srcCoords = { x: srcCoords.x + srcOff, y: srcCoords.y }; break
+		case 'left':   srcCoords = { x: srcCoords.x - srcOff, y: srcCoords.y }; break
+		case 'top':    srcCoords = { x: srcCoords.x, y: srcCoords.y - srcOff }; break
+		case 'bottom': srcCoords = { x: srcCoords.x, y: srcCoords.y + srcOff }; break
+	}
+	switch (target.position) {
+		case 'right':  tgtCoords = { x: tgtCoords.x + tgtOff, y: tgtCoords.y }; break
+		case 'left':   tgtCoords = { x: tgtCoords.x - tgtOff, y: tgtCoords.y }; break
+		case 'top':    tgtCoords = { x: tgtCoords.x, y: tgtCoords.y - tgtOff }; break
+		case 'bottom': tgtCoords = { x: tgtCoords.x, y: tgtCoords.y + tgtOff }; break
+	}
+
+	const { path: svgPath } = computePath(
+		pathType,
+		srcCoords.x, srcCoords.y,
+		tgtCoords.x, tgtCoords.y,
+		source.position, target.position,
+		curvature, borderRadius, bendPoints,
+		worldNodeMap, source.nodeId, target.nodeId,
+		laneIndex, laneCount
+	)
+
+	const strokeColor = isSelected ? focusColor : defaultColor
+	// Size matches SVG markerWidth so the PIXI polygon scales identically.
+	const arrowSize = markerSize
+
+	// Place arrows at the path endpoints (tgtCoords / srcCoords), not at the
+	// raw node-edge anchors. The marker-offset gap is already built into those
+	// coordinates, matching the SVG marker's refX/refY positioning.
+	const arrowEnd: PixiEdgeArrow | null = marker !== 'none'
+		? { x: tgtCoords.x, y: tgtCoords.y, angle: anchorArrowAngle(target.position), size: arrowSize }
+		: null
+
+	const arrowStart: PixiEdgeArrow | null = markerStart && markerStart !== 'none'
+		? { x: srcCoords.x, y: srcCoords.y, angle: anchorArrowAngle(source.position), size: arrowSize }
+		: null
+
+	return {
+		id,
+		svgPath,
+		strokeColor,
+		strokeWidth,
+		isDashed: edgeConfig.lineStyle === 'dashed',
+		arrowEnd,
+		arrowStart,
 	}
 }
 
@@ -1019,6 +1147,7 @@ export class WorkspaceConnectionManager {
 			this.config.edgesLayerEl.replaceChildren()
 			this.connector = null
 			this.lastRenderBoundsKey = null
+			this.config.onPixiEdgesReady?.([])
 			return
 		}
 
@@ -1030,6 +1159,9 @@ export class WorkspaceConnectionManager {
 
 		const offsetX = bounds.left
 		const offsetY = bounds.top
+
+		// World-coordinate node map for PIXI edge rendering (same data without bounds offset)
+		const worldNodeMap = new Map<string, NodeConfig>()
 
 		// Add nodes for anchor computation (hidden by CSS)
 		const railOff = this.config.railOffset ?? 0
@@ -1049,6 +1181,17 @@ export class WorkspaceConnectionManager {
 				className: 'workspace-edge-node'
 			}
 			this.connector.addNode(nodeConfig)
+
+			// World-coordinate version (no bounds offset) for PIXI GPU rendering
+			worldNodeMap.set(n.nodeId, {
+				id: n.nodeId,
+				shape: 'rect',
+				x: n.position.x - xShift,
+				y: n.position.y,
+				width: n.dimensions.width + xShift,
+				height: railH ?? n.dimensions.height,
+				className: 'workspace-edge-node'
+			})
 		}
 
 		// Get current zoom for proportional scaling
@@ -1060,6 +1203,12 @@ export class WorkspaceConnectionManager {
 			webUiSettings.useZoomCompensatedConnectorScaling
 				? getEdgeScaledSizes(zoom)
 				: { strokeWidth: 2, markerSize: 16, markerOffset: { source: 6, target: 19 } }
+
+		// Read CSS connector colors for PIXI rendering (set as CSS custom props on paneEl)
+		const paneStyle = getComputedStyle(this.config.paneEl)
+		const pixiDefaultColor = paneStyle.getPropertyValue('--connector-line-default-color').trim() || '#000000'
+		const pixiFocusColor = paneStyle.getPropertyValue('--connector-line-focus-color').trim() || '#000000'
+		const pixiEdgeData: PixiEdgeRenderDatum[] = []
 
 		// Compute spread-out t values for edges sharing the same node+side
 		// This prevents multiple edges from converging to the exact same point
@@ -1147,6 +1296,16 @@ export class WorkspaceConnectionManager {
 			}
 
 			this.connector.addEdge(edgeConfig)
+
+			// Collect PIXI edge data in world coordinates
+			if (this.config.onPixiEdgesReady) {
+				const pixiDatum = computePixiEdgeDatum(
+					edgeConfig, worldNodeMap, isSelected,
+					pixiDefaultColor, pixiFocusColor,
+					scaledMarkerSize, scaledMarkerOffset
+				)
+				if (pixiDatum) pixiEdgeData.push(pixiDatum)
+			}
 		}
 
 		// Add in-progress edge (new connection or reconnecting existing edge)
@@ -1267,6 +1426,8 @@ export class WorkspaceConnectionManager {
 		}
 
 		this.connector.render()
+
+		this.config.onPixiEdgesReady?.(pixiEdgeData)
 
 		this.attachEdgeInteractionHandlers()
 	}

--- a/services/web-ui/src/infographics/workspace/pixiImageDecodeWorker.ts
+++ b/services/web-ui/src/infographics/workspace/pixiImageDecodeWorker.ts
@@ -1,0 +1,27 @@
+type DecodeImageRequest = {
+    requestId: string
+    url: string
+}
+
+type DecodeImageResponse =
+    | { requestId: string; bitmap: ImageBitmap }
+    | { requestId: string; error: string }
+
+self.onmessage = async (event: MessageEvent<DecodeImageRequest>) => {
+    const { requestId, url } = event.data
+
+    try {
+        const response = await fetch(url, { credentials: 'omit' })
+        if (!response.ok) throw new Error(`Image fetch failed with status ${response.status}`)
+        const blob = await response.blob()
+        const bitmap = await createImageBitmap(blob, { imageOrientation: 'from-image' })
+        const message: DecodeImageResponse = { requestId, bitmap }
+        ;(self as any).postMessage(message, [bitmap])
+    } catch (error) {
+        const message: DecodeImageResponse = {
+            requestId,
+            error: error instanceof Error ? error.message : String(error),
+        }
+        ;(self as any).postMessage(message)
+    }
+}

--- a/services/web-ui/src/infographics/workspace/pixiImageDecoder.ts
+++ b/services/web-ui/src/infographics/workspace/pixiImageDecoder.ts
@@ -1,3 +1,9 @@
+// How many workers to run in parallel. Six matches the typical browser
+// per-origin connection limit so every available TCP slot is used for
+// image fetching while multiple CPU cores handle the decode step in
+// parallel (createImageBitmap is CPU-bound).
+const POOL_SIZE = 6
+
 type DecodeImageResponse =
     | { requestId: string; bitmap: ImageBitmap }
     | { requestId: string; error: string }
@@ -5,56 +11,74 @@ type DecodeImageResponse =
 type PendingDecode = {
     resolve: (bitmap: ImageBitmap) => void
     reject: (error: Error) => void
+    // Which worker owns this request — lets crash handler only reject
+    // work assigned to the dead worker, leaving other workers unaffected.
+    worker: Worker
 }
 
-let worker: Worker | null = null
+let pool: Worker[] = []
+let robinCursor = 0
 let requestCounter = 0
 const pending = new Map<string, PendingDecode>()
 
-function getWorker(): Worker {
-    if (worker) return worker
+function spawnWorker(): Worker {
+    const w = new Worker(new URL('./pixiImageDecodeWorker.ts', import.meta.url), { type: 'module' })
 
-    const nextWorker = new Worker(new URL('./pixiImageDecodeWorker.ts', import.meta.url), { type: 'module' })
-    worker = nextWorker
-    nextWorker.onmessage = (event: MessageEvent<DecodeImageResponse>) => {
-        const data = event.data
+    w.onmessage = (event: MessageEvent<DecodeImageResponse>) => {
+        const { data } = event
         const entry = pending.get(data.requestId)
         if (!entry) return
         pending.delete(data.requestId)
-
         if ('error' in data) {
             entry.reject(new Error(data.error))
         } else {
             entry.resolve(data.bitmap)
         }
     }
-    nextWorker.onerror = () => {
-        for (const [, entry] of pending) {
+
+    w.onerror = () => {
+        // Only reject work that was dispatched to THIS worker so that the
+        // remaining pool members can finish their own in-flight requests.
+        for (const [id, entry] of pending) {
+            if (entry.worker !== w) continue
             entry.reject(new Error('PIXI image decode worker crashed'))
+            pending.delete(id)
         }
-        pending.clear()
-        nextWorker.terminate()
-        if (worker === nextWorker) {
-            worker = null
-        }
+        const idx = pool.indexOf(w)
+        if (idx !== -1) pool.splice(idx, 1)
+        w.terminate()
     }
 
-    return nextWorker
+    return w
+}
+
+function nextWorker(): Worker {
+    // Lazily grow the pool up to POOL_SIZE on demand so cold-start pays
+    // no cost when only a few images are on screen.
+    if (pool.length < POOL_SIZE) {
+        const w = spawnWorker()
+        pool.push(w)
+        return w
+    }
+    // Round-robin across the live pool.
+    const w = pool[robinCursor % pool.length]
+    robinCursor = (robinCursor + 1) % pool.length
+    return w
 }
 
 export function decodeImageInWorker(url: string): Promise<ImageBitmap> {
     const requestId = `pixi-img-${++requestCounter}`
-    const decodeWorker = getWorker()
-
+    const worker = nextWorker()
     return new Promise<ImageBitmap>((resolve, reject) => {
-        pending.set(requestId, { resolve, reject })
-        decodeWorker.postMessage({ requestId, url })
+        pending.set(requestId, { resolve, reject, worker })
+        worker.postMessage({ requestId, url })
     })
 }
 
 export function destroyPixiImageDecoder(): void {
-    worker?.terminate()
-    worker = null
+    for (const w of pool) w.terminate()
+    pool = []
+    robinCursor = 0
     for (const [, entry] of pending) {
         entry.reject(new Error('PIXI image decoder destroyed'))
     }

--- a/services/web-ui/src/infographics/workspace/pixiImageDecoder.ts
+++ b/services/web-ui/src/infographics/workspace/pixiImageDecoder.ts
@@ -1,0 +1,62 @@
+type DecodeImageResponse =
+    | { requestId: string; bitmap: ImageBitmap }
+    | { requestId: string; error: string }
+
+type PendingDecode = {
+    resolve: (bitmap: ImageBitmap) => void
+    reject: (error: Error) => void
+}
+
+let worker: Worker | null = null
+let requestCounter = 0
+const pending = new Map<string, PendingDecode>()
+
+function getWorker(): Worker {
+    if (worker) return worker
+
+    const nextWorker = new Worker(new URL('./pixiImageDecodeWorker.ts', import.meta.url), { type: 'module' })
+    worker = nextWorker
+    nextWorker.onmessage = (event: MessageEvent<DecodeImageResponse>) => {
+        const data = event.data
+        const entry = pending.get(data.requestId)
+        if (!entry) return
+        pending.delete(data.requestId)
+
+        if ('error' in data) {
+            entry.reject(new Error(data.error))
+        } else {
+            entry.resolve(data.bitmap)
+        }
+    }
+    nextWorker.onerror = () => {
+        for (const [, entry] of pending) {
+            entry.reject(new Error('PIXI image decode worker crashed'))
+        }
+        pending.clear()
+        nextWorker.terminate()
+        if (worker === nextWorker) {
+            worker = null
+        }
+    }
+
+    return nextWorker
+}
+
+export function decodeImageInWorker(url: string): Promise<ImageBitmap> {
+    const requestId = `pixi-img-${++requestCounter}`
+    const decodeWorker = getWorker()
+
+    return new Promise<ImageBitmap>((resolve, reject) => {
+        pending.set(requestId, { resolve, reject })
+        decodeWorker.postMessage({ requestId, url })
+    })
+}
+
+export function destroyPixiImageDecoder(): void {
+    worker?.terminate()
+    worker = null
+    for (const [, entry] of pending) {
+        entry.reject(new Error('PIXI image decoder destroyed'))
+    }
+    pending.clear()
+}

--- a/services/web-ui/src/infographics/workspace/pixiMediaLayer.ts
+++ b/services/web-ui/src/infographics/workspace/pixiMediaLayer.ts
@@ -181,6 +181,17 @@ export function createPixiMediaLayer(options: PixiMediaLayerOptions): PixiMediaL
         syncDomOwnership(canvasState)
         if (!canvasState || health !== 'ready' || destroyed) return
 
+        // On workspace switch the external setViewport call arrives after sync.
+        // Apply the state's viewport directly so culling and world transform are
+        // correct before any sprites are positioned or made renderable.
+        const vp = canvasState.viewport
+        if (vp.x !== currentViewport.x || vp.y !== currentViewport.y || vp.zoom !== currentViewport.zoom) {
+            currentViewport = vp
+            currentTier = getPixiLodTier(vp.zoom)
+            world.position.set(vp.x, vp.y)
+            world.scale.set(vp.zoom, vp.zoom)
+        }
+
         const imageNodes = canvasState.nodes.filter((node: CanvasState['nodes'][number]): node is ImageCanvasNode => node.type === 'image')
         const activeIds = new Set<string>(imageNodes.map((node: ImageCanvasNode) => node.nodeId))
 

--- a/services/web-ui/src/infographics/workspace/pixiMediaLayer.ts
+++ b/services/web-ui/src/infographics/workspace/pixiMediaLayer.ts
@@ -24,6 +24,7 @@ import {
     getVisibleWorldRect,
     makeIndexedImage,
     resolveStoredImagePath,
+    tierRank,
     type IndexedImage,
     type LodTier,
     type PixiEdgeRenderDatum,
@@ -35,10 +36,21 @@ import { createPixiEdgeRenderer, type PixiEdgeRenderer } from '$src/infographics
 type PixiImageEntry = {
     sprite: Sprite
     colorRect: Graphics
-    srcKey: string
+    nodeRef: ImageCanvasNode
+    // Identity of the SOURCE image (workspace + fileId + src). When this
+    // changes (e.g. user replaces the image), all loaded state is reset.
+    sourceKey: string
+    // Tier of the texture currently rendered on the sprite. `null` means no
+    // texture has been loaded yet — the color placeholder is shown.
+    loadedTier: LodTier | null
+    // Tier of the in-flight texture request, or `null` when idle.
+    requestedTier: LodTier | null
+    // Bumped on every new request so stale completions can be ignored.
     requestId: number
+    // URL of the texture currently bound to the sprite, or `null` when none.
     textureKey: string | null
     worldRect: IndexedImage
+    isVisible: boolean
 }
 
 type TextureEntry = {
@@ -68,6 +80,7 @@ export type PixiMediaLayer = {
     setMarqueeRect: (worldRect: { x: number; y: number; width: number; height: number } | null) => void
     setSelectionOverlayBounds: (worldBounds: { x: number; y: number; width: number; height: number } | null) => void
     setPixiEdges: (edges: PixiEdgeRenderDatum[]) => void
+    getHealth: () => PixiRendererHealth
     destroy: () => void
 }
 
@@ -76,27 +89,68 @@ type PixiMediaLayerOptions = {
     viewportEl: HTMLDivElement
     getWorkspaceId: () => string
     selectionColors: SelectionColors
+    onHealthChange?: (health: PixiRendererHealth) => void
 }
 
-const CULLING_MARGIN = 800
-const MAX_TEXTURES = 256
-const MAX_TEXTURE_BYTES = 512 * 1024 * 1024
+// Margin in *world* coordinates beyond the viewport rect. Sprites whose
+// bounding box intersects this expanded rect are considered visible (and
+// therefore eligible for texture loading). Larger values trade memory for
+// pan smoothness — a sprite that just scrolled into view still has its
+// texture ready, no progressive flash.
+const VISIBILITY_MARGIN = 1200
+
+// Idle-time prefetch margin: how far past the visibility margin we
+// pre-load thumb-256 textures during idle frames. This makes pan around
+// the canvas instant after the first idle slot.
+const PREFETCH_MARGIN = 4000
+
+// Cache limits. The PIXI v8 architecture is mipmap-aware so a single
+// well-cached `full` texture serves *all* zoom levels for that sprite.
+// We therefore cache aggressively: 2k textures @ ~768MB worst case.
+const MAX_TEXTURES = 2000
+const MAX_TEXTURE_BYTES = 768 * 1024 * 1024
+
+// Schedule a low-priority callback. requestIdleCallback is the right tool;
+// fall back to setTimeout on browsers that lack it (Safari before ~16.4).
+const scheduleIdle: (cb: () => void, timeout?: number) => void = (() => {
+    if (typeof window !== 'undefined' && typeof (window as any).requestIdleCallback === 'function') {
+        return (cb, timeout = 1500) => {
+            ;(window as any).requestIdleCallback(cb, { timeout })
+        }
+    }
+    return (cb, timeout = 250) => {
+        window.setTimeout(cb, Math.min(timeout, 250))
+    }
+})()
+
+// Single shared token promise. Re-used by all concurrent `resolveImageSrc`
+// calls in a given tick so 200 in-flight image loads don't each invoke
+// `getTokenSilently` independently — one auth round-trip serves all of them.
+// Cleared after 30 s so the next batch always gets a fresh token.
+let tokenPromise: Promise<string | false> | null = null
+let tokenPromiseTimer: ReturnType<typeof setTimeout> | null = null
+
+function getSharedToken(): Promise<string | false> {
+    if (!tokenPromise) {
+        tokenPromise = AuthService.getTokenSilently().catch(() => false as const)
+        if (tokenPromiseTimer !== null) clearTimeout(tokenPromiseTimer)
+        tokenPromiseTimer = setTimeout(() => {
+            tokenPromise = null
+            tokenPromiseTimer = null
+        }, 30_000)
+    }
+    return tokenPromise
+}
 
 async function resolveImageSrc(node: ImageCanvasNode, workspaceId: string): Promise<string> {
     const API_BASE_URL = import.meta.env.VITE_API_URL || ''
     const resolvedSrc = resolveStoredImagePath(node, workspaceId)
-    const token = await AuthService.getTokenSilently()
-    return buildPixiImageSrc(resolvedSrc, API_BASE_URL, token || false)
-}
-
-function setPixiOwned(viewportEl: HTMLDivElement, nodeId: string, owned: boolean): void {
-    const nodeEl = viewportEl.querySelector(`[data-node-id="${nodeId}"]`) as HTMLElement | null
-    if (!nodeEl) return
-    nodeEl.classList.toggle('workspace-image-node--pixi-owned', owned)
+    const token = await getSharedToken()
+    return buildPixiImageSrc(resolvedSrc, API_BASE_URL, token)
 }
 
 export function createPixiMediaLayer(options: PixiMediaLayerOptions): PixiMediaLayer {
-    const { paneEl, viewportEl, getWorkspaceId, selectionColors } = options
+    const { paneEl, viewportEl, getWorkspaceId, selectionColors, onHealthChange } = options
 
     const hostStyle = {
         position: 'absolute' as const,
@@ -118,6 +172,10 @@ export function createPixiMediaLayer(options: PixiMediaLayerOptions): PixiMediaL
     const textureCache = new Map<string, TextureEntry>()
     const spatialIndex = new RBush<IndexedImage>()
     const pixiOwnedNodeIds = new Set<string>()
+    // Cached element refs keyed by nodeId. A single querySelectorAll on every
+    // sync is dramatically cheaper than per-node querySelector(`[data-node-id]`)
+    // calls during upsert.
+    const nodeElCache = new Map<string, HTMLElement>()
     let textureBytes = 0
     let textureClock = 0
     let destroyed = false
@@ -128,6 +186,15 @@ export function createPixiMediaLayer(options: PixiMediaLayerOptions): PixiMediaL
     let requestCounter = 0
     let currentViewport: CanvasViewport = { x: 0, y: 0, zoom: 1 }
     let currentTier: LodTier = getPixiLodTier(currentViewport.zoom)
+    let renderRaf: number | null = null
+    let visibilityRaf: number | null = null
+    let prefetchScheduled = false
+
+    function setHealth(next: PixiRendererHealth): void {
+        if (health === next) return
+        health = next
+        onHealthChange?.(next)
+    }
 
     void (async () => {
         try {
@@ -138,6 +205,12 @@ export function createPixiMediaLayer(options: PixiMediaLayerOptions): PixiMediaL
                 autoDensity: true,
                 resolution: Math.min(window.devicePixelRatio || 1, 2),
                 resizeTo: paneEl,
+                // We render on demand via `scheduleRender`. Letting PIXI's
+                // ticker run autoStart at 60fps wastes CPU/GPU on every frame
+                // even when the canvas is idle, and also doubles the work
+                // when call sites also invoke `app.render()` synchronously.
+                autoStart: false,
+                sharedTicker: false,
                 webgpu: {
                     antialias: true,
                     powerPreference: 'high-performance',
@@ -147,6 +220,9 @@ export function createPixiMediaLayer(options: PixiMediaLayerOptions): PixiMediaL
                     powerPreference: 'high-performance',
                 },
             })
+
+            // Keep the ticker stopped so it never auto-renders behind our backs.
+            app.ticker.stop()
 
             if (destroyed) {
                 app.destroy(true, { children: true, texture: true, textureSource: true })
@@ -169,12 +245,12 @@ export function createPixiMediaLayer(options: PixiMediaLayerOptions): PixiMediaL
             })
             world.position.set(currentViewport.x, currentViewport.y)
             world.scale.set(currentViewport.zoom, currentViewport.zoom)
-            health = 'ready'
+            setHealth('ready')
             sync(lastState)
-            renderNow()
+            scheduleRender()
         } catch (error) {
             console.error('[PixiMediaLayer] Failed to initialize PIXI media layer.', error)
-            health = 'failed'
+            setHealth('failed')
             releaseAllDomOwnership()
         }
     })()
@@ -182,29 +258,61 @@ export function createPixiMediaLayer(options: PixiMediaLayerOptions): PixiMediaL
     function setViewport(viewport: CanvasViewport): void {
         if (destroyed) return
         currentViewport = viewport
-        const nextTier = getPixiLodTier(viewport.zoom)
-        const tierChanged = nextTier !== currentTier
-        currentTier = nextTier
+        // Tier is recomputed on every viewport change so newly visible
+        // sprites get the right tier on demand. Sprites that already have a
+        // higher-or-equal tier loaded are NEVER re-fetched (mipmaps in the
+        // PIXI texture handle GPU-side downsampling for free).
+        currentTier = getPixiLodTier(viewport.zoom)
         world.position.set(viewport.x, viewport.y)
         world.scale.set(viewport.zoom, viewport.zoom)
-        if (tierChanged && lastState && health === 'ready') {
-            upsertAllImages(lastState)
-        }
-        updateVisibleImages()
-        renderNow()
+        // Visibility update is rAF-coalesced so a 60Hz wheel-zoom doesn't
+        // run the spatial-index scan + per-entry iteration 60 times per
+        // second — once per frame is enough.
+        scheduleVisibilityUpdate()
+        schedulePrefetch()
+        scheduleRender()
     }
 
-    function upsertAllImages(canvasState: CanvasState): void {
-        spatialIndex.clear()
-        const nodesById = buildNodesById(canvasState.nodes)
-        const imageNodes = canvasState.nodes.filter((node: CanvasState['nodes'][number]): node is ImageCanvasNode => node.type === 'image')
-        for (const node of imageNodes) {
-            upsertImage(node, computeWorldPosition(node, nodesById))
+    function scheduleVisibilityUpdate(): void {
+        if (destroyed || visibilityRaf !== null) return
+        visibilityRaf = requestAnimationFrame(() => {
+            visibilityRaf = null
+            if (destroyed) return
+            updateVisibleImages()
+        })
+    }
+
+    function refreshNodeElCache(): void {
+        nodeElCache.clear()
+        const all = viewportEl.querySelectorAll<HTMLElement>('[data-node-id]')
+        for (const el of all) {
+            const id = el.dataset.nodeId
+            if (id) nodeElCache.set(id, el)
         }
+    }
+
+    function getNodeEl(nodeId: string): HTMLElement | null {
+        const cached = nodeElCache.get(nodeId)
+        if (cached && cached.isConnected) return cached
+        // Fall back to a one-shot query if the cache is stale (e.g. a node
+        // was just appended after the most recent sync).
+        const el = viewportEl.querySelector(`[data-node-id="${nodeId}"]`) as HTMLElement | null
+        if (el) nodeElCache.set(nodeId, el)
+        return el
+    }
+
+    function setPixiOwnedClass(nodeId: string, owned: boolean): void {
+        const el = getNodeEl(nodeId)
+        if (!el) return
+        el.classList.toggle('workspace-image-node--pixi-owned', owned)
     }
 
     function sync(canvasState: CanvasState | null): void {
         lastState = canvasState
+        // Refresh DOM element cache once per sync. All subsequent per-node
+        // calls (setDomOwnership, etc.) read from the cache rather than
+        // querying the DOM.
+        refreshNodeElCache()
         syncDomOwnership(canvasState)
         if (!canvasState || health !== 'ready' || destroyed) return
 
@@ -234,21 +342,37 @@ export function createPixiMediaLayer(options: PixiMediaLayerOptions): PixiMediaL
             }
         }
 
-        upsertAllImages(canvasState)
+        upsertAllEntries(canvasState)
+        // Single visibility pass loads textures for visible entries only.
         updateVisibleImages()
-        renderNow()
+        schedulePrefetch()
+        scheduleRender()
     }
 
-    function renderNow(): void {
-        if (health !== 'ready' || destroyed) return
-        app.render()
+    function upsertAllEntries(canvasState: CanvasState): void {
+        spatialIndex.clear()
+        const nodesById = buildNodesById(canvasState.nodes)
+        const imageNodes = canvasState.nodes.filter(
+            (node: CanvasState['nodes'][number]): node is ImageCanvasNode => node.type === 'image'
+        )
+        for (const node of imageNodes) {
+            upsertEntry(node, computeWorldPosition(node, nodesById))
+        }
+    }
+
+    function scheduleRender(): void {
+        if (destroyed || health !== 'ready') return
+        if (renderRaf !== null) return
+        renderRaf = requestAnimationFrame(() => {
+            renderRaf = null
+            if (destroyed || health !== 'ready') return
+            app.render()
+        })
     }
 
     // Live drag/resize updates push the new world position straight to the
     // sprite without going through `sync`, so the PIXI pixels stay locked
-    // to the DOM hitbox during interaction. Once the gesture commits and
-    // `sync` runs with the final canvas state, the sprite is re-positioned
-    // from the same source of truth as the DOM.
+    // to the DOM hitbox during interaction.
     function setNodeLiveTransform(
         nodeId: string,
         worldPosition: WorldPosition,
@@ -275,8 +399,7 @@ export function createPixiMediaLayer(options: PixiMediaLayerOptions): PixiMediaL
         entry.worldRect = newRect
         spatialIndex.insert(newRect)
 
-        updateVisibleImages()
-        renderNow()
+        scheduleRender()
     }
 
     function syncDomOwnership(canvasState: CanvasState | null): void {
@@ -298,7 +421,7 @@ export function createPixiMediaLayer(options: PixiMediaLayerOptions): PixiMediaL
     }
 
     function setDomOwnership(nodeId: string, owned: boolean): void {
-        setPixiOwned(viewportEl, nodeId, owned)
+        setPixiOwnedClass(nodeId, owned)
         if (owned) {
             pixiOwnedNodeIds.add(nodeId)
         } else {
@@ -308,13 +431,18 @@ export function createPixiMediaLayer(options: PixiMediaLayerOptions): PixiMediaL
 
     function releaseAllDomOwnership(): void {
         for (const nodeId of pixiOwnedNodeIds) {
-            setPixiOwned(viewportEl, nodeId, false)
+            setPixiOwnedClass(nodeId, false)
         }
         pixiOwnedNodeIds.clear()
     }
 
-    function upsertImage(node: ImageCanvasNode, worldPosition: WorldPosition): void {
+    function makeSourceKey(node: ImageCanvasNode): string {
+        return `${getWorkspaceId()}|${node.fileId}|${node.src}`
+    }
+
+    function upsertEntry(node: ImageCanvasNode, worldPosition: WorldPosition): void {
         let entry = entries.get(node.nodeId)
+        const newSourceKey = makeSourceKey(node)
         if (!entry) {
             const sprite = new Sprite(Texture.EMPTY)
             sprite.label = `pixi-image-${node.nodeId}`
@@ -328,14 +456,29 @@ export function createPixiMediaLayer(options: PixiMediaLayerOptions): PixiMediaL
             entry = {
                 sprite,
                 colorRect,
-                srcKey: '',
+                nodeRef: node,
+                sourceKey: newSourceKey,
+                loadedTier: null,
+                requestedTier: null,
                 requestId: 0,
                 textureKey: null,
                 worldRect: makeIndexedImage(node, worldPosition),
+                isVisible: false,
             }
             entries.set(node.nodeId, entry)
+        } else if (entry.sourceKey !== newSourceKey) {
+            // Source image changed (e.g. replaced via "replace image"). Drop
+            // any loaded state so the next visibility pass refetches.
+            if (entry.textureKey) releaseTexture(entry.textureKey)
+            entry.textureKey = null
+            entry.loadedTier = null
+            entry.requestedTier = null
+            entry.requestId++
+            entry.sprite.texture = Texture.EMPTY
+            entry.sourceKey = newSourceKey
         }
 
+        entry.nodeRef = node
         entry.sprite.position.set(worldPosition.x, worldPosition.y)
         entry.sprite.width = node.dimensions.width
         entry.sprite.height = node.dimensions.height
@@ -344,60 +487,140 @@ export function createPixiMediaLayer(options: PixiMediaLayerOptions): PixiMediaL
         entry.worldRect = makeIndexedImage(node, worldPosition)
         spatialIndex.insert(entry.worldRect)
         setDomOwnership(node.nodeId, true)
-
-        const tier = currentTier
-        if (tier === 'color') {
-            entry.sprite.visible = false
-            entry.colorRect.visible = true
-            releaseTexture(entry.textureKey)
-            entry.textureKey = null
-            return
-        }
-
-        const srcKey = `${getWorkspaceId()}|${node.fileId}|${node.src}|${tier}`
-        if (entry.srcKey === srcKey) return
-
-        entry.srcKey = srcKey
-        entry.requestId = ++requestCounter
-        const requestId = entry.requestId
-
-        // Keep the existing texture (if any) visible while the new tier loads.
-        // Only show the color placeholder when no texture has been resolved yet.
-        const hasExistingTexture = entry.textureKey !== null
-        entry.sprite.visible = hasExistingTexture
-        entry.colorRect.visible = !hasExistingTexture
-
-        void (async () => {
-            try {
-                const resolved = addPixiLodSizeParam(await resolveImageSrc(node, getWorkspaceId()), tier)
-                const texture = await acquireTexture(resolved)
-                if (destroyed || entry?.requestId !== requestId) return
-                releaseTexture(entry.textureKey)
-                entry.textureKey = resolved
-                entry.sprite.texture = texture
-                entry.sprite.width = node.dimensions.width
-                entry.sprite.height = node.dimensions.height
-                entry.sprite.visible = true
-                entry.colorRect.visible = false
-                renderNow()
-            } catch (error) {
-                console.error('[PixiMediaLayer] Failed to load image texture.', error)
-                if (entry?.requestId === requestId) {
-                    entry.srcKey = ''
-                    if (!hasExistingTexture) {
-                        entry.sprite.visible = false
-                        entry.colorRect.visible = true
-                    }
-                    renderNow()
-                }
-            }
-        })()
+        // IMPORTANT: do NOT trigger texture loading here. Texture loading is
+        // driven by visibility (see `updateVisibleImages` / `ensureTextureForEntry`)
+        // so that a workspace with hundreds of images doesn't spawn hundreds of
+        // concurrent fetches on initial open or on viewport changes.
     }
 
     function drawColorRect(rect: Graphics, width: number, height: number): void {
         rect.clear()
         rect.roundRect(0, 0, width, height, 4)
         rect.fill({ color: 0xe7eaee, alpha: 0.85 })
+    }
+
+    // Idempotent texture-quality guarantor. Ensures the entry has at least
+    // `desiredTier`-quality pixels loaded. Three cardinal rules:
+    //   1) If a higher-or-equal tier is already on the sprite, do NOTHING —
+    //      mipmaps handle GPU downsampling, so a `full` texture renders fine
+    //      at any zoom and re-fetching `thumb-256` would be pure waste.
+    //   2) If a higher-or-equal tier is already in-flight, do NOTHING.
+    //   3) If we have nothing yet AND the desired tier is bigger than 256px,
+    //      progressively load `thumb-256` first for instant visual feedback,
+    //      then schedule a background upgrade to the desired tier in idle time.
+    function ensureTextureForEntry(entry: PixiImageEntry, desiredTier: LodTier): void {
+        if (desiredTier === 'color') {
+            // Extreme zoom-out: tinted rectangle suffices. Keep any existing
+            // texture cached on the sprite for when the user zooms back in.
+            entry.sprite.visible = entry.loadedTier !== null
+            entry.colorRect.visible = entry.loadedTier === null
+            return
+        }
+
+        // Rule 1: never downgrade. Mipmaps make a full-res texture render
+        // perfectly at any zoom; refetching a smaller LoD is pure waste and
+        // is exactly what made zoom-out feel sluggish.
+        if (entry.loadedTier !== null && tierRank(entry.loadedTier) >= tierRank(desiredTier)) {
+            entry.sprite.visible = true
+            entry.colorRect.visible = false
+            return
+        }
+
+        // Rule 2: a request is already in flight.
+        if (entry.requestedTier !== null) {
+            if (tierRank(entry.requestedTier) >= tierRank(desiredTier)) {
+                // In-flight request already covers our needs.
+                return
+            }
+            // In-flight is a lower tier (typically the progressive thumb-256
+            // first step). Don't race the network with a duplicate fetch —
+            // schedule an idle upgrade and let the in-flight one finish.
+            scheduleProgressiveUpgrade(entry, desiredTier)
+            return
+        }
+
+        // Rule 3: progressive `thumb-256`-first when we have nothing yet.
+        // 256px PNGs are tiny (~10–30KB) so the entire workspace can paint a
+        // recognizable preview in well under a second, then upgrade in idle
+        // time. This is the single most impactful change for first-paint.
+        const fetchTier: LodTier = (entry.loadedTier === null && desiredTier !== 'thumb-256')
+            ? 'thumb-256'
+            : desiredTier
+
+        entry.requestedTier = fetchTier
+        entry.requestId = ++requestCounter
+        const requestId = entry.requestId
+
+        const hasTexture = entry.textureKey !== null
+        if (!hasTexture) {
+            entry.sprite.visible = false
+            entry.colorRect.visible = true
+        }
+
+        const node = entry.nodeRef
+
+        void (async () => {
+            let acquiredKey: string | null = null
+            try {
+                const url = await resolveImageSrc(node, getWorkspaceId())
+                const resolved = addPixiLodSizeParam(url, fetchTier)
+                const texture = await acquireTexture(resolved)
+                acquiredKey = resolved
+                if (destroyed || entry.requestId !== requestId) {
+                    releaseTexture(resolved)
+                    return
+                }
+                // Don't downgrade if a parallel request already loaded a higher tier.
+                if (entry.loadedTier !== null && tierRank(entry.loadedTier) > tierRank(fetchTier)) {
+                    releaseTexture(resolved)
+                    entry.requestedTier = null
+                    return
+                }
+                const oldKey = entry.textureKey
+                entry.textureKey = resolved
+                entry.loadedTier = fetchTier
+                entry.requestedTier = null
+                entry.sprite.texture = texture
+                entry.sprite.width = node.dimensions.width
+                entry.sprite.height = node.dimensions.height
+                entry.sprite.visible = true
+                entry.colorRect.visible = false
+                if (oldKey && oldKey !== resolved) releaseTexture(oldKey)
+                scheduleRender()
+
+                // If the user actually wants a higher tier than we just loaded,
+                // schedule a background upgrade in an idle slot. The user sees
+                // the preview now and gets sharper pixels later, with no
+                // blocking on the critical path.
+                if (tierRank(desiredTier) > tierRank(fetchTier)) {
+                    scheduleProgressiveUpgrade(entry, desiredTier)
+                }
+            } catch (error) {
+                console.error('[PixiMediaLayer] Failed to load image texture.', error)
+                if (acquiredKey) releaseTexture(acquiredKey)
+                if (entry.requestId === requestId) {
+                    entry.requestedTier = null
+                    if (!hasTexture) {
+                        entry.sprite.visible = false
+                        entry.colorRect.visible = true
+                    }
+                    scheduleRender()
+                }
+            }
+        })()
+    }
+
+    function scheduleProgressiveUpgrade(entry: PixiImageEntry, targetTier: LodTier): void {
+        if (destroyed) return
+        scheduleIdle(() => {
+            if (destroyed) return
+            // Skip if entry is no longer visible OR already has equal/better tier
+            // OR another request has already taken over.
+            if (!entry.isVisible) return
+            if (entry.loadedTier !== null && tierRank(entry.loadedTier) >= tierRank(targetTier)) return
+            if (entry.requestedTier !== null && tierRank(entry.requestedTier) >= tierRank(targetTier)) return
+            ensureTextureForEntry(entry, targetTier)
+        }, 2000)
     }
 
     async function acquireTexture(url: string): Promise<Texture> {
@@ -410,6 +633,21 @@ export function createPixiMediaLayer(options: PixiMediaLayerOptions): PixiMediaL
 
         const bitmap = await decodeImageInWorker(url)
         const texture = Texture.from(bitmap)
+
+        // CRITICAL for zoom-out performance. Without mipmaps, every zoomed-out
+        // sprite forces the GPU to sample from the full-resolution texture for
+        // each output pixel. At zoom 0.1×, rendering a 1024-px texture as a
+        // ~10-px sprite means the GPU's texture cache must service the full
+        // 1 MB texel footprint for 100 pixels of output — catastrophic with
+        // hundreds of images visible simultaneously. With mipmaps the GPU
+        // selects the pre-computed 8×8 or 16×16 MIP level and the cache
+        // pressure drops by 3–4 orders of magnitude.
+        //
+        // We set the flag before the first GPU upload (which happens lazily on
+        // the next `app.render()` call) so PIXI generates the MIP chain during
+        // the initial upload at no extra cost.
+        texture.source.autoGenerateMipmaps = true
+
         const bytes = Math.max(1, bitmap.width) * Math.max(1, bitmap.height) * 4
         textureCache.set(url, {
             texture,
@@ -432,34 +670,128 @@ export function createPixiMediaLayer(options: PixiMediaLayerOptions): PixiMediaL
     function evictTextures(): void {
         if (textureCache.size <= MAX_TEXTURES && textureBytes <= MAX_TEXTURE_BYTES) return
 
-        const candidates = Array.from(textureCache.entries())
+        // First pass: evict textures with no live references (already
+        // detached or never bound). LRU within that pool.
+        const idleCandidates = Array.from(textureCache.entries())
             .filter(([, entry]) => entry.refCount === 0)
             .sort((a, b) => a[1].lastUsed - b[1].lastUsed)
 
-        for (const [key, entry] of candidates) {
+        for (const [key, entry] of idleCandidates) {
             if (textureCache.size <= MAX_TEXTURES && textureBytes <= MAX_TEXTURE_BYTES) break
             textureCache.delete(key)
             textureBytes -= entry.bytes
             entry.texture.destroy(true)
         }
+
+        if (textureCache.size <= MAX_TEXTURES && textureBytes <= MAX_TEXTURE_BYTES) return
+
+        // Second pass: under genuine memory pressure, detach textures from
+        // *non-visible* sprites (LRU first) so their cache slot can be
+        // reclaimed. The sprite reverts to its color placeholder; when the
+        // user pans/zooms it back into the viewport, `updateVisibleImages`
+        // re-fetches the right tier on demand.
+        //
+        // Visible sprites are NEVER evicted from under the user — that
+        // would cause flashing during zoom/pan.
+        const offscreen = Array.from(entries.values())
+            .filter((e) => !e.isVisible && e.textureKey !== null)
+            .sort((a, b) => {
+                const ta = textureCache.get(a.textureKey!)?.lastUsed ?? 0
+                const tb = textureCache.get(b.textureKey!)?.lastUsed ?? 0
+                return ta - tb
+            })
+
+        for (const e of offscreen) {
+            if (textureCache.size <= MAX_TEXTURES && textureBytes <= MAX_TEXTURE_BYTES) break
+            const key = e.textureKey
+            if (!key) continue
+            e.sprite.texture = Texture.EMPTY
+            e.textureKey = null
+            e.loadedTier = null
+            const cached = textureCache.get(key)
+            if (cached) {
+                cached.refCount = Math.max(0, cached.refCount - 1)
+                if (cached.refCount === 0) {
+                    textureCache.delete(key)
+                    textureBytes -= cached.bytes
+                    cached.texture.destroy(true)
+                }
+            }
+        }
     }
 
+    // Drive sprite renderable flags + texture loading from spatial-index
+    // visibility. Visible entries fetch on demand; non-visible entries keep
+    // any cached texture they have. This is the hot path during pan/zoom so
+    // it is intentionally lean: spatial index search + map iteration only.
     function updateVisibleImages(): void {
-        if (health !== 'ready' || !lastState) return
+        if (health !== 'ready' || !lastState || destroyed) return
         const visibleRect = getVisibleWorldRect(
             currentViewport,
             { width: paneEl.clientWidth, height: paneEl.clientHeight },
-            CULLING_MARGIN
+            VISIBILITY_MARGIN
         )
-        const visible = new Set(
+        const visibleNodeIds = new Set(
             spatialIndex.search(visibleRect).map((item: IndexedImage) => item.nodeId)
         )
 
+        const tier = currentTier
         for (const [nodeId, entry] of entries) {
-            const isVisible = visible.has(nodeId)
-            entry.sprite.renderable = isVisible
-            entry.colorRect.renderable = isVisible
+            const isVisible = visibleNodeIds.has(nodeId)
+            if (isVisible !== entry.isVisible) {
+                entry.sprite.renderable = isVisible
+                entry.colorRect.renderable = isVisible
+                entry.isVisible = isVisible
+            }
+            // Only fetch/upload textures for sprites that are actually on
+            // screen. Non-visible entries that may have a stale tier will
+            // refresh lazily once they enter the viewport.
+            if (isVisible) {
+                ensureTextureForEntry(entry, tier)
+            }
         }
+    }
+
+    // Idle-time prefetch — cache `thumb-256` for the entire workspace,
+    // prioritized by world-distance from the viewport center so the user's
+    // current focus area finishes first.
+    //
+    // 256-px PNGs are tiny (~10–30 KB each) so even a 5k-image workspace
+    // fits comfortably within the texture-cache budget. The payoff is huge:
+    // every subsequent zoom-out / pan reveals images that already have a
+    // texture on the GPU, eliminating the load-flash that made the canvas
+    // feel "absolutely atrocious" before.
+    //
+    // Visibility-driven loading still runs synchronously inside
+    // `updateVisibleImages` so the user's actual focus area never waits
+    // behind prefetch in the worker queue.
+    function schedulePrefetch(): void {
+        if (destroyed || health !== 'ready' || prefetchScheduled) return
+        prefetchScheduled = true
+        scheduleIdle(() => {
+            prefetchScheduled = false
+            if (destroyed || health !== 'ready' || !lastState) return
+
+            // Center of the current viewport in world coordinates — used to
+            // sort the prefetch order. Sprites near the user's focus get
+            // cached first; far ones later.
+            const cx = (-currentViewport.x + paneEl.clientWidth / 2) / (currentViewport.zoom || 1)
+            const cy = (-currentViewport.y + paneEl.clientHeight / 2) / (currentViewport.zoom || 1)
+
+            const candidates: { entry: PixiImageEntry; d2: number }[] = []
+            for (const [, entry] of entries) {
+                if (entry.loadedTier !== null || entry.requestedTier !== null) continue
+                const ex = (entry.worldRect.minX + entry.worldRect.maxX) * 0.5
+                const ey = (entry.worldRect.minY + entry.worldRect.maxY) * 0.5
+                const dx = ex - cx
+                const dy = ey - cy
+                candidates.push({ entry, d2: dx * dx + dy * dy })
+            }
+            candidates.sort((a, b) => a.d2 - b.d2)
+            for (const { entry } of candidates) {
+                ensureTextureForEntry(entry, 'thumb-256')
+            }
+        }, 1500)
     }
 
     function setSelectedImageNodes(selectedNodeIds: Set<string>): void {
@@ -493,14 +825,14 @@ export function createPixiMediaLayer(options: PixiMediaLayerOptions): PixiMediaL
             g.stroke({ color: selectionColors.nodeOutline, width: 1.5 / (currentViewport.zoom || 1) })
         }
 
-        renderNow()
+        scheduleRender()
     }
 
     function setMarqueeRect(worldRect: { x: number; y: number; width: number; height: number } | null): void {
         if (destroyed) return
         if (!worldRect) {
             marqueeGraphics?.clear()
-            renderNow()
+            scheduleRender()
             return
         }
 
@@ -514,20 +846,20 @@ export function createPixiMediaLayer(options: PixiMediaLayerOptions): PixiMediaL
         marqueeGraphics.fill({ color: selectionColors.marqueeFill })
         marqueeGraphics.stroke({ color: selectionColors.marqueeStroke, width: 1 / (currentViewport.zoom || 1) })
 
-        renderNow()
+        scheduleRender()
     }
 
     function setPixiEdges(edges: PixiEdgeRenderDatum[]): void {
         if (destroyed || !edgeRenderer) return
         edgeRenderer.render(edges)
-        renderNow()
+        scheduleRender()
     }
 
     function setSelectionOverlayBounds(worldBounds: { x: number; y: number; width: number; height: number } | null): void {
         if (destroyed) return
         if (!worldBounds) {
             groupOverlayGraphics?.clear()
-            renderNow()
+            scheduleRender()
             return
         }
 
@@ -542,13 +874,25 @@ export function createPixiMediaLayer(options: PixiMediaLayerOptions): PixiMediaL
         groupOverlayGraphics.fill({ color: selectionColors.groupOverlayFill })
         groupOverlayGraphics.stroke({ color: selectionColors.groupOverlayStroke, width: 1 / (currentViewport.zoom || 1) })
 
-        renderNow()
+        scheduleRender()
+    }
+
+    function getHealth(): PixiRendererHealth {
+        return health
     }
 
     function destroy(): void {
         const wasReady = health === 'ready'
         destroyed = true
-        health = 'destroyed'
+        setHealth('destroyed')
+        if (renderRaf !== null) {
+            cancelAnimationFrame(renderRaf)
+            renderRaf = null
+        }
+        if (visibilityRaf !== null) {
+            cancelAnimationFrame(visibilityRaf)
+            visibilityRaf = null
+        }
         for (const [nodeId, entry] of entries) {
             setDomOwnership(nodeId, false)
             releaseTexture(entry.textureKey)
@@ -557,6 +901,7 @@ export function createPixiMediaLayer(options: PixiMediaLayerOptions): PixiMediaL
         }
         releaseAllDomOwnership()
         entries.clear()
+        nodeElCache.clear()
         for (const [, g] of selectionOutlines) { g.destroy() }
         selectionOutlines.clear()
         marqueeGraphics?.destroy()
@@ -585,6 +930,7 @@ export function createPixiMediaLayer(options: PixiMediaLayerOptions): PixiMediaL
         setMarqueeRect,
         setSelectionOverlayBounds,
         setPixiEdges,
+        getHealth,
         destroy,
     }
 }

--- a/services/web-ui/src/infographics/workspace/pixiMediaLayer.ts
+++ b/services/web-ui/src/infographics/workspace/pixiMediaLayer.ts
@@ -51,6 +51,11 @@ type PixiImageEntry = {
     textureKey: string | null
     worldRect: IndexedImage
     isVisible: boolean
+    // Last-known geometry used to draw the placeholder colorRect. Compared
+    // before each drawColorRect call so we skip the GPU clear+rebuild when
+    // the node hasn't moved or resized.
+    colorRectW: number
+    colorRectH: number
 }
 
 type TextureEntry = {
@@ -334,6 +339,8 @@ export function createPixiMediaLayer(options: PixiMediaLayerOptions): PixiMediaL
             if (!activeIds.has(nodeId)) {
                 setDomOwnership(nodeId, false)
                 releaseTexture(entry.textureKey)
+                // Remove from spatial index before destroying the entry.
+                spatialIndex.remove(entry.worldRect, (a: IndexedImage, b: IndexedImage) => a.nodeId === b.nodeId)
                 world.removeChild(entry.sprite)
                 world.removeChild(entry.colorRect)
                 entry.sprite.destroy()
@@ -350,7 +357,10 @@ export function createPixiMediaLayer(options: PixiMediaLayerOptions): PixiMediaL
     }
 
     function upsertAllEntries(canvasState: CanvasState): void {
-        spatialIndex.clear()
+        // Do NOT clear the spatial index here. upsertEntry updates each
+        // entry's rect incrementally — remove old rect, insert new — so
+        // the index stays consistent without the O(N log N) full rebuild
+        // that was happening on every sync.
         const nodesById = buildNodesById(canvasState.nodes)
         const imageNodes = canvasState.nodes.filter(
             (node: CanvasState['nodes'][number]): node is ImageCanvasNode => node.type === 'image'
@@ -382,20 +392,23 @@ export function createPixiMediaLayer(options: PixiMediaLayerOptions): PixiMediaL
         const entry = entries.get(nodeId)
         if (!entry) return
 
-        entry.sprite.position.set(worldPosition.x, worldPosition.y)
-        entry.sprite.width = dimensions.width
-        entry.sprite.height = dimensions.height
-        entry.colorRect.position.set(worldPosition.x, worldPosition.y)
-        drawColorRect(entry.colorRect, dimensions.width, dimensions.height)
+        const x = worldPosition.x
+        const y = worldPosition.y
+        const w = dimensions.width
+        const h = dimensions.height
+
+        entry.sprite.position.set(x, y)
+        entry.sprite.width = w
+        entry.sprite.height = h
+        entry.colorRect.position.set(x, y)
+        if (w !== entry.colorRectW || h !== entry.colorRectH) {
+            drawColorRect(entry.colorRect, w, h)
+            entry.colorRectW = w
+            entry.colorRectH = h
+        }
 
         spatialIndex.remove(entry.worldRect, (a: IndexedImage, b: IndexedImage) => a.nodeId === b.nodeId)
-        const newRect: IndexedImage = {
-            minX: worldPosition.x,
-            minY: worldPosition.y,
-            maxX: worldPosition.x + dimensions.width,
-            maxY: worldPosition.y + dimensions.height,
-            nodeId,
-        }
+        const newRect: IndexedImage = { minX: x, minY: y, maxX: x + w, maxY: y + h, nodeId }
         entry.worldRect = newRect
         spatialIndex.insert(newRect)
 
@@ -441,8 +454,9 @@ export function createPixiMediaLayer(options: PixiMediaLayerOptions): PixiMediaL
     }
 
     function upsertEntry(node: ImageCanvasNode, worldPosition: WorldPosition): void {
-        let entry = entries.get(node.nodeId)
         const newSourceKey = makeSourceKey(node)
+        let entry = entries.get(node.nodeId)
+
         if (!entry) {
             const sprite = new Sprite(Texture.EMPTY)
             sprite.label = `pixi-image-${node.nodeId}`
@@ -453,6 +467,7 @@ export function createPixiMediaLayer(options: PixiMediaLayerOptions): PixiMediaL
             colorRect.eventMode = 'none'
             world.addChild(sprite)
             world.addChild(colorRect)
+            const rect = makeIndexedImage(node, worldPosition)
             entry = {
                 sprite,
                 colorRect,
@@ -462,13 +477,22 @@ export function createPixiMediaLayer(options: PixiMediaLayerOptions): PixiMediaL
                 requestedTier: null,
                 requestId: 0,
                 textureKey: null,
-                worldRect: makeIndexedImage(node, worldPosition),
+                worldRect: rect,
                 isVisible: false,
+                colorRectW: -1,
+                colorRectH: -1,
             }
             entries.set(node.nodeId, entry)
-        } else if (entry.sourceKey !== newSourceKey) {
-            // Source image changed (e.g. replaced via "replace image"). Drop
-            // any loaded state so the next visibility pass refetches.
+            spatialIndex.insert(rect)
+            // DOM ownership is new — always set.
+            setDomOwnership(node.nodeId, true)
+            return
+        }
+
+        // Existing entry — only update what changed.
+
+        if (entry.sourceKey !== newSourceKey) {
+            // Source image replaced. Drop loaded state; next visibility pass refetches.
             if (entry.textureKey) releaseTexture(entry.textureKey)
             entry.textureKey = null
             entry.loadedTier = null
@@ -479,18 +503,41 @@ export function createPixiMediaLayer(options: PixiMediaLayerOptions): PixiMediaL
         }
 
         entry.nodeRef = node
-        entry.sprite.position.set(worldPosition.x, worldPosition.y)
-        entry.sprite.width = node.dimensions.width
-        entry.sprite.height = node.dimensions.height
-        entry.colorRect.position.set(worldPosition.x, worldPosition.y)
-        drawColorRect(entry.colorRect, node.dimensions.width, node.dimensions.height)
-        entry.worldRect = makeIndexedImage(node, worldPosition)
-        spatialIndex.insert(entry.worldRect)
-        setDomOwnership(node.nodeId, true)
+
+        const x = worldPosition.x
+        const y = worldPosition.y
+        const w = node.dimensions.width
+        const h = node.dimensions.height
+
+        // Sprite transform — always cheap (matrix update only).
+        entry.sprite.position.set(x, y)
+        entry.sprite.width = w
+        entry.sprite.height = h
+
+        // Color-rect geometry — only rebuild GPU path when size actually changed.
+        // Position is a transform update; width/height require path re-upload.
+        entry.colorRect.position.set(x, y)
+        if (w !== entry.colorRectW || h !== entry.colorRectH) {
+            drawColorRect(entry.colorRect, w, h)
+            entry.colorRectW = w
+            entry.colorRectH = h
+        }
+
+        // Spatial index — incremental: remove old rect only if position/size changed.
+        const old = entry.worldRect
+        if (old.minX !== x || old.minY !== y || old.maxX !== x + w || old.maxY !== y + h) {
+            spatialIndex.remove(old, (a: IndexedImage, b: IndexedImage) => a.nodeId === b.nodeId)
+            const newRect = makeIndexedImage(node, worldPosition)
+            entry.worldRect = newRect
+            spatialIndex.insert(newRect)
+        }
+
+        // DOM ownership — skip classList.toggle when already in the right state.
+        if (!pixiOwnedNodeIds.has(node.nodeId)) {
+            setDomOwnership(node.nodeId, true)
+        }
         // IMPORTANT: do NOT trigger texture loading here. Texture loading is
-        // driven by visibility (see `updateVisibleImages` / `ensureTextureForEntry`)
-        // so that a workspace with hundreds of images doesn't spawn hundreds of
-        // concurrent fetches on initial open or on viewport changes.
+        // driven by visibility (updateVisibleImages / ensureTextureForEntry).
     }
 
     function drawColorRect(rect: Graphics, width: number, height: number): void {
@@ -788,8 +835,19 @@ export function createPixiMediaLayer(options: PixiMediaLayerOptions): PixiMediaL
                 candidates.push({ entry, d2: dx * dx + dy * dy })
             }
             candidates.sort((a, b) => a.d2 - b.d2)
-            for (const { entry } of candidates) {
-                ensureTextureForEntry(entry, 'thumb-256')
+
+            // Process at most PREFETCH_BATCH_SIZE images per idle tick so one
+            // callback can't queue thousands of concurrent decode requests.
+            // Remaining candidates will be picked up on the next schedulePrefetch()
+            // call (triggered by the next viewport change or sync).
+            const PREFETCH_BATCH_SIZE = 20
+            for (let i = 0; i < Math.min(candidates.length, PREFETCH_BATCH_SIZE); i++) {
+                ensureTextureForEntry(candidates[i].entry, 'thumb-256')
+            }
+            // If more remain, schedule another idle pass.
+            if (candidates.length > PREFETCH_BATCH_SIZE) {
+                prefetchScheduled = false
+                schedulePrefetch()
             }
         }, 1500)
     }

--- a/services/web-ui/src/infographics/workspace/pixiMediaLayer.ts
+++ b/services/web-ui/src/infographics/workspace/pixiMediaLayer.ts
@@ -26,9 +26,11 @@ import {
     resolveStoredImagePath,
     type IndexedImage,
     type LodTier,
+    type PixiEdgeRenderDatum,
     type PixiRendererHealth,
     type WorldPosition,
 } from '$src/infographics/workspace/pixiMediaLayerLogic.ts'
+import { createPixiEdgeRenderer, type PixiEdgeRenderer } from '$src/infographics/workspace/rendering/pixiEdgeRenderer.ts'
 
 type PixiImageEntry = {
     sprite: Sprite
@@ -65,6 +67,7 @@ export type PixiMediaLayer = {
     setSelectedImageNodes: (selectedNodeIds: Set<string>) => void
     setMarqueeRect: (worldRect: { x: number; y: number; width: number; height: number } | null) => void
     setSelectionOverlayBounds: (worldBounds: { x: number; y: number; width: number; height: number } | null) => void
+    setPixiEdges: (edges: PixiEdgeRenderDatum[]) => void
     destroy: () => void
 }
 
@@ -108,8 +111,10 @@ export function createPixiMediaLayer(options: PixiMediaLayerOptions): PixiMediaL
     const app = new Application()
     const world = new Container({ label: 'workspace-pixi-media-world' })
     const fgLayer = new Container({ label: 'workspace-pixi-fg' })
+    const edgeLayer = new Container({ label: 'workspace-pixi-edges' })
     const entries = new Map<string, PixiImageEntry>()
     const selectionOutlines = new Map<string, Graphics>()
+    let edgeRenderer: PixiEdgeRenderer | null = null
     const textureCache = new Map<string, TextureEntry>()
     const spatialIndex = new RBush<IndexedImage>()
     const pixiOwnedNodeIds = new Set<string>()
@@ -149,13 +154,18 @@ export function createPixiMediaLayer(options: PixiMediaLayerOptions): PixiMediaL
             }
 
             app.stage.addChild(world)
+            world.addChild(edgeLayer)
             world.addChild(fgLayer)
+            edgeRenderer = createPixiEdgeRenderer(edgeLayer)
             hostEl.appendChild(app.canvas)
+            // Only position the canvas — DO NOT set width/height explicitly.
+            // `autoDensity: true` + `resizeTo: paneEl` own the canvas pixel
+            // buffer and CSS display size. Overriding them with percentage values
+            // conflicts with PIXI's ResizeObserver and creates an inconsistent
+            // aspect ratio after pane-size changes (e.g. sidebar opening).
             applyStyle(app.canvas as HTMLCanvasElement, {
                 position: 'absolute',
                 inset: '0',
-                width: '100%',
-                height: '100%',
             })
             world.position.set(currentViewport.x, currentViewport.y)
             world.scale.set(currentViewport.zoom, currentViewport.zoom)
@@ -507,6 +517,12 @@ export function createPixiMediaLayer(options: PixiMediaLayerOptions): PixiMediaL
         renderNow()
     }
 
+    function setPixiEdges(edges: PixiEdgeRenderDatum[]): void {
+        if (destroyed || !edgeRenderer) return
+        edgeRenderer.render(edges)
+        renderNow()
+    }
+
     function setSelectionOverlayBounds(worldBounds: { x: number; y: number; width: number; height: number } | null): void {
         if (destroyed) return
         if (!worldBounds) {
@@ -547,6 +563,8 @@ export function createPixiMediaLayer(options: PixiMediaLayerOptions): PixiMediaL
         marqueeGraphics = null
         groupOverlayGraphics?.destroy()
         groupOverlayGraphics = null
+        edgeRenderer?.destroy()
+        edgeRenderer = null
         for (const [, entry] of textureCache) {
             entry.texture.destroy(true)
         }
@@ -566,6 +584,7 @@ export function createPixiMediaLayer(options: PixiMediaLayerOptions): PixiMediaL
         setSelectedImageNodes,
         setMarqueeRect,
         setSelectionOverlayBounds,
+        setPixiEdges,
         destroy,
     }
 }

--- a/services/web-ui/src/infographics/workspace/pixiMediaLayer.ts
+++ b/services/web-ui/src/infographics/workspace/pixiMediaLayer.ts
@@ -46,6 +46,14 @@ type TextureEntry = {
     lastUsed: number
 }
 
+export type SelectionColors = {
+    nodeOutline: string
+    marqueeStroke: string
+    marqueeFill: string
+    groupOverlayStroke: string
+    groupOverlayFill: string
+}
+
 export type PixiMediaLayer = {
     sync: (canvasState: CanvasState | null) => void
     setViewport: (viewport: CanvasViewport) => void
@@ -54,6 +62,9 @@ export type PixiMediaLayer = {
         worldPosition: WorldPosition,
         dimensions: { width: number; height: number }
     ) => void
+    setSelectedImageNodes: (selectedNodeIds: Set<string>) => void
+    setMarqueeRect: (worldRect: { x: number; y: number; width: number; height: number } | null) => void
+    setSelectionOverlayBounds: (worldBounds: { x: number; y: number; width: number; height: number } | null) => void
     destroy: () => void
 }
 
@@ -61,6 +72,7 @@ type PixiMediaLayerOptions = {
     paneEl: HTMLDivElement
     viewportEl: HTMLDivElement
     getWorkspaceId: () => string
+    selectionColors: SelectionColors
 }
 
 const CULLING_MARGIN = 800
@@ -81,7 +93,7 @@ function setPixiOwned(viewportEl: HTMLDivElement, nodeId: string, owned: boolean
 }
 
 export function createPixiMediaLayer(options: PixiMediaLayerOptions): PixiMediaLayer {
-    const { paneEl, viewportEl, getWorkspaceId } = options
+    const { paneEl, viewportEl, getWorkspaceId, selectionColors } = options
 
     const hostStyle = {
         position: 'absolute' as const,
@@ -95,7 +107,9 @@ export function createPixiMediaLayer(options: PixiMediaLayerOptions): PixiMediaL
 
     const app = new Application()
     const world = new Container({ label: 'workspace-pixi-media-world' })
+    const fgLayer = new Container({ label: 'workspace-pixi-fg' })
     const entries = new Map<string, PixiImageEntry>()
+    const selectionOutlines = new Map<string, Graphics>()
     const textureCache = new Map<string, TextureEntry>()
     const spatialIndex = new RBush<IndexedImage>()
     const pixiOwnedNodeIds = new Set<string>()
@@ -103,6 +117,8 @@ export function createPixiMediaLayer(options: PixiMediaLayerOptions): PixiMediaL
     let textureClock = 0
     let destroyed = false
     let health: PixiRendererHealth = 'initializing'
+    let marqueeGraphics: Graphics | null = null
+    let groupOverlayGraphics: Graphics | null = null
     let lastState: CanvasState | null = null
     let requestCounter = 0
     let currentViewport: CanvasViewport = { x: 0, y: 0, zoom: 1 }
@@ -133,6 +149,7 @@ export function createPixiMediaLayer(options: PixiMediaLayerOptions): PixiMediaL
             }
 
             app.stage.addChild(world)
+            world.addChild(fgLayer)
             hostEl.appendChild(app.canvas)
             applyStyle(app.canvas as HTMLCanvasElement, {
                 position: 'absolute',
@@ -435,6 +452,83 @@ export function createPixiMediaLayer(options: PixiMediaLayerOptions): PixiMediaL
         }
     }
 
+    function setSelectedImageNodes(selectedNodeIds: Set<string>): void {
+        if (destroyed) return
+
+        // Remove outlines for nodes that are no longer selected or no longer exist.
+        for (const [nodeId, g] of selectionOutlines) {
+            if (!selectedNodeIds.has(nodeId) || !entries.has(nodeId)) {
+                g.destroy()
+                selectionOutlines.delete(nodeId)
+            }
+        }
+
+        // Add/update outline for each newly selected PIXI-owned node.
+        for (const nodeId of selectedNodeIds) {
+            const entry = entries.get(nodeId)
+            if (!entry) continue
+
+            let g = selectionOutlines.get(nodeId)
+            if (!g) {
+                g = new Graphics()
+                fgLayer.addChild(g)
+                selectionOutlines.set(nodeId, g)
+            }
+
+            const { x, y } = entry.sprite.position
+            const w = entry.sprite.width
+            const h = entry.sprite.height
+            g.clear()
+            g.roundRect(x, y, w, h, 4)
+            g.stroke({ color: selectionColors.nodeOutline, width: 1.5 / (currentViewport.zoom || 1) })
+        }
+
+        renderNow()
+    }
+
+    function setMarqueeRect(worldRect: { x: number; y: number; width: number; height: number } | null): void {
+        if (destroyed) return
+        if (!worldRect) {
+            marqueeGraphics?.clear()
+            renderNow()
+            return
+        }
+
+        if (!marqueeGraphics) {
+            marqueeGraphics = new Graphics()
+            fgLayer.addChild(marqueeGraphics)
+        }
+
+        marqueeGraphics.clear()
+        marqueeGraphics.roundRect(worldRect.x, worldRect.y, worldRect.width, worldRect.height, 8 / (currentViewport.zoom || 1))
+        marqueeGraphics.fill({ color: selectionColors.marqueeFill })
+        marqueeGraphics.stroke({ color: selectionColors.marqueeStroke, width: 1 / (currentViewport.zoom || 1) })
+
+        renderNow()
+    }
+
+    function setSelectionOverlayBounds(worldBounds: { x: number; y: number; width: number; height: number } | null): void {
+        if (destroyed) return
+        if (!worldBounds) {
+            groupOverlayGraphics?.clear()
+            renderNow()
+            return
+        }
+
+        if (!groupOverlayGraphics) {
+            groupOverlayGraphics = new Graphics()
+            fgLayer.addChild(groupOverlayGraphics)
+        }
+
+        const r = 18 / (currentViewport.zoom || 1)
+        groupOverlayGraphics.clear()
+        groupOverlayGraphics.roundRect(worldBounds.x, worldBounds.y, worldBounds.width, worldBounds.height, r)
+        groupOverlayGraphics.fill({ color: selectionColors.groupOverlayFill })
+        groupOverlayGraphics.stroke({ color: selectionColors.groupOverlayStroke, width: 1 / (currentViewport.zoom || 1) })
+
+        renderNow()
+    }
+
     function destroy(): void {
         const wasReady = health === 'ready'
         destroyed = true
@@ -447,6 +541,12 @@ export function createPixiMediaLayer(options: PixiMediaLayerOptions): PixiMediaL
         }
         releaseAllDomOwnership()
         entries.clear()
+        for (const [, g] of selectionOutlines) { g.destroy() }
+        selectionOutlines.clear()
+        marqueeGraphics?.destroy()
+        marqueeGraphics = null
+        groupOverlayGraphics?.destroy()
+        groupOverlayGraphics = null
         for (const [, entry] of textureCache) {
             entry.texture.destroy(true)
         }
@@ -463,6 +563,9 @@ export function createPixiMediaLayer(options: PixiMediaLayerOptions): PixiMediaL
         sync,
         setViewport,
         setNodeLiveTransform,
+        setSelectedImageNodes,
+        setMarqueeRect,
+        setSelectionOverlayBounds,
         destroy,
     }
 }

--- a/services/web-ui/src/infographics/workspace/pixiMediaLayer.ts
+++ b/services/web-ui/src/infographics/workspace/pixiMediaLayer.ts
@@ -1,0 +1,408 @@
+import {
+    Application,
+    Container,
+    Graphics,
+    Sprite,
+    Texture,
+} from 'pixi.js'
+import RBush from 'rbush'
+import type {
+    CanvasState,
+    ImageCanvasNode,
+    CanvasViewport,
+} from '@lixpi/constants'
+
+import { html, applyStyle } from '$src/utils/domTemplates.ts'
+import AuthService from '$src/services/auth-service.ts'
+import { decodeImageInWorker, destroyPixiImageDecoder } from '$src/infographics/workspace/pixiImageDecoder.ts'
+
+type PixiImageEntry = {
+    sprite: Sprite
+    colorRect: Graphics
+    srcKey: string
+    requestId: number
+    textureKey: string | null
+    worldRect: IndexedImage
+}
+
+type TextureEntry = {
+    texture: Texture
+    bytes: number
+    refCount: number
+    lastUsed: number
+}
+
+type IndexedImage = {
+    minX: number
+    minY: number
+    maxX: number
+    maxY: number
+    nodeId: string
+}
+
+type LodTier = 'color' | 'thumb-256' | 'thumb-1024' | 'full'
+
+export type PixiMediaLayer = {
+    sync: (canvasState: CanvasState | null) => void
+    setViewport: (viewport: CanvasViewport) => void
+    destroy: () => void
+}
+
+type PixiMediaLayerOptions = {
+    paneEl: HTMLDivElement
+    viewportEl: HTMLDivElement
+    getWorkspaceId: () => string
+}
+
+const transparentPixel = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII='
+const CULLING_MARGIN = 800
+const MAX_TEXTURES = 256
+const MAX_TEXTURE_BYTES = 512 * 1024 * 1024
+
+function buildImageSrc(imageUrl: string, apiBaseUrl: string, token: string | false): string {
+    if (!imageUrl) return transparentPixel
+    if (imageUrl.startsWith('data:')) return imageUrl
+    if (imageUrl.startsWith('/api/')) return `${apiBaseUrl}${imageUrl}${token ? `?token=${token}` : ''}`
+    return imageUrl
+}
+
+function isStoredImageSrc(src: string): boolean {
+    const stripped = src.replace(/[?&]token=[^&]+/, '')
+    return stripped.startsWith('/api/') || (stripped.startsWith('http') && stripped.includes('/api/images/'))
+}
+
+async function resolveImageSrc(node: ImageCanvasNode, workspaceId: string): Promise<string> {
+    const API_BASE_URL = import.meta.env.VITE_API_URL || ''
+    const strippedSrc = node.src.replace(/[?&]token=[^&]+/, '')
+    const resolvedSrc = isStoredImageSrc(strippedSrc)
+        ? `/api/images/${workspaceId}/${node.fileId}`
+        : strippedSrc
+    const token = await AuthService.getTokenSilently()
+    return buildImageSrc(resolvedSrc, API_BASE_URL, token || false)
+}
+
+function getLodTier(zoom: number): LodTier {
+    if (zoom < 0.1) return 'color'
+    if (zoom < 0.4) return 'thumb-256'
+    if (zoom < 1) return 'thumb-1024'
+    return 'full'
+}
+
+function addLodSizeParam(url: string, tier: LodTier): string {
+    if (tier === 'full' || tier === 'color') return url
+    if (!url.includes('/api/images/')) return url
+
+    try {
+        const parsed = new URL(url, window.location.origin)
+        parsed.searchParams.set('size', tier === 'thumb-256' ? '256' : '1024')
+        return parsed.toString()
+    } catch {
+        return url
+    }
+}
+
+function makeIndexedImage(node: ImageCanvasNode): IndexedImage {
+    return {
+        minX: node.position.x,
+        minY: node.position.y,
+        maxX: node.position.x + node.dimensions.width,
+        maxY: node.position.y + node.dimensions.height,
+        nodeId: node.nodeId,
+    }
+}
+
+function setPixiOwned(viewportEl: HTMLDivElement, nodeId: string, owned: boolean): void {
+    const nodeEl = viewportEl.querySelector(`[data-node-id="${nodeId}"]`) as HTMLElement | null
+    if (!nodeEl) return
+    nodeEl.classList.toggle('workspace-image-node--pixi-owned', owned)
+}
+
+export function createPixiMediaLayer(options: PixiMediaLayerOptions): PixiMediaLayer {
+    const { paneEl, viewportEl, getWorkspaceId } = options
+
+    const hostStyle = {
+        position: 'absolute' as const,
+        inset: '0',
+        pointerEvents: 'none' as const,
+        zIndex: '0',
+        overflow: 'hidden',
+    }
+    const hostEl = html`<div className="workspace-pixi-media-layer" style=${hostStyle}></div>` as HTMLDivElement
+    paneEl.insertBefore(hostEl, viewportEl)
+
+    const app = new Application()
+    const world = new Container({ label: 'workspace-pixi-media-world' })
+    const entries = new Map<string, PixiImageEntry>()
+    const textureCache = new Map<string, TextureEntry>()
+    const spatialIndex = new RBush<IndexedImage>()
+    let textureBytes = 0
+    let textureClock = 0
+    let destroyed = false
+    let ready = false
+    let lastState: CanvasState | null = null
+    let requestCounter = 0
+    let currentViewport: CanvasViewport = { x: 0, y: 0, zoom: 1 }
+    let currentTier: LodTier = getLodTier(currentViewport.zoom)
+
+    void (async () => {
+        try {
+            await app.init({
+                preference: 'webgpu',
+                backgroundAlpha: 0,
+                antialias: true,
+                autoDensity: true,
+                resolution: Math.min(window.devicePixelRatio || 1, 2),
+                resizeTo: paneEl,
+                webgpu: {
+                    antialias: true,
+                    powerPreference: 'high-performance',
+                },
+                webgl: {
+                    antialias: true,
+                    powerPreference: 'high-performance',
+                },
+            })
+
+            if (destroyed) {
+                app.destroy(true, { children: true, texture: true, textureSource: true })
+                return
+            }
+
+            app.stage.addChild(world)
+            hostEl.appendChild(app.canvas)
+            applyStyle(app.canvas as HTMLCanvasElement, {
+                position: 'absolute',
+                inset: '0',
+                width: '100%',
+                height: '100%',
+            })
+            ready = true
+            sync(lastState)
+        } catch (error) {
+            console.error('[PixiMediaLayer] Failed to initialize PIXI media layer.', error)
+            ready = false
+        }
+    })()
+
+    function setViewport(viewport: CanvasViewport): void {
+        currentViewport = viewport
+        const nextTier = getLodTier(viewport.zoom)
+        const tierChanged = nextTier !== currentTier
+        currentTier = nextTier
+        world.position.set(viewport.x, viewport.y)
+        world.scale.set(viewport.zoom, viewport.zoom)
+        if (tierChanged && lastState && ready && !destroyed) {
+            sync(lastState)
+            return
+        }
+        updateVisibleImages()
+    }
+
+    function sync(canvasState: CanvasState | null): void {
+        lastState = canvasState
+        syncOwnership(canvasState)
+        if (!ready || destroyed || !canvasState) return
+
+        setViewport(canvasState.viewport)
+        const imageNodes = canvasState.nodes.filter((node: CanvasState['nodes'][number]): node is ImageCanvasNode => node.type === 'image')
+        const activeIds = new Set<string>(imageNodes.map((node: ImageCanvasNode) => node.nodeId))
+
+        for (const [nodeId, entry] of entries) {
+            if (!activeIds.has(nodeId)) {
+                setPixiOwned(viewportEl, nodeId, false)
+                releaseTexture(entry.textureKey)
+                world.removeChild(entry.sprite)
+                world.removeChild(entry.colorRect)
+                entry.sprite.destroy()
+                entry.colorRect.destroy()
+                entries.delete(nodeId)
+            }
+        }
+
+        spatialIndex.clear()
+        for (const node of imageNodes) {
+            upsertImage(node)
+        }
+        updateVisibleImages()
+    }
+
+    function syncOwnership(canvasState: CanvasState | null): void {
+        const imageNodeIds = new Set<string>(
+            canvasState?.nodes
+                .filter((node: CanvasState['nodes'][number]): node is ImageCanvasNode => node.type === 'image')
+                .map((node: ImageCanvasNode) => node.nodeId) ?? []
+        )
+
+        for (const nodeId of imageNodeIds) {
+            setPixiOwned(viewportEl, nodeId, true)
+        }
+    }
+
+    function upsertImage(node: ImageCanvasNode): void {
+        let entry = entries.get(node.nodeId)
+        if (!entry) {
+            const sprite = new Sprite(Texture.EMPTY)
+            sprite.label = `pixi-image-${node.nodeId}`
+            sprite.eventMode = 'none'
+            sprite.visible = false
+            const colorRect = new Graphics()
+            colorRect.label = `pixi-image-color-${node.nodeId}`
+            colorRect.eventMode = 'none'
+            world.addChild(sprite)
+            world.addChild(colorRect)
+            entry = {
+                sprite,
+                colorRect,
+                srcKey: '',
+                requestId: 0,
+                textureKey: null,
+                worldRect: makeIndexedImage(node),
+            }
+            entries.set(node.nodeId, entry)
+        }
+
+        setPixiOwned(viewportEl, node.nodeId, true)
+
+        entry.sprite.position.set(node.position.x, node.position.y)
+        entry.sprite.width = node.dimensions.width
+        entry.sprite.height = node.dimensions.height
+        entry.colorRect.position.set(node.position.x, node.position.y)
+        drawColorRect(entry.colorRect, node.dimensions.width, node.dimensions.height)
+        entry.worldRect = makeIndexedImage(node)
+        spatialIndex.insert(entry.worldRect)
+
+        const tier = currentTier
+        if (tier === 'color') {
+            entry.sprite.visible = false
+            entry.colorRect.visible = true
+            releaseTexture(entry.textureKey)
+            entry.textureKey = null
+            return
+        }
+
+        const srcKey = `${getWorkspaceId()}|${node.fileId}|${node.src}|${tier}`
+        if (entry.srcKey === srcKey) return
+
+        entry.srcKey = srcKey
+        entry.requestId = ++requestCounter
+        const requestId = entry.requestId
+        entry.sprite.visible = false
+        entry.colorRect.visible = true
+
+        void (async () => {
+            try {
+                const resolved = addLodSizeParam(await resolveImageSrc(node, getWorkspaceId()), tier)
+                const texture = await acquireTexture(resolved)
+                if (destroyed || entry?.requestId !== requestId) return
+                releaseTexture(entry.textureKey)
+                entry.textureKey = resolved
+                entry.sprite.texture = texture
+                entry.sprite.width = node.dimensions.width
+                entry.sprite.height = node.dimensions.height
+                entry.sprite.visible = true
+                entry.colorRect.visible = false
+            } catch (error) {
+                console.error('[PixiMediaLayer] Failed to load image texture.', error)
+                if (entry?.requestId === requestId) {
+                    entry.sprite.visible = false
+                    entry.colorRect.visible = true
+                }
+            }
+        })()
+    }
+
+    function drawColorRect(rect: Graphics, width: number, height: number): void {
+        rect.clear()
+        rect.roundRect(0, 0, width, height, 4)
+        rect.fill({ color: 0xe7eaee, alpha: 0.85 })
+    }
+
+    async function acquireTexture(url: string): Promise<Texture> {
+        const cached = textureCache.get(url)
+        if (cached) {
+            cached.refCount++
+            cached.lastUsed = ++textureClock
+            return cached.texture
+        }
+
+        const bitmap = await decodeImageInWorker(url)
+        const texture = Texture.from(bitmap)
+        const bytes = Math.max(1, bitmap.width) * Math.max(1, bitmap.height) * 4
+        textureCache.set(url, {
+            texture,
+            bytes,
+            refCount: 1,
+            lastUsed: ++textureClock,
+        })
+        textureBytes += bytes
+        evictTextures()
+        return texture
+    }
+
+    function releaseTexture(url: string | null): void {
+        if (!url) return
+        const entry = textureCache.get(url)
+        if (!entry) return
+        entry.refCount = Math.max(0, entry.refCount - 1)
+    }
+
+    function evictTextures(): void {
+        if (textureCache.size <= MAX_TEXTURES && textureBytes <= MAX_TEXTURE_BYTES) return
+
+        const candidates = Array.from(textureCache.entries())
+            .filter(([, entry]) => entry.refCount === 0)
+            .sort((a, b) => a[1].lastUsed - b[1].lastUsed)
+
+        for (const [key, entry] of candidates) {
+            if (textureCache.size <= MAX_TEXTURES && textureBytes <= MAX_TEXTURE_BYTES) break
+            textureCache.delete(key)
+            textureBytes -= entry.bytes
+            entry.texture.destroy(true)
+        }
+    }
+
+    function updateVisibleImages(): void {
+        if (!ready || !lastState) return
+        const visible = new Set(
+            spatialIndex.search({
+                minX: (-currentViewport.x / currentViewport.zoom) - CULLING_MARGIN,
+                minY: (-currentViewport.y / currentViewport.zoom) - CULLING_MARGIN,
+                maxX: ((paneEl.clientWidth - currentViewport.x) / currentViewport.zoom) + CULLING_MARGIN,
+                maxY: ((paneEl.clientHeight - currentViewport.y) / currentViewport.zoom) + CULLING_MARGIN,
+            }).map((item: IndexedImage) => item.nodeId)
+        )
+
+        for (const [nodeId, entry] of entries) {
+            const isVisible = visible.has(nodeId)
+            entry.sprite.renderable = isVisible
+            entry.colorRect.renderable = isVisible
+        }
+    }
+
+    function destroy(): void {
+        destroyed = true
+        for (const [nodeId, entry] of entries) {
+            setPixiOwned(viewportEl, nodeId, false)
+            releaseTexture(entry.textureKey)
+            entry.sprite.destroy()
+            entry.colorRect.destroy()
+        }
+        entries.clear()
+        for (const [, entry] of textureCache) {
+            entry.texture.destroy(true)
+        }
+        textureCache.clear()
+        spatialIndex.clear()
+        destroyPixiImageDecoder()
+        hostEl.remove()
+        if (ready) {
+            app.destroy(true, { children: true, texture: false, textureSource: false })
+        }
+    }
+
+    return {
+        sync,
+        setViewport,
+        destroy,
+    }
+}

--- a/services/web-ui/src/infographics/workspace/pixiMediaLayer.ts
+++ b/services/web-ui/src/infographics/workspace/pixiMediaLayer.ts
@@ -15,6 +15,20 @@ import type {
 import { html, applyStyle } from '$src/utils/domTemplates.ts'
 import AuthService from '$src/services/auth-service.ts'
 import { decodeImageInWorker, destroyPixiImageDecoder } from '$src/infographics/workspace/pixiImageDecoder.ts'
+import {
+    addPixiLodSizeParam,
+    buildNodesById,
+    buildPixiImageSrc,
+    computeWorldPosition,
+    getPixiLodTier,
+    getVisibleWorldRect,
+    makeIndexedImage,
+    resolveStoredImagePath,
+    type IndexedImage,
+    type LodTier,
+    type PixiRendererHealth,
+    type WorldPosition,
+} from '$src/infographics/workspace/pixiMediaLayerLogic.ts'
 
 type PixiImageEntry = {
     sprite: Sprite
@@ -32,19 +46,14 @@ type TextureEntry = {
     lastUsed: number
 }
 
-type IndexedImage = {
-    minX: number
-    minY: number
-    maxX: number
-    maxY: number
-    nodeId: string
-}
-
-type LodTier = 'color' | 'thumb-256' | 'thumb-1024' | 'full'
-
 export type PixiMediaLayer = {
     sync: (canvasState: CanvasState | null) => void
     setViewport: (viewport: CanvasViewport) => void
+    setNodeLiveTransform: (
+        nodeId: string,
+        worldPosition: WorldPosition,
+        dimensions: { width: number; height: number }
+    ) => void
     destroy: () => void
 }
 
@@ -54,61 +63,15 @@ type PixiMediaLayerOptions = {
     getWorkspaceId: () => string
 }
 
-const transparentPixel = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII='
 const CULLING_MARGIN = 800
 const MAX_TEXTURES = 256
 const MAX_TEXTURE_BYTES = 512 * 1024 * 1024
 
-function buildImageSrc(imageUrl: string, apiBaseUrl: string, token: string | false): string {
-    if (!imageUrl) return transparentPixel
-    if (imageUrl.startsWith('data:')) return imageUrl
-    if (imageUrl.startsWith('/api/')) return `${apiBaseUrl}${imageUrl}${token ? `?token=${token}` : ''}`
-    return imageUrl
-}
-
-function isStoredImageSrc(src: string): boolean {
-    const stripped = src.replace(/[?&]token=[^&]+/, '')
-    return stripped.startsWith('/api/') || (stripped.startsWith('http') && stripped.includes('/api/images/'))
-}
-
 async function resolveImageSrc(node: ImageCanvasNode, workspaceId: string): Promise<string> {
     const API_BASE_URL = import.meta.env.VITE_API_URL || ''
-    const strippedSrc = node.src.replace(/[?&]token=[^&]+/, '')
-    const resolvedSrc = isStoredImageSrc(strippedSrc)
-        ? `/api/images/${workspaceId}/${node.fileId}`
-        : strippedSrc
+    const resolvedSrc = resolveStoredImagePath(node, workspaceId)
     const token = await AuthService.getTokenSilently()
-    return buildImageSrc(resolvedSrc, API_BASE_URL, token || false)
-}
-
-function getLodTier(zoom: number): LodTier {
-    if (zoom < 0.1) return 'color'
-    if (zoom < 0.4) return 'thumb-256'
-    if (zoom < 1) return 'thumb-1024'
-    return 'full'
-}
-
-function addLodSizeParam(url: string, tier: LodTier): string {
-    if (tier === 'full' || tier === 'color') return url
-    if (!url.includes('/api/images/')) return url
-
-    try {
-        const parsed = new URL(url, window.location.origin)
-        parsed.searchParams.set('size', tier === 'thumb-256' ? '256' : '1024')
-        return parsed.toString()
-    } catch {
-        return url
-    }
-}
-
-function makeIndexedImage(node: ImageCanvasNode): IndexedImage {
-    return {
-        minX: node.position.x,
-        minY: node.position.y,
-        maxX: node.position.x + node.dimensions.width,
-        maxY: node.position.y + node.dimensions.height,
-        nodeId: node.nodeId,
-    }
+    return buildPixiImageSrc(resolvedSrc, API_BASE_URL, token || false)
 }
 
 function setPixiOwned(viewportEl: HTMLDivElement, nodeId: string, owned: boolean): void {
@@ -124,7 +87,7 @@ export function createPixiMediaLayer(options: PixiMediaLayerOptions): PixiMediaL
         position: 'absolute' as const,
         inset: '0',
         pointerEvents: 'none' as const,
-        zIndex: '0',
+        zIndex: '2',
         overflow: 'hidden',
     }
     const hostEl = html`<div className="workspace-pixi-media-layer" style=${hostStyle}></div>` as HTMLDivElement
@@ -135,14 +98,15 @@ export function createPixiMediaLayer(options: PixiMediaLayerOptions): PixiMediaL
     const entries = new Map<string, PixiImageEntry>()
     const textureCache = new Map<string, TextureEntry>()
     const spatialIndex = new RBush<IndexedImage>()
+    const pixiOwnedNodeIds = new Set<string>()
     let textureBytes = 0
     let textureClock = 0
     let destroyed = false
-    let ready = false
+    let health: PixiRendererHealth = 'initializing'
     let lastState: CanvasState | null = null
     let requestCounter = 0
     let currentViewport: CanvasViewport = { x: 0, y: 0, zoom: 1 }
-    let currentTier: LodTier = getLodTier(currentViewport.zoom)
+    let currentTier: LodTier = getPixiLodTier(currentViewport.zoom)
 
     void (async () => {
         try {
@@ -176,40 +140,53 @@ export function createPixiMediaLayer(options: PixiMediaLayerOptions): PixiMediaL
                 width: '100%',
                 height: '100%',
             })
-            ready = true
+            world.position.set(currentViewport.x, currentViewport.y)
+            world.scale.set(currentViewport.zoom, currentViewport.zoom)
+            health = 'ready'
             sync(lastState)
+            renderNow()
         } catch (error) {
             console.error('[PixiMediaLayer] Failed to initialize PIXI media layer.', error)
-            ready = false
+            health = 'failed'
+            releaseAllDomOwnership()
         }
     })()
 
     function setViewport(viewport: CanvasViewport): void {
+        if (destroyed) return
         currentViewport = viewport
-        const nextTier = getLodTier(viewport.zoom)
+        const nextTier = getPixiLodTier(viewport.zoom)
         const tierChanged = nextTier !== currentTier
         currentTier = nextTier
         world.position.set(viewport.x, viewport.y)
         world.scale.set(viewport.zoom, viewport.zoom)
-        if (tierChanged && lastState && ready && !destroyed) {
-            sync(lastState)
-            return
+        if (tierChanged && lastState && health === 'ready') {
+            upsertAllImages(lastState)
         }
         updateVisibleImages()
+        renderNow()
+    }
+
+    function upsertAllImages(canvasState: CanvasState): void {
+        spatialIndex.clear()
+        const nodesById = buildNodesById(canvasState.nodes)
+        const imageNodes = canvasState.nodes.filter((node: CanvasState['nodes'][number]): node is ImageCanvasNode => node.type === 'image')
+        for (const node of imageNodes) {
+            upsertImage(node, computeWorldPosition(node, nodesById))
+        }
     }
 
     function sync(canvasState: CanvasState | null): void {
         lastState = canvasState
-        syncOwnership(canvasState)
-        if (!ready || destroyed || !canvasState) return
+        syncDomOwnership(canvasState)
+        if (!canvasState || health !== 'ready' || destroyed) return
 
-        setViewport(canvasState.viewport)
         const imageNodes = canvasState.nodes.filter((node: CanvasState['nodes'][number]): node is ImageCanvasNode => node.type === 'image')
         const activeIds = new Set<string>(imageNodes.map((node: ImageCanvasNode) => node.nodeId))
 
         for (const [nodeId, entry] of entries) {
             if (!activeIds.has(nodeId)) {
-                setPixiOwned(viewportEl, nodeId, false)
+                setDomOwnership(nodeId, false)
                 releaseTexture(entry.textureKey)
                 world.removeChild(entry.sprite)
                 world.removeChild(entry.colorRect)
@@ -219,26 +196,86 @@ export function createPixiMediaLayer(options: PixiMediaLayerOptions): PixiMediaL
             }
         }
 
-        spatialIndex.clear()
-        for (const node of imageNodes) {
-            upsertImage(node)
-        }
+        upsertAllImages(canvasState)
         updateVisibleImages()
+        renderNow()
     }
 
-    function syncOwnership(canvasState: CanvasState | null): void {
-        const imageNodeIds = new Set<string>(
+    function renderNow(): void {
+        if (health !== 'ready' || destroyed) return
+        app.render()
+    }
+
+    // Live drag/resize updates push the new world position straight to the
+    // sprite without going through `sync`, so the PIXI pixels stay locked
+    // to the DOM hitbox during interaction. Once the gesture commits and
+    // `sync` runs with the final canvas state, the sprite is re-positioned
+    // from the same source of truth as the DOM.
+    function setNodeLiveTransform(
+        nodeId: string,
+        worldPosition: WorldPosition,
+        dimensions: { width: number; height: number }
+    ): void {
+        if (destroyed) return
+        const entry = entries.get(nodeId)
+        if (!entry) return
+
+        entry.sprite.position.set(worldPosition.x, worldPosition.y)
+        entry.sprite.width = dimensions.width
+        entry.sprite.height = dimensions.height
+        entry.colorRect.position.set(worldPosition.x, worldPosition.y)
+        drawColorRect(entry.colorRect, dimensions.width, dimensions.height)
+
+        spatialIndex.remove(entry.worldRect, (a: IndexedImage, b: IndexedImage) => a.nodeId === b.nodeId)
+        const newRect: IndexedImage = {
+            minX: worldPosition.x,
+            minY: worldPosition.y,
+            maxX: worldPosition.x + dimensions.width,
+            maxY: worldPosition.y + dimensions.height,
+            nodeId,
+        }
+        entry.worldRect = newRect
+        spatialIndex.insert(newRect)
+
+        updateVisibleImages()
+        renderNow()
+    }
+
+    function syncDomOwnership(canvasState: CanvasState | null): void {
+        const nextImageNodeIds = new Set<string>(
             canvasState?.nodes
                 .filter((node: CanvasState['nodes'][number]): node is ImageCanvasNode => node.type === 'image')
                 .map((node: ImageCanvasNode) => node.nodeId) ?? []
         )
 
-        for (const nodeId of imageNodeIds) {
-            setPixiOwned(viewportEl, nodeId, true)
+        for (const nodeId of pixiOwnedNodeIds) {
+            if (!nextImageNodeIds.has(nodeId)) {
+                setDomOwnership(nodeId, false)
+            }
+        }
+
+        for (const nodeId of nextImageNodeIds) {
+            setDomOwnership(nodeId, true)
         }
     }
 
-    function upsertImage(node: ImageCanvasNode): void {
+    function setDomOwnership(nodeId: string, owned: boolean): void {
+        setPixiOwned(viewportEl, nodeId, owned)
+        if (owned) {
+            pixiOwnedNodeIds.add(nodeId)
+        } else {
+            pixiOwnedNodeIds.delete(nodeId)
+        }
+    }
+
+    function releaseAllDomOwnership(): void {
+        for (const nodeId of pixiOwnedNodeIds) {
+            setPixiOwned(viewportEl, nodeId, false)
+        }
+        pixiOwnedNodeIds.clear()
+    }
+
+    function upsertImage(node: ImageCanvasNode, worldPosition: WorldPosition): void {
         let entry = entries.get(node.nodeId)
         if (!entry) {
             const sprite = new Sprite(Texture.EMPTY)
@@ -256,20 +293,19 @@ export function createPixiMediaLayer(options: PixiMediaLayerOptions): PixiMediaL
                 srcKey: '',
                 requestId: 0,
                 textureKey: null,
-                worldRect: makeIndexedImage(node),
+                worldRect: makeIndexedImage(node, worldPosition),
             }
             entries.set(node.nodeId, entry)
         }
 
-        setPixiOwned(viewportEl, node.nodeId, true)
-
-        entry.sprite.position.set(node.position.x, node.position.y)
+        entry.sprite.position.set(worldPosition.x, worldPosition.y)
         entry.sprite.width = node.dimensions.width
         entry.sprite.height = node.dimensions.height
-        entry.colorRect.position.set(node.position.x, node.position.y)
+        entry.colorRect.position.set(worldPosition.x, worldPosition.y)
         drawColorRect(entry.colorRect, node.dimensions.width, node.dimensions.height)
-        entry.worldRect = makeIndexedImage(node)
+        entry.worldRect = makeIndexedImage(node, worldPosition)
         spatialIndex.insert(entry.worldRect)
+        setDomOwnership(node.nodeId, true)
 
         const tier = currentTier
         if (tier === 'color') {
@@ -286,12 +322,16 @@ export function createPixiMediaLayer(options: PixiMediaLayerOptions): PixiMediaL
         entry.srcKey = srcKey
         entry.requestId = ++requestCounter
         const requestId = entry.requestId
-        entry.sprite.visible = false
-        entry.colorRect.visible = true
+
+        // Keep the existing texture (if any) visible while the new tier loads.
+        // Only show the color placeholder when no texture has been resolved yet.
+        const hasExistingTexture = entry.textureKey !== null
+        entry.sprite.visible = hasExistingTexture
+        entry.colorRect.visible = !hasExistingTexture
 
         void (async () => {
             try {
-                const resolved = addLodSizeParam(await resolveImageSrc(node, getWorkspaceId()), tier)
+                const resolved = addPixiLodSizeParam(await resolveImageSrc(node, getWorkspaceId()), tier)
                 const texture = await acquireTexture(resolved)
                 if (destroyed || entry?.requestId !== requestId) return
                 releaseTexture(entry.textureKey)
@@ -301,11 +341,16 @@ export function createPixiMediaLayer(options: PixiMediaLayerOptions): PixiMediaL
                 entry.sprite.height = node.dimensions.height
                 entry.sprite.visible = true
                 entry.colorRect.visible = false
+                renderNow()
             } catch (error) {
                 console.error('[PixiMediaLayer] Failed to load image texture.', error)
                 if (entry?.requestId === requestId) {
-                    entry.sprite.visible = false
-                    entry.colorRect.visible = true
+                    entry.srcKey = ''
+                    if (!hasExistingTexture) {
+                        entry.sprite.visible = false
+                        entry.colorRect.visible = true
+                    }
+                    renderNow()
                 }
             }
         })()
@@ -362,14 +407,14 @@ export function createPixiMediaLayer(options: PixiMediaLayerOptions): PixiMediaL
     }
 
     function updateVisibleImages(): void {
-        if (!ready || !lastState) return
+        if (health !== 'ready' || !lastState) return
+        const visibleRect = getVisibleWorldRect(
+            currentViewport,
+            { width: paneEl.clientWidth, height: paneEl.clientHeight },
+            CULLING_MARGIN
+        )
         const visible = new Set(
-            spatialIndex.search({
-                minX: (-currentViewport.x / currentViewport.zoom) - CULLING_MARGIN,
-                minY: (-currentViewport.y / currentViewport.zoom) - CULLING_MARGIN,
-                maxX: ((paneEl.clientWidth - currentViewport.x) / currentViewport.zoom) + CULLING_MARGIN,
-                maxY: ((paneEl.clientHeight - currentViewport.y) / currentViewport.zoom) + CULLING_MARGIN,
-            }).map((item: IndexedImage) => item.nodeId)
+            spatialIndex.search(visibleRect).map((item: IndexedImage) => item.nodeId)
         )
 
         for (const [nodeId, entry] of entries) {
@@ -380,13 +425,16 @@ export function createPixiMediaLayer(options: PixiMediaLayerOptions): PixiMediaL
     }
 
     function destroy(): void {
+        const wasReady = health === 'ready'
         destroyed = true
+        health = 'destroyed'
         for (const [nodeId, entry] of entries) {
-            setPixiOwned(viewportEl, nodeId, false)
+            setDomOwnership(nodeId, false)
             releaseTexture(entry.textureKey)
             entry.sprite.destroy()
             entry.colorRect.destroy()
         }
+        releaseAllDomOwnership()
         entries.clear()
         for (const [, entry] of textureCache) {
             entry.texture.destroy(true)
@@ -395,7 +443,7 @@ export function createPixiMediaLayer(options: PixiMediaLayerOptions): PixiMediaL
         spatialIndex.clear()
         destroyPixiImageDecoder()
         hostEl.remove()
-        if (ready) {
+        if (wasReady) {
             app.destroy(true, { children: true, texture: false, textureSource: false })
         }
     }
@@ -403,6 +451,7 @@ export function createPixiMediaLayer(options: PixiMediaLayerOptions): PixiMediaL
     return {
         sync,
         setViewport,
+        setNodeLiveTransform,
         destroy,
     }
 }

--- a/services/web-ui/src/infographics/workspace/pixiMediaLayerLogic.ts
+++ b/services/web-ui/src/infographics/workspace/pixiMediaLayerLogic.ts
@@ -1,0 +1,114 @@
+import type {
+    CanvasNode,
+    CanvasViewport,
+    ImageCanvasNode,
+} from '@lixpi/constants'
+
+export type IndexedImage = {
+    minX: number
+    minY: number
+    maxX: number
+    maxY: number
+    nodeId: string
+}
+
+export type WorldPosition = {
+    x: number
+    y: number
+}
+
+// Walks a node's parent chain and returns its absolute world position.
+// Context-region children store `position` relative to their parent; PIXI
+// renders sprites in world coordinates, so it must accumulate parent offsets
+// the same way the DOM rendering does (via `getNodeWorldPosition`).
+export function computeWorldPosition(
+    node: CanvasNode,
+    nodesById: Map<string, CanvasNode>
+): WorldPosition {
+    let x = 0
+    let y = 0
+    const visited = new Set<string>()
+    let current: CanvasNode | undefined = node
+    while (current) {
+        if (visited.has(current.nodeId)) break
+        visited.add(current.nodeId)
+        x += current.position.x
+        y += current.position.y
+        const parentId = current.parentId
+        if (!parentId) break
+        current = nodesById.get(parentId)
+    }
+    return { x, y }
+}
+
+export function buildNodesById(nodes: ReadonlyArray<CanvasNode>): Map<string, CanvasNode> {
+    return new Map(nodes.map((node: CanvasNode) => [node.nodeId, node]))
+}
+
+export type LodTier = 'color' | 'thumb-256' | 'thumb-1024' | 'full'
+
+export type PixiRendererHealth = 'initializing' | 'ready' | 'failed' | 'destroyed'
+
+export const transparentPixel = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII='
+
+export function buildPixiImageSrc(imageUrl: string, apiBaseUrl: string, token: string | false): string {
+    if (!imageUrl) return transparentPixel
+    if (imageUrl.startsWith('data:')) return imageUrl
+    if (imageUrl.startsWith('/api/')) return `${apiBaseUrl}${imageUrl}${token ? `?token=${token}` : ''}`
+    return imageUrl
+}
+
+export function isStoredImageSrc(src: string): boolean {
+    const stripped = src.replace(/[?&]token=[^&]+/, '')
+    return stripped.startsWith('/api/') || (stripped.startsWith('http') && stripped.includes('/api/images/'))
+}
+
+export function resolveStoredImagePath(node: ImageCanvasNode, workspaceId: string): string {
+    const strippedSrc = node.src.replace(/[?&]token=[^&]+/, '')
+    return isStoredImageSrc(strippedSrc)
+        ? `/api/images/${workspaceId}/${node.fileId}`
+        : strippedSrc
+}
+
+export function getPixiLodTier(zoom: number): LodTier {
+    if (zoom < 0.1) return 'color'
+    if (zoom < 0.4) return 'thumb-256'
+    if (zoom < 1) return 'thumb-1024'
+    return 'full'
+}
+
+export function addPixiLodSizeParam(url: string, tier: LodTier): string {
+    if (tier === 'full' || tier === 'color') return url
+    if (!url.includes('/api/images/')) return url
+
+    try {
+        const parsed = new URL(url, window.location.origin)
+        parsed.searchParams.set('size', tier === 'thumb-256' ? '256' : '1024')
+        return parsed.toString()
+    } catch {
+        return url
+    }
+}
+
+export function makeIndexedImage(node: ImageCanvasNode, worldPosition: WorldPosition): IndexedImage {
+    return {
+        minX: worldPosition.x,
+        minY: worldPosition.y,
+        maxX: worldPosition.x + node.dimensions.width,
+        maxY: worldPosition.y + node.dimensions.height,
+        nodeId: node.nodeId,
+    }
+}
+
+export function getVisibleWorldRect(
+    viewport: CanvasViewport,
+    paneSize: { width: number; height: number },
+    margin: number
+): Omit<IndexedImage, 'nodeId'> {
+    return {
+        minX: (-viewport.x / viewport.zoom) - margin,
+        minY: (-viewport.y / viewport.zoom) - margin,
+        maxX: ((paneSize.width - viewport.x) / viewport.zoom) + margin,
+        maxY: ((paneSize.height - viewport.y) / viewport.zoom) + margin,
+    }
+}

--- a/services/web-ui/src/infographics/workspace/pixiMediaLayerLogic.ts
+++ b/services/web-ui/src/infographics/workspace/pixiMediaLayerLogic.ts
@@ -47,6 +47,20 @@ export function buildNodesById(nodes: ReadonlyArray<CanvasNode>): Map<string, Ca
 
 export type LodTier = 'color' | 'thumb-256' | 'thumb-1024' | 'full'
 
+// Higher rank = higher pixel quality. The PIXI media layer uses this to
+// avoid the classic LoD-pyramid trap of refetching a smaller texture when
+// the user zooms out: a higher-resolution texture already on the GPU can
+// be downsampled for free by mipmapping, so zooming out should never
+// trigger a network round-trip.
+export function tierRank(tier: LodTier): number {
+    switch (tier) {
+        case 'color': return 0
+        case 'thumb-256': return 1
+        case 'thumb-1024': return 2
+        case 'full': return 3
+    }
+}
+
 export type PixiRendererHealth = 'initializing' | 'ready' | 'failed' | 'destroyed'
 
 export const transparentPixel = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII='

--- a/services/web-ui/src/infographics/workspace/pixiMediaLayerLogic.ts
+++ b/services/web-ui/src/infographics/workspace/pixiMediaLayerLogic.ts
@@ -100,6 +100,29 @@ export function makeIndexedImage(node: ImageCanvasNode, worldPosition: WorldPosi
     }
 }
 
+// =============================================================================
+// PIXI edge renderer types
+// =============================================================================
+
+export type PixiEdgeArrow = {
+    x: number
+    y: number
+    // Direction the arrowhead points (into the node it touches)
+    // left anchor = Math.PI, right = 0, top = -Math.PI/2, bottom = Math.PI/2
+    angle: number
+    size: number  // world pixels
+}
+
+export type PixiEdgeRenderDatum = {
+    id: string
+    svgPath: string     // SVG path string in world coordinates
+    strokeColor: string
+    strokeWidth: number
+    isDashed: boolean
+    arrowEnd: PixiEdgeArrow | null
+    arrowStart: PixiEdgeArrow | null
+}
+
 export function getVisibleWorldRect(
     viewport: CanvasViewport,
     paneSize: { width: number; height: number },

--- a/services/web-ui/src/infographics/workspace/rendering/mediaNodeRegistry.ts
+++ b/services/web-ui/src/infographics/workspace/rendering/mediaNodeRegistry.ts
@@ -1,0 +1,81 @@
+import type { CanvasNode, CanvasState } from '@lixpi/constants'
+import type { WorldPosition } from '$src/infographics/workspace/pixiMediaLayerLogic.ts'
+
+// Extension point for future non-image media node types (video, audio, etc.).
+// Each registered handler receives the raw canvas node and its computed world
+// position and is responsible for its own PIXI primitives and DOM ownership.
+// Image nodes are handled by the core `pixiMediaLayer` and must NOT be
+// registered here.
+
+export type MediaNodeHandler<T extends CanvasNode = CanvasNode> = {
+    // Return true when this handler owns the given node type.
+    canHandle: (node: CanvasNode) => node is T
+
+    // Called by the PIXI layer on every `sync` for nodes this handler owns.
+    upsert: (node: T, worldPosition: WorldPosition, canvasState: CanvasState) => void
+
+    // Called when the node is removed from the canvas state.
+    remove: (nodeId: string) => void
+
+    // Called on live drag/resize to keep the visual in sync with the DOM.
+    setLiveTransform: (nodeId: string, worldPosition: WorldPosition, dimensions: { width: number; height: number }) => void
+
+    // Called when the PIXI layer is being torn down.
+    destroy: () => void
+}
+
+// Phase 3 video handler would be:
+//   registry.register(createVideoNodeHandler({ ... }))
+// and the pixiMediaLayer would call registry.dispatchSync(node, ...) for any
+// node type it does not own natively.
+
+export type MediaNodeRegistry = {
+    register: <T extends CanvasNode>(handler: MediaNodeHandler<T>) => void
+    dispatchSync: (node: CanvasNode, worldPosition: WorldPosition, canvasState: CanvasState) => boolean
+    dispatchRemove: (nodeId: string) => void
+    dispatchLiveTransform: (nodeId: string, worldPosition: WorldPosition, dimensions: { width: number; height: number }) => void
+    destroy: () => void
+}
+
+export function createMediaNodeRegistry(): MediaNodeRegistry {
+    const handlers: MediaNodeHandler[] = []
+
+    function register<T extends CanvasNode>(handler: MediaNodeHandler<T>): void {
+        handlers.push(handler as MediaNodeHandler)
+    }
+
+    function dispatchSync(node: CanvasNode, worldPosition: WorldPosition, canvasState: CanvasState): boolean {
+        for (const handler of handlers) {
+            if (handler.canHandle(node)) {
+                handler.upsert(node, worldPosition, canvasState)
+                return true
+            }
+        }
+        return false
+    }
+
+    function dispatchRemove(nodeId: string): void {
+        for (const handler of handlers) {
+            handler.remove(nodeId)
+        }
+    }
+
+    function dispatchLiveTransform(
+        nodeId: string,
+        worldPosition: WorldPosition,
+        dimensions: { width: number; height: number }
+    ): void {
+        for (const handler of handlers) {
+            handler.setLiveTransform(nodeId, worldPosition, dimensions)
+        }
+    }
+
+    function destroy(): void {
+        for (const handler of handlers) {
+            handler.destroy()
+        }
+        handlers.length = 0
+    }
+
+    return { register, dispatchSync, dispatchRemove, dispatchLiveTransform, destroy }
+}

--- a/services/web-ui/src/infographics/workspace/rendering/pixiEdgeRenderer.ts
+++ b/services/web-ui/src/infographics/workspace/rendering/pixiEdgeRenderer.ts
@@ -102,45 +102,73 @@ function drawArrowhead(g: Graphics, arrow: PixiEdgeArrow, color: string): void {
     g.fill(color)
 }
 
-export function createPixiEdgeRenderer(container: Container): PixiEdgeRenderer {
-    const edgeGraphics = new Map<string, Graphics>()
+// Stable datum fingerprint used to detect when an edge actually changed.
+// Only redraws the Graphics object when the path, color, width, or arrows differ.
+function edgeDatumKey(e: PixiEdgeRenderDatum): string {
+    const a = e.arrowEnd ? `${e.arrowEnd.x},${e.arrowEnd.y},${e.arrowEnd.angle},${e.arrowEnd.size}` : ''
+    const b = e.arrowStart ? `${e.arrowStart.x},${e.arrowStart.y},${e.arrowStart.angle},${e.arrowStart.size}` : ''
+    return `${e.svgPath}|${e.strokeColor}|${e.strokeWidth}|${e.isDashed ? 1 : 0}|${a}|${b}`
+}
 
-    function clearAll(): void {
-        for (const g of edgeGraphics.values()) {
-            container.removeChild(g)
-            g.destroy()
-        }
-        edgeGraphics.clear()
+export function createPixiEdgeRenderer(container: Container): PixiEdgeRenderer {
+    // Map of edgeId → { Graphics, last datum key }. Graphics are reused
+    // across renders; geometry is only rebuilt when the datum fingerprint
+    // changes. This avoids the original O(edges) destroy+alloc+GPU-upload
+    // cycle on every `scheduleEdgesRender` call.
+    const edgeGraphics = new Map<string, { g: Graphics; key: string }>()
+
+    function destroyEntry(entry: { g: Graphics }): void {
+        container.removeChild(entry.g)
+        entry.g.destroy()
+    }
+
+    function paintEdge(g: Graphics, edge: PixiEdgeRenderDatum): void {
+        g.clear()
+        drawSvgPath(g, edge.svgPath)
+        g.stroke({
+            color: edge.strokeColor,
+            width: edge.strokeWidth,
+            cap: 'round',
+            join: 'round',
+        })
+        if (edge.arrowEnd) drawArrowhead(g, edge.arrowEnd, edge.strokeColor)
+        if (edge.arrowStart) drawArrowhead(g, edge.arrowStart, edge.strokeColor)
     }
 
     function render(edges: PixiEdgeRenderDatum[]): void {
-        clearAll()
+        const incomingIds = new Set(edges.map((e) => e.id))
 
+        // Remove Graphics for edges that no longer exist.
+        for (const [id, entry] of edgeGraphics) {
+            if (!incomingIds.has(id)) {
+                destroyEntry(entry)
+                edgeGraphics.delete(id)
+            }
+        }
+
+        // Update or create Graphics for each incoming edge.
         for (const edge of edges) {
-            const g = new Graphics()
+            const key = edgeDatumKey(edge)
+            const existing = edgeGraphics.get(edge.id)
 
-            drawSvgPath(g, edge.svgPath)
-            g.stroke({
-                color: edge.strokeColor,
-                width: edge.strokeWidth,
-                cap: 'round',
-                join: 'round',
-            })
-
-            if (edge.arrowEnd) {
-                drawArrowhead(g, edge.arrowEnd, edge.strokeColor)
+            if (existing) {
+                // Reuse Graphics object. Only repaint if the edge actually changed.
+                if (existing.key !== key) {
+                    paintEdge(existing.g, edge)
+                    existing.key = key
+                }
+            } else {
+                const g = new Graphics()
+                paintEdge(g, edge)
+                container.addChild(g)
+                edgeGraphics.set(edge.id, { g, key })
             }
-            if (edge.arrowStart) {
-                drawArrowhead(g, edge.arrowStart, edge.strokeColor)
-            }
-
-            container.addChild(g)
-            edgeGraphics.set(edge.id, g)
         }
     }
 
     function destroy(): void {
-        clearAll()
+        for (const entry of edgeGraphics.values()) destroyEntry(entry)
+        edgeGraphics.clear()
     }
 
     return { render, destroy }

--- a/services/web-ui/src/infographics/workspace/rendering/pixiEdgeRenderer.ts
+++ b/services/web-ui/src/infographics/workspace/rendering/pixiEdgeRenderer.ts
@@ -1,0 +1,147 @@
+import { Container, Graphics } from 'pixi.js'
+import type { PixiEdgeArrow, PixiEdgeRenderDatum } from '$src/infographics/workspace/pixiMediaLayerLogic.ts'
+
+export type PixiEdgeRenderer = {
+    render: (edges: PixiEdgeRenderDatum[]) => void
+    destroy: () => void
+}
+
+// Minimal SVG path parser that converts M/L/H/V/C/Q commands to PIXI Graphics
+// draw calls. This avoids relying on Graphics.svg() which is not guaranteed to
+// exist across all PIXI v8 minor versions.
+function drawSvgPath(g: Graphics, svgPath: string): void {
+    const cmdRegex = /([MmLlHhVvCcQqZz])([^MmLlHhVvCcQqZz]*)/g
+    let match: RegExpExecArray | null
+    let cx = 0
+    let cy = 0
+
+    while ((match = cmdRegex.exec(svgPath)) !== null) {
+        const cmd = match[1]
+        const args = match[2].trim().split(/[\s,]+/).filter(Boolean).map(Number)
+
+        switch (cmd) {
+            case 'M': {
+                cx = args[0]; cy = args[1]
+                g.moveTo(cx, cy)
+                for (let i = 2; i < args.length; i += 2) {
+                    cx = args[i]; cy = args[i + 1]
+                    g.lineTo(cx, cy)
+                }
+                break
+            }
+            case 'L': {
+                for (let i = 0; i < args.length; i += 2) {
+                    cx = args[i]; cy = args[i + 1]
+                    g.lineTo(cx, cy)
+                }
+                break
+            }
+            case 'H': {
+                cx = args[0]
+                g.lineTo(cx, cy)
+                break
+            }
+            case 'V': {
+                cy = args[0]
+                g.lineTo(cx, cy)
+                break
+            }
+            case 'C': {
+                for (let i = 0; i < args.length; i += 6) {
+                    cx = args[i + 4]; cy = args[i + 5]
+                    g.bezierCurveTo(args[i], args[i + 1], args[i + 2], args[i + 3], cx, cy)
+                }
+                break
+            }
+            case 'Q': {
+                for (let i = 0; i < args.length; i += 4) {
+                    cx = args[i + 2]; cy = args[i + 3]
+                    g.quadraticCurveTo(args[i], args[i + 1], cx, cy)
+                }
+                break
+            }
+            case 'Z':
+            case 'z': {
+                g.closePath()
+                break
+            }
+        }
+    }
+}
+
+// Replicates the arrowRightIcon shape (flaticon 9903638, 256×256 viewBox).
+// refX=48, refY=128 is the path attachment point; tip extends rightward.
+// Key vertices in icon space (relative to refX/refY), traced from the SVG path:
+//   tipTop=(181,-19), tipBottom=(181,19),
+//   lowerOuter=(1,122), lowerInner=(-31,96), notch=(4,0),
+//   upperInner=(-31,-96), upperOuter=(1,-122)
+function drawArrowhead(g: Graphics, arrow: PixiEdgeArrow, color: string): void {
+    const { x, y, angle, size } = arrow
+    const s = size / 256  // scale factor: markerWidth=size maps to 256px viewBox
+    const cos = Math.cos(angle)
+    const sin = Math.sin(angle)
+
+    // Transform icon-space (ix, iy) → world space around the attachment point (x, y)
+    function pt(ix: number, iy: number): [number, number] {
+        return [x + ix * s * cos - iy * s * sin, y + ix * s * sin + iy * s * cos]
+    }
+
+    const verts = [
+        pt(181, -19),   // tip top
+        pt(181,  19),   // tip bottom
+        pt(  1, 122),   // lower outer
+        pt(-31,  96),   // lower inner (V-notch bottom)
+        pt(  4,   0),   // notch center
+        pt(-31, -96),   // upper inner (V-notch top)
+        pt(  1, -122),  // upper outer
+    ]
+
+    const flat: number[] = []
+    for (const [px, py] of verts) { flat.push(px, py) }
+    g.poly(flat)
+    g.fill(color)
+}
+
+export function createPixiEdgeRenderer(container: Container): PixiEdgeRenderer {
+    const edgeGraphics = new Map<string, Graphics>()
+
+    function clearAll(): void {
+        for (const g of edgeGraphics.values()) {
+            container.removeChild(g)
+            g.destroy()
+        }
+        edgeGraphics.clear()
+    }
+
+    function render(edges: PixiEdgeRenderDatum[]): void {
+        clearAll()
+
+        for (const edge of edges) {
+            const g = new Graphics()
+
+            drawSvgPath(g, edge.svgPath)
+            g.stroke({
+                color: edge.strokeColor,
+                width: edge.strokeWidth,
+                cap: 'round',
+                join: 'round',
+            })
+
+            if (edge.arrowEnd) {
+                drawArrowhead(g, edge.arrowEnd, edge.strokeColor)
+            }
+            if (edge.arrowStart) {
+                drawArrowhead(g, edge.arrowStart, edge.strokeColor)
+            }
+
+            container.addChild(g)
+            edgeGraphics.set(edge.id, g)
+        }
+    }
+
+    function destroy(): void {
+        clearAll()
+    }
+
+    return { render, destroy }
+}

--- a/services/web-ui/src/infographics/workspace/rendering/viewportBridge.ts
+++ b/services/web-ui/src/infographics/workspace/rendering/viewportBridge.ts
@@ -1,0 +1,29 @@
+import type { CanvasViewport } from '@lixpi/constants'
+import type { PixiMediaLayer } from '$src/infographics/workspace/pixiMediaLayer.ts'
+
+export type ViewportBridge = {
+    applyViewport: (viewport: CanvasViewport) => void
+    destroy: () => void
+}
+
+type ViewportBridgeOptions = {
+    viewportEl: HTMLDivElement
+    getPixiLayer: () => PixiMediaLayer | null
+}
+
+// Applies a viewport change to both the DOM CSS transform and the PIXI world
+// in a single call so they can never fall out of sync between call sites.
+export function createViewportBridge(options: ViewportBridgeOptions): ViewportBridge {
+    const { viewportEl, getPixiLayer } = options
+
+    function applyViewport(viewport: CanvasViewport): void {
+        viewportEl.style.transform = `translate(${viewport.x}px, ${viewport.y}px) scale(${viewport.zoom})`
+        getPixiLayer()?.setViewport(viewport)
+    }
+
+    function destroy(): void {
+        // No owned resources; provided for lifecycle symmetry with other modules.
+    }
+
+    return { applyViewport, destroy }
+}

--- a/services/web-ui/src/infographics/workspace/workspace-canvas.scss
+++ b/services/web-ui/src/infographics/workspace/workspace-canvas.scss
@@ -237,6 +237,15 @@
     left: 0;
     transform-origin: 0 0;
     will-change: transform;
+    z-index: 1;
+}
+
+.workspace-pixi-media-layer {
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    z-index: 0;
+    contain: layout paint;
 }
 
 .workspace-selection-rect {
@@ -625,6 +634,21 @@
 
         .image-node-img {
             border-radius: 6px;
+        }
+    }
+
+    // The PIXI media layer owns image pixels. The DOM node still owns all
+    // interaction chrome: drag overlay, resize handles, generation border,
+    // spinner, provider badge, and context-region frame.
+    &.workspace-image-node--pixi-owned {
+        background: transparent;
+
+        &.workspace-image-node--context-region-child {
+            background: transparent;
+        }
+
+        .image-node-img {
+            opacity: 0;
         }
     }
 

--- a/services/web-ui/src/infographics/workspace/workspace-canvas.scss
+++ b/services/web-ui/src/infographics/workspace/workspace-canvas.scss
@@ -17,7 +17,7 @@
     display: flex;
     flex-direction: column;
     position: relative;
-    padding: var(--workspace-canvas-padding-top) var(--workspace-canvas-padding-inline) var(--workspace-canvas-padding-bottom);
+    padding: 0;
     overflow: hidden;
 }
 
@@ -950,7 +950,10 @@
     transform: translateZ(0);
 
     .connector-svg {
-        // SVG itself doesn't block events
+        // Visual rendering handed to PIXI. Keep SVG in DOM with opacity 0
+        // so isPointInStroke and getPointAtLength still work for hit testing
+        // and edge bubble menu positioning.
+        opacity: 0;
         pointer-events: none;
 
         .workspace-edge-node {

--- a/services/web-ui/src/infographics/workspace/workspace-canvas.scss
+++ b/services/web-ui/src/infographics/workspace/workspace-canvas.scss
@@ -259,14 +259,13 @@
 }
 
 .workspace-selection-group-overlay {
+    // Visual (border + fill) is drawn by the PIXI foreground layer so it
+    // renders above image sprites. This DOM element is kept solely as a
+    // drag hit target and has no visible styling.
     position: absolute;
     z-index: 10000;
     cursor: move;
-    border: 1px solid var(--selection-overlay-border-color);
-    background: var(--selection-overlay-background-color);
-    border-radius: 18px;
     box-sizing: border-box;
-    backdrop-filter: blur(1px);
 }
 
 .workspace-document-node {
@@ -639,12 +638,15 @@
 
     // The PIXI media layer owns image pixels. The DOM node still owns all
     // interaction chrome: drag overlay, resize handles, generation border,
-    // spinner, provider badge, and context-region frame.
+    // spinner, and provider badge. All visible frame/background styling is
+    // stripped so PIXI pixels are the only visible surface.
     &.workspace-image-node--pixi-owned {
         background: transparent;
+        box-shadow: none;
 
         &.workspace-image-node--context-region-child {
             background: transparent;
+            box-shadow: none;
         }
 
         .image-node-img {

--- a/services/web-ui/src/infographics/workspace/workspace-canvas.scss
+++ b/services/web-ui/src/infographics/workspace/workspace-canvas.scss
@@ -244,7 +244,7 @@
     position: absolute;
     inset: 0;
     pointer-events: none;
-    z-index: 0;
+    z-index: 2;
     contain: layout paint;
 }
 


### PR DESCRIPTION
Relates to #143.

Early step toward the PIXI.js v8 media layer (issue #143): adds `pixiMediaLayer`, worker-backed image decode helpers, `WorkspaceCanvas` integration, SCSS host for the Pixi view, `pixi.js` dependency, and updates CANVAS / workspace feature docs.

This PR is intentionally incremental; LoD tiers, video pipeline, masks, and further tuning land in follow-ups.