### PR TITLE
LIX-162 # Fix context-region selection, drag, marquee, and visual artifact regressions

### DIFF
--- a/documentation/features/CONTEXT-REGION-CLOUDS.md
+++ b/documentation/features/CONTEXT-REGION-CLOUDS.md
@@ -227,6 +227,77 @@ Drop adoption uses the same geometry model. `scoreRectAgainstContextRegionCloud(
 
 This shared geometry rule is non-negotiable: visible pixels, body clicks, title placement, and adoption scoring must remain aligned. Rectangular math is allowed only as a cheap broad phase.
 
+## Interaction Invariants
+
+Context regions are visually different from normal rectangular nodes, but they still pass through the shared canvas interaction system. Keep these invariants intact when changing selection, marquee, drag, resize, edge, or PIXI rendering behavior.
+
+### Plain Clicks And Selection Overlays
+
+A plain click on a single context region must not draw a selection border, cloud outline, group rectangle, or filled overlay. Plain single-node clicks on editable document and AI chat thread nodes also must not show the group overlay, because that overlay can block ProseMirror editing.
+
+The selection rectangle is reserved for two states:
+
+1. More than one selected node.
+2. A selection created by marquee, even if the marquee contains only one node.
+
+This rule belongs in `shouldShowSelectionGroupOverlay()` in [WorkspaceCanvas.ts](../../services/web-ui/src/infographics/workspace/WorkspaceCanvas.ts): empty selection returns `false`, multi-selection returns `true`, and single selection returns `selectionIsFromMarquee`. Do not special-case context regions in that function.
+
+Context regions should use bounded pulse feedback for activation. Do not reintroduce selected cloud chrome in [pixiContextRegionLayer.ts](../../services/web-ui/src/infographics/workspace/rendering/pixiContextRegionLayer.ts). The PIXI context-region layer should draw the cloud surface and title, not a second selected silhouette.
+
+### Marquee Starts Only From Empty Canvas Movement
+
+Marquee selection must start only when all of these are true:
+
+1. The pointer down happened on empty canvas after image/document/thread/context-region hit precedence failed.
+2. The user moved farther than the drag threshold.
+3. Any previous marquee and stale selection state was cleared before assigning the new `marqueeSelection` object.
+
+Do not create `marqueeSelection` during `mousedown`. Creating it before pointer movement makes plain empty-canvas clicks clear selection and makes context-region cloud clicks look like accidental marquee starts.
+
+When checking context-region hits before marquee, use both layers of hit detection:
+
+- `contextRegionLayer.hitTest(worldPoint)` for title/body shape hits.
+- The region's visual cloud bounds from `getSelectionOverlayBoundsForNode(...)` as a fallback before treating the point as empty canvas.
+
+The bounds fallback exists because the visible cloud can extend beyond the transparent DOM proxy rectangle and beyond the strict interior/title hit zones. It is only a guard against empty-canvas fallthrough; foreground image/document/thread hits still win first.
+
+### Drag And Resize Scope
+
+Dragging or resizing a context region must not automatically include connected, anchored, generated, or leaf nodes. A region move is visually about the region and its real contained descendants, not every related image or generated output in the graph.
+
+The drag plan should follow these rules:
+
+| Situation | Drag participants |
+|---|---|
+| Single context-region drag | The region plus real parented descendants needed for live visual movement. |
+| Multi-selected context-region drag | Every selected context region plus each selected region's real parented descendants. |
+| Anchored image nodes | Excluded from context-region drag sets. |
+| Generated output image nodes | Excluded from context-region drag sets. |
+| Connected nodes through edges | Excluded unless they are also real selected or parented drag participants. |
+
+Keep this logic centralized in [workspaceDragPlan.ts](../../services/web-ui/src/infographics/workspace/workspaceDragPlan.ts). Do not rebuild ad hoc participant sets in `WorkspaceCanvas.ts`.
+
+### Edge Visibility And PIXI Graphics Paths
+
+Connector lines are independent of node selection. Selecting a context region must not filter, hide, or resync edges differently. If a selection visual creates artifacts around connectors, fix the selection visual or PIXI renderer; do not hide edges based on selected nodes.
+
+PIXI `Graphics` path state must be isolated. In [pixiEdgeRenderer.ts](../../services/web-ui/src/infographics/workspace/rendering/pixiEdgeRenderer.ts), edge painting starts a new path before drawing the SVG path, and arrowhead drawing starts and closes its own path before fill. Without that path isolation, a previous edge segment can weld to a later arrowhead and produce long stray lines.
+
+The same cleanup principle applies to context-region chrome: if `Graphics` children are rebuilt, remove and destroy old children first. Stale `Graphics` objects are a common cause of ghost outlines after selection, drag, or rerender.
+
+### Regression Coverage
+
+Changes in this area should update or add focused regression coverage in the same commit:
+
+| Test file | What it protects |
+|---|---|
+| [workspace-canvas.test.ts](../../services/web-ui/src/infographics/workspace/workspace-canvas.test.ts) | Selection overlay source rules, no plain-click border, marquee defer-until-move behavior, context-region bounds hit fallback, connector visibility, and pane hit precedence. |
+| [workspaceDragPlan.test.ts](../../services/web-ui/src/infographics/workspace/workspaceDragPlan.test.ts) | Context-region drag participant sets, multi-region group drag, and anchored/generated image exclusions. |
+| [pixiContextRegionLayer.test.ts](../../services/web-ui/src/infographics/workspace/rendering/pixiContextRegionLayer.test.ts) | No selected-cloud chrome path and proper `Graphics` cleanup. |
+| [pixiEdgeRenderer.test.ts](../../services/web-ui/src/infographics/workspace/rendering/pixiEdgeRenderer.test.ts) | Edge and arrowhead `Graphics` path isolation. |
+
+If a future change intentionally changes one of these invariants, update this document and the tests together so the new behavior is explicit.
+
 ## Workspace Integration
 
 `WorkspaceCanvas` remains the orchestration owner:
@@ -234,9 +305,11 @@ This shared geometry rule is non-negotiable: visible pixels, body clicks, title 
 - Builds region datums from current canvas nodes and AI chat thread titles.
 - Keeps transparent context-region DOM nodes registered with `data-node-id` so existing drag, selection, connection, and parent-child paths still work.
 - Skips resize-handle creation for context-region proxies.
-- Routes pane-background clicks through image/document precedence, then cloud hit testing.
+- Routes pane-background clicks through image/document precedence, then cloud hit testing, then visual-bounds fallback before empty-canvas marquee handling.
 - Calls the normal drag machinery when a cloud body/title is clicked, so dragging a region still uses the existing canvas drag lifecycle.
-- Includes context-region descendants in the live dragged set so children move visually with the parent region during drag, not only after commit.
+- Includes context-region descendants in the live dragged set so real parented children move visually with the parent region during drag, not only after commit.
+- Excludes anchored/generated image leaves from context-region drag sets unless a future interaction model explicitly makes those nodes real region children.
+- Shows the group selection rectangle only for marquee-sourced selections or multi-selection, never for a plain single context-region click.
 - Uses CO2 cloud scoring when releasing a dragged node to decide parent adoption.
 - Keeps generated output image nodes from being adopted into regions.
 
@@ -337,6 +410,18 @@ Do not apply masks component-by-component. Apply the CO2 mask once at the end of
 
 Do not create a separate selected outline cloud sprite. Selection should stay subtle and should not require a second silhouette copy.
 
+Do not make `shouldShowSelectionGroupOverlay()` depend on context-region node type. Plain single context-region clicks must not draw a border; only marquee selection and multi-selection show the rectangle.
+
+Do not assign `marqueeSelection` on `mousedown`. Defer marquee state until pointer movement crosses the threshold from an empty-canvas start.
+
+Do not let context-region visual bounds fall through to empty-canvas marquee. The visible cloud can extend beyond the transparent DOM proxy and strict body/title hit shape.
+
+Do not include anchored image leaves, generated output images, or merely connected nodes in context-region drag/resize participant sets.
+
+Do not hide or filter connector edges based on node selection. Connector visibility is independent of selection state.
+
+Do not draw multiple PIXI `Graphics` paths without path isolation or cleanup. Begin a fresh path before edge drawing, begin and close arrowhead paths, and destroy stale context-region chrome children before replacing them.
+
 Do not animate every cloud continuously. Use bounded event pulses and then stop scheduling frames.
 
 Do not generate or upload per-region textures while dragging, resizing, panning, or zooming. Runtime gestures should update transforms and culling only.
@@ -364,7 +449,14 @@ Do not treat persisted `canvasState.viewport` as authoritative during an active 
 | Cloud pixels and clicks do not line up | Renderer shape and geometry shape diverged | Compare CO2 constants in `pixiContextRegionLayer.ts` and `contextRegionClouds.ts`. |
 | Cloud becomes a square/rectangle hit target | Rectangular broad phase used as final hit | Inspect `hitTestContextRegionCloud(...)` and adoption scoring. |
 | Image clicks inside a region start dragging the region | Foreground hit precedence broke | Check `getNodeHitBeforeContextRegion(...)` in `WorkspaceCanvas.ts`. |
+| Clicking the visible cloud starts marquee | Visual-bounds fallback was removed or runs after empty-canvas handling | Check `getContextRegionBoundsHit(...)` and pane `mousedown` ordering in `WorkspaceCanvas.ts`. |
+| Plain click on a context region draws a rectangle or border | `shouldShowSelectionGroupOverlay()` special-cased context regions | The function should return `false` for empty selection, `true` for multi-selection, and `selectionIsFromMarquee` for single selection. |
+| Empty-canvas click clears selection even without movement | Marquee state is created on `mousedown` | Create `marqueeSelection` only after pointer movement exceeds the threshold. |
 | Children lag behind while dragging a region | Descendants were not included in live drag set | Check `includeContextRegionDescendants(...)` and live transforms. |
+| Multi-selected context regions do not move together | Drag plan ignored the selected set for context-region drags | Check `computeWorkspaceDragPlan(...)` in `workspaceDragPlan.ts`. |
+| Anchored/generated images move with a context region unexpectedly | Drag participant set includes related leaves instead of real region children | Check anchored-image and generated-output exclusions in `workspaceDragPlan.ts`. |
+| Connector lines disappear when selecting regions | Edge rendering is filtered by selection | Keep `connectionManager.syncEdges(...)` and PIXI edge sync independent of selected node IDs. |
+| Long stray lines appear through arrowheads | PIXI `Graphics` path state leaked between edge path and arrowhead drawing | Check `beginPath()` / `closePath()` isolation in `pixiEdgeRenderer.ts`. |
 | A ghost cloud appears on selection | Separate selection silhouette was reintroduced | Keep selection chrome separate from a duplicate cloud sprite. |
 | Texture looks pale or flat | Gradient/overlay alpha washed out color and grain | Check seafoam gradient mix, bloom overlays, and final alpha. |
 | Border does not match the cloud | Border drawn as generic stroke or separate sprite | Use the baked exact vector ring path controlled by `contextRegionCloudBorderEnabled`. |

--- a/services/web-ui/src/infographics/workspace/WorkspaceCanvas.ts
+++ b/services/web-ui/src/infographics/workspace/WorkspaceCanvas.ts
@@ -576,6 +576,19 @@ export function createWorkspaceCanvas(options: WorkspaceCanvasOptions) {
         return null
     }
 
+    function getContextRegionBoundsHit(point: { x: number; y: number }): ContextRegionNode | null {
+        if (!currentCanvasState) return null
+        const nodesById = getCanvasNodesById(currentCanvasState.nodes)
+        const threadMap = new Map<string, AiChatThread>(currentAiChatThreads.map((thread) => [thread.threadId, thread]))
+        for (let i = currentCanvasState.nodes.length - 1; i >= 0; i--) {
+            const node = currentCanvasState.nodes[i]
+            if (!isContextRegionCanvasNode(node)) continue
+            const rect = getSelectionOverlayBoundsForNode(node, nodesById, threadMap)
+            if (rectContainsCanvasPoint(rect, point)) return node
+        }
+        return null
+    }
+
     function getConnectedNodeIds(nodeId: string, canvasState: CanvasState | null = currentCanvasState): string[] {
         if (!canvasState) return []
         const connectedNodeIds = new Set<string>()
@@ -971,13 +984,25 @@ export function createWorkspaceCanvas(options: WorkspaceCanvasOptions) {
         }
     }
 
+    function clearMarqueeInteractionState(): void {
+        marqueeSelection = null
+        hideSelectionRectElement()
+        pixiMediaLayer?.setSelectionOverlayBounds(null)
+        if (selectionGroupOverlayEl) applyStyle(selectionGroupOverlayEl, { display: 'none' })
+    }
+
     function getSelectionOverlayBounds(): Rect | null {
         if (!currentCanvasState || !shouldShowSelectionGroupOverlay()) return null
         if (marqueeSelection) return null
 
+        const nodesById = getCanvasNodesById(currentCanvasState.nodes)
         const overlayNodeIds = new Set<string>()
         for (const nodeId of selectedNodeIds) {
             overlayNodeIds.add(nodeId)
+
+            const selectedNode = nodesById.get(nodeId)
+            if (selectedNode && isContextRegionCanvasNode(selectedNode)) continue
+
             for (const anchor of getValidAnchorsForCanvasThread(nodeId)) {
                 overlayNodeIds.add(anchor.imageNodeId)
             }
@@ -985,9 +1010,7 @@ export function createWorkspaceCanvas(options: WorkspaceCanvasOptions) {
 
         const overlayNodes = currentCanvasState.nodes.filter((node: CanvasNode) => overlayNodeIds.has(node.nodeId))
         if (overlayNodes.length === 0) return null
-        if (overlayNodes.every((node: CanvasNode) => isContextRegionCanvasNode(node))) return null
 
-        const nodesById = getCanvasNodesById(currentCanvasState.nodes)
         const threadMap = new Map<string, AiChatThread>(currentAiChatThreads.map((thread) => [thread.threadId, thread]))
 
         const bounds = overlayNodes.map((node: CanvasNode) => {
@@ -1014,11 +1037,33 @@ export function createWorkspaceCanvas(options: WorkspaceCanvasOptions) {
         }
     }
 
+    function shouldUseSelectionGroupOverlayHitTarget(): boolean {
+        if (!currentCanvasState || !shouldShowSelectionGroupOverlay()) return false
+        if (selectedNodeIds.size > 1) return true
+
+        for (const nodeId of selectedNodeIds) {
+            const node = currentCanvasState.nodes.find((candidate: CanvasNode) => candidate.nodeId === nodeId)
+            if (node && !isContextRegionCanvasNode(node)) return true
+        }
+
+        return false
+    }
+
+    function shouldFillSelectionOverlayBounds(): boolean {
+        if (!currentCanvasState) return true
+        if (selectedNodeIds.size !== 1) return true
+        if (selectionIsFromMarquee) return true
+
+        const selectedNodeId = getSingleSelectedNodeId()
+        const selectedNode = currentCanvasState.nodes.find((node: CanvasNode) => node.nodeId === selectedNodeId)
+        return !(selectedNode && isContextRegionCanvasNode(selectedNode))
+    }
+
     function updateSelectionGroupOverlayElement(): void {
         const bounds = getSelectionOverlayBounds()
 
         // PIXI draws the visible selection overlay for image nodes.
-        pixiMediaLayer?.setSelectionOverlayBounds(bounds)
+        pixiMediaLayer?.setSelectionOverlayBounds(bounds, { fill: shouldFillSelectionOverlayBounds() })
 
         // The DOM element is kept invisible but in place as a drag hit target.
         // Its background/border are stripped in the SCSS so PIXI owns the visual.
@@ -1026,6 +1071,11 @@ export function createWorkspaceCanvas(options: WorkspaceCanvasOptions) {
         if (!overlayEl) return
 
         if (!bounds) {
+            applyStyle(overlayEl, { display: 'none' })
+            return
+        }
+
+        if (!shouldUseSelectionGroupOverlayHitTarget()) {
             applyStyle(overlayEl, { display: 'none' })
             return
         }
@@ -1107,15 +1157,25 @@ export function createWorkspaceCanvas(options: WorkspaceCanvasOptions) {
         showFloatingInput(singleSelectedNodeId)
     }
 
+    function clearSelectedEdgeSelection(force = false): void {
+        if (!force && !selectedEdgeId) return
+        selectedEdgeId = null
+        connectionManager?.deselect()
+        hideEdgeBubbleMenu()
+    }
+
     function setSelectedNodes(nextSelectedNodeIds: Set<string>, fromMarquee = false): void {
         const prevSelectedNodeIds = selectedNodeIds
         selectedNodeIds = nextSelectedNodeIds
         selectionIsFromMarquee = fromMarquee && nextSelectedNodeIds.size > 0
+        if (currentCanvasState) connectionManager?.syncEdges(currentCanvasState.edges)
+        if (nextSelectedNodeIds.size > 0) clearSelectedEdgeSelection()
         updateNodeSelectionClasses(prevSelectedNodeIds, selectedNodeIds)
         updateSelectionGroupOverlayElement()
         updateSelectionDrivenUi()
         pixiMediaLayer?.setSelectedImageNodes(nextSelectedNodeIds)
         syncContextRegionLayer(undefined)
+        scheduleEdgesRender()
         for (const nodeId of nextSelectedNodeIds) {
             if (prevSelectedNodeIds.has(nodeId)) continue
             const node = currentCanvasState?.nodes.find((candidate: CanvasNode) => candidate.nodeId === nodeId)
@@ -3467,7 +3527,7 @@ export function createWorkspaceCanvas(options: WorkspaceCanvasOptions) {
             }
         }
 
-        const dragOverlay = html`<div className="node-drag-overlay nopan" onmousedown=${(e: MouseEvent) => handleDragStart(e, node.nodeId, isContextRegion ? { suppressPaneClick: true, allowSelection: false } : {})}></div>` as HTMLDivElement
+        const dragOverlay = html`<div className="node-drag-overlay nopan" onmousedown=${(e: MouseEvent) => handleDragStart(e, node.nodeId, isContextRegion ? { suppressPaneClick: true } : {})}></div>` as HTMLDivElement
         nodeEl.appendChild(dragOverlay)
 
         return { nodeEl, dragOverlay }
@@ -4121,6 +4181,7 @@ export function createWorkspaceCanvas(options: WorkspaceCanvasOptions) {
         // Find the node to check if it's an image (for aspect ratio locking)
         const node = currentCanvasState.nodes.find((n: CanvasNode) => n.nodeId === nodeId)
         const isImageNode = node?.type === 'image'
+        const isContextRegionResize = isContextRegionNodeElement(nodeEl)
 
         // PIXI owns image pixels; the hidden DOM <img> can finish loading after
         // workspace switches, so do not derive resize behavior from DOM natural
@@ -4164,7 +4225,7 @@ export function createWorkspaceCanvas(options: WorkspaceCanvasOptions) {
 
         // Anchored image resize constraints
         const resizeAnchor = isImageNode ? getValidAnchorForCanvasImage(nodeId) : undefined
-        const resizeAnchorsForThread = !isImageNode ? getValidAnchorsForCanvasThread(nodeId) : []
+        const resizeAnchorsForThread = !isImageNode && !isContextRegionResize ? getValidAnchorsForCanvasThread(nodeId) : []
 
         const handleMouseMove = (moveEvent: MouseEvent) => {
             const deltaX = directionX === 0 ? 0 : ((moveEvent.clientX - startX) / currentZoom) * directionX
@@ -4232,7 +4293,7 @@ export function createWorkspaceCanvas(options: WorkspaceCanvasOptions) {
             pixiMediaLayer?.setNodeLiveTransform(nodeId, liveResizePosition, liveResizeDimensions)
             contextRegionLayer?.setNodeLiveTransform(nodeId, liveResizePosition, liveResizeDimensions)
             pixiMediaLayer?.setSelectedImageNodes(selectedNodeIds)
-            pixiMediaLayer?.setSelectionOverlayBounds(getSelectionOverlayBounds())
+            pixiMediaLayer?.setSelectionOverlayBounds(getSelectionOverlayBounds(), { fill: shouldFillSelectionOverlayBounds() })
 
             // If resizing a region child, visibly grow the region in real-time.
             // `nodeEl.style.left/top` is in world coordinates; convert to parent-
@@ -4751,7 +4812,8 @@ export function createWorkspaceCanvas(options: WorkspaceCanvasOptions) {
         const start = getCanvasPointFromClient(event.clientX, event.clientY)
         const nodeHit = getNodeHitBeforeContextRegion(start)
         const regionHit = nodeHit ? { kind: 'none' as const } : contextRegionLayer?.hitTest(start) ?? { kind: 'none' as const }
-        const hitNodeId = nodeHit?.nodeId ?? (regionHit.kind !== 'none' ? regionHit.nodeId : null)
+        const regionBoundsHit = nodeHit || regionHit.kind !== 'none' ? null : getContextRegionBoundsHit(start)
+        const hitNodeId = nodeHit?.nodeId ?? (regionHit.kind !== 'none' ? regionHit.nodeId : regionBoundsHit?.nodeId ?? null)
         if (!hitNodeId) return
 
         suspendPanZoomForNodePointer(hitNodeId)
@@ -4778,6 +4840,10 @@ export function createWorkspaceCanvas(options: WorkspaceCanvasOptions) {
         }
 
         const regionHit = contextRegionLayer?.hitTest(point) ?? { kind: 'none' as const }
+        if (regionHit.kind === 'none' && getContextRegionBoundsHit(point)) {
+            paneEl.style.cursor = ''
+            return
+        }
         paneEl.style.cursor = regionHit.kind === 'resize' ? regionHit.cursor : ''
     }
 
@@ -4811,10 +4877,19 @@ export function createWorkspaceCanvas(options: WorkspaceCanvasOptions) {
                 : undefined
             handleDragStart(event, regionHit.nodeId, {
                 suppressPaneClick: true,
-                allowSelection: false,
                 onClick: () => {
                     if (regionNode && isContextRegionCanvasNode(regionNode)) activateAiChatPanel(regionNode, thread)
                 },
+            })
+            return
+        }
+
+        const regionBoundsHit = getContextRegionBoundsHit(start)
+        if (regionBoundsHit) {
+            const thread = currentAiChatThreads.find((candidate) => candidate.threadId === regionBoundsHit.referenceId)
+            handleDragStart(event, regionBoundsHit.nodeId, {
+                suppressPaneClick: true,
+                onClick: () => activateAiChatPanel(regionBoundsHit, thread),
             })
             return
         }
@@ -4823,15 +4898,7 @@ export function createWorkspaceCanvas(options: WorkspaceCanvasOptions) {
 
         event.preventDefault()
         event.stopPropagation()
-        connectionManager?.cancelTransientConnection()
-
-        marqueeSelection = {
-            start,
-            current: start,
-            moved: false,
-        }
-        updateSelectionRectElement()
-        updateSelectionGroupOverlayElement()
+        clearMarqueeInteractionState()
 
         if (panZoom) {
             panZoom.update({
@@ -4844,15 +4911,26 @@ export function createWorkspaceCanvas(options: WorkspaceCanvasOptions) {
         }
 
         const handleMouseMove = (moveEvent: MouseEvent) => {
-            if (!marqueeSelection) return
-
-            marqueeSelection.current = getCanvasPointFromClient(moveEvent.clientX, moveEvent.clientY)
             const movedX = Math.abs(moveEvent.clientX - event.clientX)
             const movedY = Math.abs(moveEvent.clientY - event.clientY)
-            marqueeSelection.moved = marqueeSelection.moved || movedX > 3 || movedY > 3
-            updateSelectionRectElement()
+            if (!marqueeSelection && movedX <= 3 && movedY <= 3) return
 
-            if (!marqueeSelection.moved) return
+            if (!marqueeSelection) {
+                connectionManager?.cancelTransientConnection()
+                clearSelectedEdgeSelection(true)
+                clearMarqueeInteractionState()
+                if (selectedNodeIds.size > 0) setSelectedNodes(new Set())
+
+                marqueeSelection = {
+                    start,
+                    current: start,
+                    moved: true,
+                }
+            }
+
+            marqueeSelection.current = getCanvasPointFromClient(moveEvent.clientX, moveEvent.clientY)
+            marqueeSelection.moved = true
+            updateSelectionRectElement()
 
             const selectedIds = getSelectableNodeIdsInRect(getCanvasRectFromSelection(marqueeSelection))
             setSelectedNodes(new Set(selectedIds), true)
@@ -5115,8 +5193,7 @@ export function createWorkspaceCanvas(options: WorkspaceCanvasOptions) {
 
         if (isCanvasBackgroundTarget(e.target)) {
             clearNodeSelection()
-            selectedEdgeId = null
-            hideEdgeBubbleMenu()
+            clearSelectedEdgeSelection(true)
         }
     })
 
@@ -5129,10 +5206,8 @@ export function createWorkspaceCanvas(options: WorkspaceCanvasOptions) {
         )
 
         if (e.key === 'Escape') {
-            selectedEdgeId = null
-            connectionManager?.deselect()
+            clearSelectedEdgeSelection(true)
             selectNode(null)
-            hideEdgeBubbleMenu()
             return
         }
 

--- a/services/web-ui/src/infographics/workspace/pixiMediaLayer.ts
+++ b/services/web-ui/src/infographics/workspace/pixiMediaLayer.ts
@@ -73,6 +73,10 @@ export type SelectionColors = {
     groupOverlayFill: string
 }
 
+type SelectionOverlayOptions = {
+    fill?: boolean
+}
+
 export type PixiMediaLayer = {
     sync: (canvasState: CanvasState | null) => void
     setViewport: (viewport: CanvasViewport) => void
@@ -83,7 +87,7 @@ export type PixiMediaLayer = {
     ) => void
     setSelectedImageNodes: (selectedNodeIds: Set<string>) => void
     setMarqueeRect: (worldRect: { x: number; y: number; width: number; height: number } | null) => void
-    setSelectionOverlayBounds: (worldBounds: { x: number; y: number; width: number; height: number } | null) => void
+    setSelectionOverlayBounds: (worldBounds: { x: number; y: number; width: number; height: number } | null, options?: SelectionOverlayOptions) => void
     setPixiEdges: (edges: PixiEdgeRenderDatum[]) => void
     getHealth: () => PixiRendererHealth
     destroy: () => void
@@ -923,7 +927,7 @@ export function createPixiMediaLayer(options: PixiMediaLayerOptions): PixiMediaL
         scheduleRender()
     }
 
-    function setSelectionOverlayBounds(worldBounds: { x: number; y: number; width: number; height: number } | null): void {
+    function setSelectionOverlayBounds(worldBounds: { x: number; y: number; width: number; height: number } | null, options: SelectionOverlayOptions = {}): void {
         if (destroyed) return
         if (!worldBounds || !Number.isFinite(worldBounds.width) || !Number.isFinite(worldBounds.height) || worldBounds.width <= 0 || worldBounds.height <= 0) {
             groupOverlayGraphics = destroyForegroundGraphics(groupOverlayGraphics)
@@ -937,7 +941,7 @@ export function createPixiMediaLayer(options: PixiMediaLayerOptions): PixiMediaL
 
         const r = 18 / (currentViewport.zoom || 1)
         groupOverlayGraphics.roundRect(worldBounds.x, worldBounds.y, worldBounds.width, worldBounds.height, r)
-        groupOverlayGraphics.fill({ color: selectionColors.groupOverlayFill })
+        if (options.fill !== false) groupOverlayGraphics.fill({ color: selectionColors.groupOverlayFill })
         groupOverlayGraphics.stroke({ color: selectionColors.groupOverlayStroke, width: 1 / (currentViewport.zoom || 1) })
 
         scheduleRender()

--- a/services/web-ui/src/infographics/workspace/rendering/pixiContextRegionLayer.test.ts
+++ b/services/web-ui/src/infographics/workspace/rendering/pixiContextRegionLayer.test.ts
@@ -1,0 +1,51 @@
+'use strict'
+
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+
+function loadSource(): string {
+    return readFileSync(resolve(__dirname, 'pixiContextRegionLayer.ts'), 'utf-8')
+}
+
+function extractTopLevelFunction(source: string, functionName: string): string {
+    const match = new RegExp(`function\\s+${functionName}\\b[\\s\\S]*?^\\}`, 'm').exec(source)
+    expect(match, `${functionName} should exist`).not.toBeNull()
+    return match![0]
+}
+
+// =============================================================================
+// Context-region selected chrome regression guards
+// =============================================================================
+
+describe('pixiContextRegionLayer — selected chrome regression guards', () => {
+    const source = loadSource()
+
+    it('does not draw cloud-shaped selection chrome', () => {
+        expect(source.includes('function drawSelectedCloudChrome'), 'cloud-shaped selection chrome must stay removed').toBe(false)
+
+        const drawChrome = extractTopLevelFunction(source, 'drawChrome')
+        expect(drawChrome.includes('datum.selected'), 'drawChrome must not branch on selected state').toBe(false)
+        expect(drawChrome.includes('drawSelectedCloudChrome'), 'drawChrome must not call selected-cloud chrome').toBe(false)
+    })
+
+    it('purges stale Graphics children before redrawing chrome', () => {
+        const drawChrome = extractTopLevelFunction(source, 'drawChrome')
+
+        expect(drawChrome).toContain('for (const child of [...entry.container.children])')
+        expect(drawChrome).toContain('if (!(child instanceof Graphics)) continue')
+        expect(drawChrome).toContain('entry.container.removeChild(child)')
+        expect(drawChrome).toContain('child.destroy()')
+        expect(drawChrome).toContain('entry.container.addChildAt(chrome, 1)')
+        expect(drawChrome).toContain('entry.chrome = chrome')
+    })
+
+    it('keeps live region data aligned during drag transforms', () => {
+        const setNodeLiveTransform = extractTopLevelFunction(source, 'setNodeLiveTransform')
+
+        expect(setNodeLiveTransform).toContain('const liveDatum = {')
+        expect(setNodeLiveTransform).toContain('currentRegions = currentRegions.map((region) => region.nodeId === nodeId ? liveDatum : region)')
+        expect(setNodeLiveTransform).toContain('syncEntry(liveDatum)')
+        expect(setNodeLiveTransform).toContain('updateVisibility()')
+    })
+})

--- a/services/web-ui/src/infographics/workspace/rendering/pixiContextRegionLayer.ts
+++ b/services/web-ui/src/infographics/workspace/rendering/pixiContextRegionLayer.ts
@@ -10,7 +10,6 @@ import {
 import { webUiThemeSettings } from '$src/webUiThemeSettings.ts'
 import { html, applyStyle } from '$src/utils/domTemplates.ts'
 import { getVisibleWorldRect, type PixiRendererHealth, type WorldPosition } from '$src/infographics/workspace/pixiMediaLayerLogic.ts'
-import * as contextRegionCloudGeometry from '$src/infographics/workspace/rendering/contextRegionClouds.ts'
 import {
     getContextRegionCloudBleed,
     getContextRegionCloudBounds,
@@ -661,32 +660,6 @@ function getBackdropRect(datum: ContextRegionCloudDatum, style: ContextRegionClo
     }
 }
 
-function drawSelectedCloudChrome(chrome: Graphics, datum: ContextRegionCloudDatum, style: ContextRegionCloudStyle, zoom: number): void {
-    if (typeof contextRegionCloudGeometry.getContextRegionCloudOutline !== 'function') return
-
-    const outline = contextRegionCloudGeometry.getContextRegionCloudOutline(datum, style)
-    const strokeWidth = 1.5 / zoom
-    const fill = { color: webUiThemeSettings.selectionOverlayBackgroundColor }
-    const stroke = {
-        color: webUiThemeSettings.selectionOverlayBorderColor,
-        width: strokeWidth,
-        join: 'round' as const,
-        cap: 'round' as const,
-    }
-
-    for (const polygon of outline.polygons) {
-        chrome.poly(polygon, true)
-        chrome.fill(fill)
-        chrome.stroke(stroke)
-    }
-
-    for (const circle of outline.circles) {
-        chrome.circle(circle.x, circle.y, circle.radius)
-        chrome.fill(fill)
-        chrome.stroke(stroke)
-    }
-}
-
 function drawTitle(text: Text, datum: ContextRegionCloudDatum, style: ContextRegionCloudStyle, zoom: number): void {
     const rect = getContextRegionCloudTitleRect(datum, zoom)
 
@@ -703,15 +676,21 @@ function drawTitle(text: Text, datum: ContextRegionCloudDatum, style: ContextReg
 }
 
 function drawChrome(entry: PixiContextRegionEntry, viewport: ContextRegionViewport): void {
-    const { datum, chrome, titleText } = entry
+    const { datum, titleText } = entry
     const zoom = Math.max(viewport.zoom, 0.01)
+
+    for (const child of [...entry.container.children]) {
+        if (!(child instanceof Graphics)) continue
+        entry.container.removeChild(child)
+        child.destroy()
+    }
+
+    const chrome = new Graphics()
+    entry.container.addChildAt(chrome, 1)
+    entry.chrome = chrome
+
     const style = getContextRegionCloudStyle(datum.nodeId, datum.width, datum.height)
-    chrome.clear()
-
     drawTitle(titleText, datum, style, zoom)
-
-    if (!datum.selected) return
-    drawSelectedCloudChrome(chrome, datum, style, zoom)
 }
 
 function getGeometryKey(datum: ContextRegionCloudDatum, viewport: ContextRegionViewport): string {
@@ -855,13 +834,16 @@ export function createPixiContextRegionLayer(options: PixiContextRegionLayerOpti
     function setNodeLiveTransform(nodeId: string, worldPosition: WorldPosition, dimensions: { width: number; height: number }): void {
         const entry = entries.get(nodeId)
         if (!entry) return
-        syncEntry({
+        const liveDatum = {
             ...entry.datum,
             x: worldPosition.x,
             y: worldPosition.y,
             width: dimensions.width,
             height: dimensions.height,
-        })
+        }
+        currentRegions = currentRegions.map((region) => region.nodeId === nodeId ? liveDatum : region)
+        syncEntry(liveDatum)
+        updateVisibility()
         scheduleRender()
     }
 

--- a/services/web-ui/src/infographics/workspace/rendering/pixiEdgeRenderer.test.ts
+++ b/services/web-ui/src/infographics/workspace/rendering/pixiEdgeRenderer.test.ts
@@ -1,0 +1,60 @@
+'use strict'
+
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+
+function loadSource(): string {
+    return readFileSync(resolve(__dirname, 'pixiEdgeRenderer.ts'), 'utf-8')
+}
+
+function extractTopLevelFunction(source: string, functionName: string): string {
+    const start = source.indexOf(`function ${functionName}`)
+    expect(start, `${functionName} should exist`).toBeGreaterThanOrEqual(0)
+
+    const bodyStart = source.indexOf('{', start)
+    expect(bodyStart, `${functionName} should have a function body`).toBeGreaterThan(start)
+
+    let depth = 0
+    for (let index = bodyStart; index < source.length; index++) {
+        if (source[index] === '{') depth++
+        if (source[index] === '}') depth--
+        if (depth === 0) return source.slice(start, index + 1)
+    }
+
+    throw new Error(`${functionName} function body did not close`)
+}
+
+// =============================================================================
+// PIXI edge path regression guards
+// =============================================================================
+
+describe('pixiEdgeRenderer — path isolation regression guards', () => {
+    const source = loadSource()
+
+    it('starts a fresh path before stroking the SVG edge path', () => {
+        const paintEdge = extractTopLevelFunction(source, 'paintEdge')
+
+        const clearIndex = paintEdge.indexOf('g.clear()')
+        const beginPathIndex = paintEdge.indexOf('g.beginPath()')
+        const drawPathIndex = paintEdge.indexOf('drawSvgPath(g, edge.svgPath)')
+        const strokeIndex = paintEdge.indexOf('g.stroke({')
+
+        expect(beginPathIndex).toBeGreaterThan(clearIndex)
+        expect(drawPathIndex).toBeGreaterThan(beginPathIndex)
+        expect(strokeIndex).toBeGreaterThan(drawPathIndex)
+    })
+
+    it('draws arrowheads as closed independent paths', () => {
+        const drawArrowhead = extractTopLevelFunction(source, 'drawArrowhead')
+
+        const beginPathIndex = drawArrowhead.indexOf('g.beginPath()')
+        const polyIndex = drawArrowhead.indexOf('g.poly(flat)')
+        const closePathIndex = drawArrowhead.indexOf('g.closePath()')
+        const fillIndex = drawArrowhead.indexOf('g.fill(color)')
+
+        expect(polyIndex).toBeGreaterThan(beginPathIndex)
+        expect(closePathIndex).toBeGreaterThan(polyIndex)
+        expect(fillIndex).toBeGreaterThan(closePathIndex)
+    })
+})

--- a/services/web-ui/src/infographics/workspace/rendering/pixiEdgeRenderer.ts
+++ b/services/web-ui/src/infographics/workspace/rendering/pixiEdgeRenderer.ts
@@ -98,7 +98,9 @@ function drawArrowhead(g: Graphics, arrow: PixiEdgeArrow, color: string): void {
 
     const flat: number[] = []
     for (const [px, py] of verts) { flat.push(px, py) }
+    g.beginPath()
     g.poly(flat)
+    g.closePath()
     g.fill(color)
 }
 
@@ -124,6 +126,7 @@ export function createPixiEdgeRenderer(container: Container): PixiEdgeRenderer {
 
     function paintEdge(g: Graphics, edge: PixiEdgeRenderDatum): void {
         g.clear()
+        g.beginPath()
         drawSvgPath(g, edge.svgPath)
         g.stroke({
             color: edge.strokeColor,

--- a/services/web-ui/src/infographics/workspace/workspace-canvas.test.ts
+++ b/services/web-ui/src/infographics/workspace/workspace-canvas.test.ts
@@ -184,6 +184,14 @@ describe('PIXI media layer — first sync geometry', () => {
 		expect(fnBody).toContain('entry.colorRectW = w')
 		expect(fnBody).toContain('entry.colorRectH = h')
 	})
+
+	it('supports optional fill for selection overlays', () => {
+		expectSourceToContain(ts, 'type SelectionOverlayOptions = {')
+		expectSourceToContain(ts, 'fill?: boolean')
+		expectSourceToContain(ts, 'options: SelectionOverlayOptions = {}')
+		expectSourceToContain(ts, 'if (options.fill !== false) groupOverlayGraphics.fill({ color: selectionColors.groupOverlayFill })')
+		expectSourceToContain(ts, 'groupOverlayGraphics.stroke({ color: selectionColors.groupOverlayStroke')
+	})
 })
 
 // =============================================================================
@@ -1129,9 +1137,10 @@ describe('Workspace canvas — multi-selection and group drag', () => {
 	// Selection overlay rules
 	// -------------------------------------------------------------------------
 
-	it('tracks selection source (marquee vs click) to control overlay visibility', () => {
-		// selectionIsFromMarquee flag controls whether a single-node selection
-		// shows the overlay. Plain click = no overlay. Marquee = overlay.
+	it('tracks selection source to control overlay visibility', () => {
+		// selectionIsFromMarquee controls whether a single-node selection shows
+		// the overlay. Plain clicks on any node, including context regions, do
+		// not draw a selection rectangle. Marquee selection does.
 		expectSourceToContain(ts, 'let selectionIsFromMarquee = false')
 		expectSourceToContain(ts, 'return selectionIsFromMarquee')
 
@@ -1153,6 +1162,8 @@ describe('Workspace canvas — multi-selection and group drag', () => {
 
 		// Single node = overlay only if selected via marquee
 		expect(fnBody).toContain('return selectionIsFromMarquee')
+		expect(fnBody).not.toContain('const selectedNodeId = getSingleSelectedNodeId()')
+		expect(fnBody).not.toContain('const selectedNode = currentCanvasState.nodes.find')
 
 		// Must NOT contain any node-type special casing (e.g. aiChatThread)
 		expect(fnBody).not.toContain("'aiChatThread'")
@@ -1201,7 +1212,6 @@ describe('Workspace canvas — multi-selection and group drag', () => {
 		expectSourceToContain(ts, 'function getSelectionOverlayBoundsForNode(')
 		expectSourceToContain(ts, 'function updateSelectionGroupOverlayElement(): void')
 		expectSourceToContain(ts, 'if (!currentCanvasState || !shouldShowSelectionGroupOverlay()) return null')
-		expectSourceToContain(ts, 'if (overlayNodes.every((node: CanvasNode) => isContextRegionCanvasNode(node))) return null')
 		expectSourceToContain(ts, 'getContextRegionCloudBounds(datum)')
 		expectSourceToContain(ts, 'updateSelectionGroupOverlayElement()')
 		expectSourceToContain(scss, '.workspace-selection-group-overlay')
@@ -1215,6 +1225,24 @@ describe('Workspace canvas — multi-selection and group drag', () => {
 		expectSourceToContain(ts, 'if (!shouldShowSelectionGroupOverlay()) return')
 		expectSourceToContain(ts, 'const primaryNodeId = Array.from(selectedNodeIds)[0]')
 		expectSourceToContain(ts, 'handleDragStart(event, primaryNodeId)')
+	})
+
+	it('keeps connector lines visible when context regions are selected', () => {
+		expectSourceNotToContain(ts, 'function getEdgesForConnectionManager')
+		expectSourceNotToContain(ts, 'syncEdges(getEdgesForConnectionManager')
+		expectSourceNotToContain(ts, 'selectedContextRegionNodeIds')
+		expectSourceToContain(ts, 'connectionManager?.syncEdges(nextState.edges)')
+		expectSourceToContain(ts, 'connectionManager.syncEdges(currentCanvasState.edges)')
+	})
+
+	it('keeps the overlay hit target active for multi-region group drag but hidden for a single region', () => {
+		const fnMatch = ts.match(/function\s+shouldUseSelectionGroupOverlayHitTarget[\s\S]*?^    \}/m)
+		expect(fnMatch).not.toBeNull()
+		const fnBody = fnMatch![0]
+
+		expect(fnBody).toContain('if (selectedNodeIds.size > 1) return true')
+		expect(fnBody).toContain('if (node && !isContextRegionCanvasNode(node)) return true')
+		expect(fnBody).toContain('return false')
 	})
 
 	it('wires selection colors from webUiThemeSettings to CSS custom properties', () => {
@@ -1268,6 +1296,74 @@ describe('Workspace canvas — multi-selection and group drag', () => {
 		const fnMatch = ts.match(/function\s+isCanvasBackgroundTarget[\s\S]*?^    \}/m)
 		expect(fnMatch).not.toBeNull()
 		expect(fnMatch![0]).toContain("'.workspace-ai-chat-floating-panel'")
+	})
+
+	it('does not start marquee when mousedown is inside a context-region node bounds', () => {
+		expectSourceToContain(ts, 'function getContextRegionBoundsHit(point: { x: number; y: number }): ContextRegionNode | null')
+		expectSourceToContain(ts, 'const threadMap = new Map<string, AiChatThread>(currentAiChatThreads.map((thread) => [thread.threadId, thread]))')
+		expectSourceToContain(ts, 'if (!isContextRegionCanvasNode(node)) continue')
+		expectSourceToContain(ts, 'const rect = getSelectionOverlayBoundsForNode(node, nodesById, threadMap)')
+		expectSourceToContain(ts, 'if (rectContainsCanvasPoint(rect, point)) return node')
+
+		const paneMouseDownMatch = ts.match(/function\s+handlePaneMouseDown[\s\S]*?^    \}/m)
+		expect(paneMouseDownMatch).not.toBeNull()
+		const fnBody = paneMouseDownMatch![0]
+
+		const boundsHitIndex = fnBody.indexOf('const regionBoundsHit = getContextRegionBoundsHit(start)')
+		const boundsReturnIndex = fnBody.indexOf('if (regionBoundsHit) {')
+		const marqueeIndex = fnBody.indexOf('marqueeSelection = {')
+
+		expect(boundsHitIndex).toBeGreaterThanOrEqual(0)
+		expect(boundsReturnIndex).toBeGreaterThan(boundsHitIndex)
+		expect(marqueeIndex).toBeGreaterThan(boundsReturnIndex)
+		expect(fnBody).toContain('handleDragStart(event, regionBoundsHit.nodeId, {')
+		expect(fnBody).toContain('return')
+	})
+
+	it('creates marquee selection state only after empty-canvas pointer movement', () => {
+		const paneMouseDownMatch = ts.match(/function\s+handlePaneMouseDown[\s\S]*?^    \}/m)
+		expect(paneMouseDownMatch).not.toBeNull()
+		const fnBody = paneMouseDownMatch![0]
+
+		const moveHandlerIndex = fnBody.indexOf('const handleMouseMove = (moveEvent: MouseEvent) => {')
+		const movementGateIndex = fnBody.indexOf('if (!marqueeSelection && movedX <= 3 && movedY <= 3) return')
+		const marqueeCreateIndex = fnBody.indexOf('marqueeSelection = {')
+		const selectedClearIndex = fnBody.indexOf('if (selectedNodeIds.size > 0) setSelectedNodes(new Set())')
+
+		expect(moveHandlerIndex).toBeGreaterThanOrEqual(0)
+		expect(movementGateIndex).toBeGreaterThan(moveHandlerIndex)
+		expect(selectedClearIndex).toBeGreaterThan(movementGateIndex)
+		expect(marqueeCreateIndex).toBeGreaterThan(selectedClearIndex)
+		expect(fnBody).toContain('moved: true')
+	})
+
+	it('does not draw any overlay for a plain single context-region click', () => {
+		const showMatch = ts.match(/function\s+shouldShowSelectionGroupOverlay[\s\S]*?^    \}/m)
+		expect(showMatch).not.toBeNull()
+		const showBody = showMatch![0]
+
+		expect(showBody).toContain('return selectionIsFromMarquee')
+		expect(showBody).not.toContain('isContextRegionCanvasNode(selectedNode)')
+
+		const fillMatch = ts.match(/function\s+shouldFillSelectionOverlayBounds[\s\S]*?^    \}/m)
+		expect(fillMatch).not.toBeNull()
+		const fillBody = fillMatch![0]
+
+		expect(fillBody).toContain('if (selectedNodeIds.size !== 1) return true')
+		expect(fillBody).toContain('if (selectionIsFromMarquee) return true')
+		expect(fillBody).toContain('return !(selectedNode && isContextRegionCanvasNode(selectedNode))')
+		expectSourceToContain(ts, 'pixiMediaLayer?.setSelectionOverlayBounds(bounds, { fill: shouldFillSelectionOverlayBounds() })')
+		expectSourceToContain(ts, 'pixiMediaLayer?.setSelectionOverlayBounds(getSelectionOverlayBounds(), { fill: shouldFillSelectionOverlayBounds() })')
+	})
+
+	it('treats context-region bounds as node hits before pan/zoom can start marquee', () => {
+		const panePointerDownMatch = ts.match(/function\s+handlePanePointerDown[\s\S]*?^    \}/m)
+		expect(panePointerDownMatch).not.toBeNull()
+		const fnBody = panePointerDownMatch![0]
+
+		expect(fnBody).toContain("const regionBoundsHit = nodeHit || regionHit.kind !== 'none' ? null : getContextRegionBoundsHit(start)")
+		expect(fnBody).toContain("const hitNodeId = nodeHit?.nodeId ?? (regionHit.kind !== 'none' ? regionHit.nodeId : regionBoundsHit?.nodeId ?? null)")
+		expect(fnBody).toContain('suspendPanZoomForNodePointer(hitNodeId)')
 	})
 
 	// -------------------------------------------------------------------------
@@ -1335,10 +1431,20 @@ describe('Workspace canvas — multi-selection and group drag', () => {
 		expectSourceToContain(ts, "node.type === 'aiChatThread' && hiddenEmptyThreadNodeIds.has(node.nodeId) && rectsOverlap(rect, getSelectionBoundsForNode(node))")
 	})
 
-	it('includes anchored AI images when computing the selection overlay bounds', () => {
-		expectSourceToContain(ts, 'for (const anchor of getValidAnchorsForCanvasThread(nodeId)) {')
-		expectSourceToContain(ts, 'overlayNodeIds.add(anchor.imageNodeId)')
-		expectSourceToContain(ts, 'const rect = getSelectionOverlayBoundsForNode(node, nodesById, threadMap)')
+	it('includes anchored AI images for thread selection overlay bounds but not for context-region overlay bounds', () => {
+		const fnMatch = ts.match(/function\s+getSelectionOverlayBounds\(\): Rect \| null[\s\S]*?^    \}/m)
+		expect(fnMatch).not.toBeNull()
+		const fnBody = fnMatch![0]
+
+		const selectedNodeIndex = fnBody.indexOf('const selectedNode = nodesById.get(nodeId)')
+		const contextRegionContinueIndex = fnBody.indexOf('if (selectedNode && isContextRegionCanvasNode(selectedNode)) continue')
+		const anchorLoopIndex = fnBody.indexOf('for (const anchor of getValidAnchorsForCanvasThread(nodeId)) {')
+
+		expect(selectedNodeIndex).toBeGreaterThanOrEqual(0)
+		expect(contextRegionContinueIndex).toBeGreaterThan(selectedNodeIndex)
+		expect(anchorLoopIndex).toBeGreaterThan(contextRegionContinueIndex)
+		expect(fnBody).toContain('overlayNodeIds.add(anchor.imageNodeId)')
+		expect(fnBody).toContain('const rect = getSelectionOverlayBoundsForNode(node, nodesById, threadMap)')
 	})
 
 	// -------------------------------------------------------------------------
@@ -1432,16 +1538,17 @@ describe('Workspace canvas — selection interaction regression guards', () => {
 		//   2. Overlay covers the thread content → resize handles activate
 		//   3. User cannot click into ProseMirror to edit text
 		//
-		// Invariant: shouldShowSelectionGroupOverlay must NOT check node.type
+		// Invariant: shouldShowSelectionGroupOverlay must NOT check raw node.type,
+		// the aiChatThread string, or context-region node types. Plain single-node
+		// clicks never draw the group overlay; marquee/multi-selection does.
 		const fnMatch = ts.match(/function\s+shouldShowSelectionGroupOverlay[\s\S]*?^    \}/m)
 		expect(fnMatch).not.toBeNull()
 		const fnBody = fnMatch![0]
 
 		expect(fnBody).not.toContain("'aiChatThread'")
 		expect(fnBody).not.toContain('node.type')
-		// Must not look up individual node objects to check their type
-		expect(fnBody).not.toContain('getNode(')
-		expect(fnBody).not.toContain('.nodes.find')
+		expect(fnBody).not.toContain('isContextRegionCanvasNode(selectedNode)')
+		expect(fnBody).toContain('return selectionIsFromMarquee')
 	})
 
 	it('REGRESSION: clicking AI chat thread content must NOT trigger selectNode', () => {
@@ -1696,13 +1803,32 @@ describe('Marquee selection — stale group overlay suppressed during active mar
 		expectSourceToContain(fnBody, 'if (marqueeSelection) return null')
 	})
 
-	it('calls updateSelectionGroupOverlayElement immediately when marquee starts', () => {
-		// The group overlay must be cleared right when marqueeSelection is assigned,
-		// so the stale overlay from a prior selection does not linger during the drag.
-		const marqueStartMatch = ts.match(
-			/marqueeSelection\s*=\s*\{[\s\S]*?moved:\s*false[\s\S]*?\}[\s\S]*?updateSelectionRectElement\(\)[\s\S]*?updateSelectionGroupOverlayElement\(\)/
+	it('clears stale selection before creating marquee selection state', () => {
+		// Marquee state is now deferred until the pointer actually moves from empty
+		// canvas. Any old group overlay must be cleared before marqueeSelection is
+		// assigned, and marquee-selected nodes must be applied while marqueeSelection
+		// is active so getSelectionOverlayBounds suppresses the stale overlay.
+		const mouseMoveMatches = Array.from(
+			ts.matchAll(/const handleMouseMove = \(moveEvent: MouseEvent\) => \{[\s\S]*?const handleMouseUp = \(\) => \{/g),
+			(match) => match[0],
 		)
-		expect(marqueStartMatch).not.toBeNull()
+		const fnBody = mouseMoveMatches.find((body) =>
+			body.includes('getSelectableNodeIdsInRect(getCanvasRectFromSelection(marqueeSelection))'),
+		)
+		expect(fnBody).toBeDefined()
+
+		expect(fnBody!).toContain('if (!marqueeSelection && movedX <= 3 && movedY <= 3) return')
+
+		const clearIndex = fnBody!.indexOf('if (selectedNodeIds.size > 0) setSelectedNodes(new Set())')
+		const marqueeStartIndex = fnBody!.indexOf('marqueeSelection = {')
+		expect(clearIndex).toBeGreaterThan(-1)
+		expect(marqueeStartIndex).toBeGreaterThan(clearIndex)
+		expect(fnBody!).toContain('moved: true')
+
+		const updateRectIndex = fnBody!.indexOf('updateSelectionRectElement()')
+		const marqueeSelectIndex = fnBody!.indexOf('setSelectedNodes(new Set(selectedIds), true)')
+		expect(updateRectIndex).toBeGreaterThan(marqueeStartIndex)
+		expect(marqueeSelectIndex).toBeGreaterThan(updateRectIndex)
 	})
 
 	it('calls updateSelectionGroupOverlayElement on mouseup after clearing marqueeSelection', () => {

--- a/services/web-ui/src/infographics/workspace/workspaceDragPlan.test.ts
+++ b/services/web-ui/src/infographics/workspace/workspaceDragPlan.test.ts
@@ -171,6 +171,67 @@ describe('computeWorkspaceDragPlan — context region drags', () => {
         expect(result.allowCollisionResolution).toBe(false)
     })
 
+    it('moves every selected context region as one group', () => {
+        const regionA = makeRegion({ nodeId: 'region-a' })
+        const regionB = makeRegion({ nodeId: 'region-b' })
+
+        const result = plan({
+            nodes: [regionA, regionB],
+            primaryNodeId: 'region-b',
+            selectedNodeIds: new Set(['region-a', 'region-b']),
+        })
+
+        expect(result.resolvedNodeId).toBe('region-b')
+        expect(result.draggedNodeIds).toEqual(['region-a', 'region-b'])
+        expect(result.moveAnchoredImageIds).toEqual([])
+        expect(result.allowProximityConnection).toBe(false)
+        expect(result.allowCollisionResolution).toBe(false)
+    })
+
+    it('moves selected regions with their real children but not unrelated leaves', () => {
+        const regionA = makeRegion({ nodeId: 'region-a' })
+        const regionB = makeRegion({ nodeId: 'region-b' })
+        const childA = makeImage({ nodeId: 'child-a', parentId: 'region-a', position: { x: 48, y: 72 } })
+        const childB = makeImage({ nodeId: 'child-b', parentId: 'region-b', position: { x: 64, y: 80 } })
+        const unrelatedLeaf = makeImage({ nodeId: 'unrelated-leaf', position: { x: 900, y: 240 } })
+
+        const result = plan({
+            nodes: [regionA, childA, regionB, childB, unrelatedLeaf],
+            primaryNodeId: 'region-a',
+            selectedNodeIds: new Set(['region-a', 'region-b']),
+        })
+
+        expect(result.draggedNodeIds).toEqual(['region-a', 'region-b', 'child-b', 'child-a'])
+        expect(result.draggedNodeIds).not.toContain('unrelated-leaf')
+        expect(result.moveAnchoredImageIds).toEqual([])
+    })
+
+    it('moves mixed selected groups that include a context region without pulling generated outputs', () => {
+        const region = makeRegion({ nodeId: 'region-1', referenceId: 'thread-1' })
+        const document = makeDocument({ nodeId: 'doc-1' })
+        const generatedOutput = makeImage({
+            nodeId: 'generated-output',
+            position: { x: 760, y: 120 },
+            generatedBy: {
+                aiChatThreadId: 'thread-1',
+                responseId: 'response-1',
+                aiModel: 'openai:gpt-4o' as any,
+                responseMessageId: 'message-1',
+            },
+        })
+
+        const result = plan({
+            nodes: [region, document, generatedOutput],
+            primaryNodeId: 'region-1',
+            selectedNodeIds: new Set(['region-1', 'doc-1', 'generated-output']),
+        })
+
+        expect(result.draggedNodeIds).toEqual(['region-1', 'doc-1'])
+        expect(result.draggedNodeIds).not.toContain('generated-output')
+        expect(result.moveAnchoredImageIds).toEqual([])
+        expect(result.allowCollisionResolution).toBe(false)
+    })
+
     it('disables global collision resolution for context region release', () => {
         const result = plan({
             nodes: [makeRegion({ nodeId: 'region-1' })],

--- a/services/web-ui/src/infographics/workspace/workspaceDragPlan.ts
+++ b/services/web-ui/src/infographics/workspace/workspaceDragPlan.ts
@@ -57,12 +57,14 @@ export function computeWorkspaceDragPlan(input: WorkspaceDragPlanInput): Workspa
     const isContextRegionDrag = isContextRegionNode(primaryNode)
 
     let baseDraggedNodeIds: string[]
-    if (isContextRegionDrag) {
-        baseDraggedNodeIds = [resolvedNodeId]
-    } else if (!input.selectedNodeIds.has(resolvedNodeId)) {
+    if (!input.selectedNodeIds.has(resolvedNodeId)) {
         baseDraggedNodeIds = [resolvedNodeId]
     } else {
-        baseDraggedNodeIds = Array.from(input.selectedNodeIds).filter((nodeId) => !input.isAnchoredImageNode(nodeId))
+        baseDraggedNodeIds = Array.from(input.selectedNodeIds).filter((nodeId) => {
+            if (input.isAnchoredImageNode(nodeId)) return false
+            if (isContextRegionDrag && isGeneratedOutputImageNode(nodesById.get(nodeId))) return false
+            return true
+        })
         if (baseDraggedNodeIds.length === 0) baseDraggedNodeIds = [resolvedNodeId]
     }
 


### PR DESCRIPTION
Closes #162

## What changed

Ten interconnected bugs in the workspace canvas, all affecting context-region node behaviour during selection, drag, marquee, and rendering.

### Production fixes

| File | Change |
|------|--------|
| `WorkspaceCanvas.ts` | `shouldShowSelectionGroupOverlay` now returns `true` only for multi-select or marquee-sourced single-select — plain click on any node type draws no border. Marquee state creation deferred to first `mousemove` above movement threshold (no more accidental marquee on plain click). Added `getContextRegionBoundsHit` so clicks on the full visual cloud area register as node hits and never fall through to marquee. Removed edge-visibility filtering that hid connector lines when regions were selected. |
| `workspaceDragPlan.ts` | Context-region drag now uses the full `selectedNodeIds` set so multi-region group drag works. Anchored-image and generated-output nodes excluded from region drag sets. |
| `pixiContextRegionLayer.ts` | `drawChrome()` destroys stale `Graphics` children before creating a new one, eliminating ghost cloud artefacts. Removed selected-cloud chrome draw path entirely — rectangular overlay handles multi-select/marquee visuals. |
| `pixiEdgeRenderer.ts` | `paintEdge` calls `beginPath()` before drawing SVG path; `drawArrowhead` wraps its poly in `beginPath()`/`closePath()`, eliminating the stray line artefacts through arrowheads. |
| `pixiMediaLayer.ts` | `setSelectionOverlayBounds` accepts optional `{ fill?: boolean }` for stroke-only overlays. |

### Tests added / updated

| File | Coverage |
|------|----------|
| `workspace-canvas.test.ts` | Regression guards for all ten bugs: overlay visibility rules, deferred marquee creation, context-region bounds hit detection, connector visibility, no-border-on-plain-click, multi-select/marquee overlay invariants. |
| `workspaceDragPlan.test.ts` | Multi-region group drag moves all selected regions; generated-output nodes excluded from drag sets. |
| `pixiContextRegionLayer.test.ts` | Source-shape guard: no selected-cloud chrome code path exists. |
| `pixiEdgeRenderer.test.ts` | Source-shape guard: `beginPath`/`closePath` isolation around edge and arrowhead drawing. |

## Verification

- 677 tests pass (`Test Files 27 passed, Tests 677 passed`).
- Manually verified: plain region click → no border; empty-canvas drag → marquee only after movement; multi-region drag → all regions move; connector lines always visible; no ghost cloud outlines.
