### PR TITLE
LIX-149 # Fix AI chat floating panel: 15px edge spacing, top clipping, rail height on resize

### DIFF
--- a/services/web-ui/src/infographics/workspace/WorkspaceCanvas.ts
+++ b/services/web-ui/src/infographics/workspace/WorkspaceCanvas.ts
@@ -1460,7 +1460,6 @@ export function createWorkspaceCanvas(options: WorkspaceCanvasOptions) {
 
         requestAnimationFrame(() => {
             const threadHeight = editorContainer.offsetHeight || Math.max(0, promptEl.offsetTop - 16)
-            rail.style.height = `${panelEl.offsetHeight}px`
             rail.style.setProperty('--rail-thread-height', `${threadHeight}px`)
         })
     }
@@ -2601,6 +2600,13 @@ export function createWorkspaceCanvas(options: WorkspaceCanvasOptions) {
         paneRect = paneEl.getBoundingClientRect()
         if (activeAiChatPanelWidth !== null) {
             applyActiveAiChatPanelWidth(activeAiChatPanelWidth)
+        }
+        if (activeAiChatPanelEl) {
+            const panelRail = activeAiChatPanelEl.querySelector<HTMLElement>('.workspace-ai-chat-floating-panel__rail')
+            const editorContainer = activeAiChatPanelEl.querySelector<HTMLElement>('.ai-chat-thread-node-editor')
+            if (panelRail && editorContainer) {
+                panelRail.style.setProperty('--rail-thread-height', `${editorContainer.offsetHeight}px`)
+            }
         }
         updateVisibleNodes()
     })

--- a/services/web-ui/src/infographics/workspace/workspace-canvas.scss
+++ b/services/web-ui/src/infographics/workspace/workspace-canvas.scss
@@ -7,8 +7,8 @@
     --workspace-ai-chat-sidebar-padding: 15px;
     --workspace-ai-chat-sidebar-zoom-gap: 15px;
     --workspace-canvas-padding-top: 32px;
-    --workspace-canvas-padding-inline: 16px;
-    --workspace-canvas-padding-bottom: 16px;
+    --workspace-canvas-padding-inline: 0px;
+    --workspace-canvas-padding-bottom: 0px;
 }
 
 .workspace-canvas {
@@ -480,8 +480,7 @@
 
 .workspace-ai-chat-floating-panel {
     position: absolute;
-    // top: calc(var(--workspace-ai-chat-sidebar-edge-gap) - var(--workspace-canvas-padding-top));
-    top: calc(-1 * var(--workspace-canvas-padding-top));
+    top: 0px;
     right: calc(var(--workspace-ai-chat-sidebar-edge-gap) - var(--workspace-canvas-padding-inline));
     bottom: calc(var(--workspace-ai-chat-sidebar-edge-gap) - var(--workspace-canvas-padding-bottom));
     width: var(--workspace-ai-chat-sidebar-width);
@@ -586,6 +585,7 @@
 .workspace-thread-rail.workspace-ai-chat-floating-panel__rail {
     cursor: ew-resize;
     touch-action: none;
+    height: 100%;
 }
 
 .workspace-ai-chat-floating-panel.is-resizing {


### PR DESCRIPTION
## Summary

- **15px edge spacing** — `--workspace-canvas-padding-inline` and `--workspace-canvas-padding-bottom` were both `16px`, making `calc(15px - 16px) = -1px` so the panel sat flush/clipped against the pane edges. Setting them to `0px` gives the intended `right: 15px` and `bottom: 15px`.
- **Top content no longer clipped** — `top: calc(-1 * 32px) = -32px` pushed the panel 32px above the pane, and `overflow: hidden` on `.workspace-canvas` cut off the first messages. Changed to `top: 0px`.
- **Rail height updates on resize** — The vertical drag rail had its height set once in a `requestAnimationFrame` at creation time; window/sidebar resize never updated it. Removed the JS pixel assignment and added `height: 100%` via CSS instead, plus a `--rail-thread-height` update in the existing `ResizeObserver` so the visual line and boundary circle track the editor area on every layout change.

Closes #149