### PR TITLE
LIX-166 # Fix image node connectors always anchor to vertical midpoint

### DIFF
--- a/services/web-ui/src/infographics/workspace/README.md
+++ b/services/web-ui/src/infographics/workspace/README.md
@@ -215,6 +215,8 @@ New PIXI image entries must initialize their sprite position, size, and placehol
 
 Image resize always preserves aspect ratio using the `aspectRatio` value stored when the image was uploaded.
 
+Connector edges that enter or leave image nodes always anchor to the vertical midpoint of the image side. Image endpoints do not slide, fan out, or follow message-level source alignment; non-image endpoints can still use those behaviors.
+
 On image load the client verifies the image's natural aspect ratio and will auto-correct the node's dimensions if a mismatch is detected (this helps self-heal nodes created by older clients). When a correction is necessary the client persists the corrected `dimensions` and updated `aspectRatio` via the normal canvas state persistence flow (`onCanvasStateChange` / `commitCanvasState`).
 
 Resizing uses a stable diagonal-based calculation to preserve aspect ratio smoothly during diagonal drags and avoid axis-switching jumps that can cause jitter during resize. Resize handles are dynamically sized and positioned (computed from the current viewport zoom) so they remain a uniform screen-pixel size and precisely aligned to node corners regardless of canvas zoom or node scale. The handles are invisible hitboxes until their own corner is hovered; selecting or hovering the body of a node does not reveal every handle. This zoom-compensated sizing is controlled by `useZoomCompensatedResizeHandleScaling` in `webUiSettings.ts` (default `true`).

--- a/services/web-ui/src/infographics/workspace/WorkspaceConnectionManager.test.ts
+++ b/services/web-ui/src/infographics/workspace/WorkspaceConnectionManager.test.ts
@@ -677,7 +677,7 @@ describe('computeSpreadTValues — targetT auto-alignment', () => {
 		// Source center at y=50 (0 + 100/2), target at y=0..100
 		// idealT = (50 - 0) / 100 = 0.5 → straight line through center
 		const source = makeNode({ nodeId: 'src', type: 'aiChatThread', position: { x: 0, y: 0 }, dimensions: { width: 200, height: 100 } })
-		const target = makeNode({ nodeId: 'tgt', type: 'image', position: { x: 300, y: 0 }, dimensions: { width: 200, height: 100 } })
+		const target = makeNode({ nodeId: 'tgt', type: 'document', position: { x: 300, y: 0 }, dimensions: { width: 200, height: 100 } })
 
 		const edge = makeEdge({ edgeId: 'e-1', sourceNodeId: 'src', targetNodeId: 'tgt' })
 		const result = computeSpreadTValues([edge], [source, target])
@@ -690,7 +690,7 @@ describe('computeSpreadTValues — targetT auto-alignment', () => {
 		// Source center at y=50, target at y=200..400
 		// idealT = (50 - 200) / 200 = -0.75 → clamp to 0.065
 		const source = makeNode({ nodeId: 'src', type: 'aiChatThread', position: { x: 0, y: 0 }, dimensions: { width: 200, height: 100 } })
-		const target = makeNode({ nodeId: 'tgt', type: 'image', position: { x: 300, y: 200 }, dimensions: { width: 200, height: 200 } })
+		const target = makeNode({ nodeId: 'tgt', type: 'document', position: { x: 300, y: 200 }, dimensions: { width: 200, height: 200 } })
 
 		const edge = makeEdge({ edgeId: 'e-1', sourceNodeId: 'src', targetNodeId: 'tgt' })
 		const result = computeSpreadTValues([edge], [source, target])
@@ -703,7 +703,7 @@ describe('computeSpreadTValues — targetT auto-alignment', () => {
 		// Source center at y=550, target at y=0..200
 		// idealT = (550 - 0) / 200 = 2.75 → clamp to 0.935
 		const source = makeNode({ nodeId: 'src', type: 'aiChatThread', position: { x: 0, y: 500 }, dimensions: { width: 200, height: 100 } })
-		const target = makeNode({ nodeId: 'tgt', type: 'image', position: { x: 300, y: 0 }, dimensions: { width: 200, height: 200 } })
+		const target = makeNode({ nodeId: 'tgt', type: 'document', position: { x: 300, y: 0 }, dimensions: { width: 200, height: 200 } })
 
 		const edge = makeEdge({ edgeId: 'e-1', sourceNodeId: 'src', targetNodeId: 'tgt' })
 		const result = computeSpreadTValues([edge], [source, target])
@@ -716,7 +716,7 @@ describe('computeSpreadTValues — targetT auto-alignment', () => {
 		// Source center at y=150 (100 + 100/2), target at y=200..400 (height=200)
 		// idealT = (150 - 200) / 200 = -0.25 → clamp to 0.065
 		const source = makeNode({ nodeId: 'src', type: 'aiChatThread', position: { x: 0, y: 100 }, dimensions: { width: 200, height: 100 } })
-		const target = makeNode({ nodeId: 'tgt', type: 'image', position: { x: 300, y: 200 }, dimensions: { width: 200, height: 200 } })
+		const target = makeNode({ nodeId: 'tgt', type: 'document', position: { x: 300, y: 200 }, dimensions: { width: 200, height: 200 } })
 
 		const edge = makeEdge({ edgeId: 'e-1', sourceNodeId: 'src', targetNodeId: 'tgt' })
 		const result = computeSpreadTValues([edge], [source, target])
@@ -742,7 +742,7 @@ describe('computeSpreadTValues — targetT auto-alignment', () => {
 		try {
 			// Source far above target → should clamp to 0.1 (not 0.025)
 			const source = makeNode({ nodeId: 'src', type: 'aiChatThread', position: { x: 0, y: 0 }, dimensions: { width: 200, height: 100 } })
-			const target = makeNode({ nodeId: 'tgt', type: 'image', position: { x: 300, y: 500 }, dimensions: { width: 200, height: 200 } })
+			const target = makeNode({ nodeId: 'tgt', type: 'document', position: { x: 300, y: 500 }, dimensions: { width: 200, height: 200 } })
 			const edge = makeEdge({ edgeId: 'e-1', sourceNodeId: 'src', targetNodeId: 'tgt' })
 			const result = computeSpreadTValues([edge], [source, target])
 
@@ -768,7 +768,7 @@ describe('computeSpreadTValues — targetT auto-alignment', () => {
 		try {
 			// Target height (100) is below threshold (200) → snap to center
 			const source = makeNode({ nodeId: 'src', type: 'aiChatThread', position: { x: 0, y: 0 }, dimensions: { width: 200, height: 100 } })
-			const target = makeNode({ nodeId: 'tgt', type: 'image', position: { x: 300, y: 0 }, dimensions: { width: 200, height: 100 } })
+			const target = makeNode({ nodeId: 'tgt', type: 'document', position: { x: 300, y: 0 }, dimensions: { width: 200, height: 100 } })
 			const edge = makeEdge({ edgeId: 'e-1', sourceNodeId: 'src', targetNodeId: 'tgt' })
 			const result = computeSpreadTValues([edge], [source, target])
 
@@ -785,7 +785,7 @@ describe('computeSpreadTValues — targetT auto-alignment', () => {
 		try {
 			// Target height (300) exceeds threshold (200) → slide freely
 			const source = makeNode({ nodeId: 'src', type: 'aiChatThread', position: { x: 0, y: 0 }, dimensions: { width: 200, height: 100 } })
-			const target = makeNode({ nodeId: 'tgt', type: 'image', position: { x: 300, y: 0 }, dimensions: { width: 200, height: 300 } })
+			const target = makeNode({ nodeId: 'tgt', type: 'document', position: { x: 300, y: 0 }, dimensions: { width: 200, height: 300 } })
 			const edge = makeEdge({ edgeId: 'e-1', sourceNodeId: 'src', targetNodeId: 'tgt' })
 			const result = computeSpreadTValues([edge], [source, target])
 
@@ -797,6 +797,16 @@ describe('computeSpreadTValues — targetT auto-alignment', () => {
 		} finally {
 			;(webUiThemeSettings as Record<string, unknown>).aiChatThreadRailMinSlideHeight = original
 		}
+	})
+
+	it('keeps targetT at 0.5 when the target is an image node', () => {
+		const source = makeNode({ nodeId: 'src', type: 'aiChatThread', position: { x: 0, y: 500 }, dimensions: { width: 200, height: 100 } })
+		const target = makeNode({ nodeId: 'tgt', type: 'image', position: { x: 300, y: 0 }, dimensions: { width: 200, height: 300 } })
+
+		const edge = makeEdge({ edgeId: 'e-1', sourceNodeId: 'src', targetNodeId: 'tgt', targetT: 0.9 })
+		const result = computeSpreadTValues([edge], [source, target])
+
+		expect(result.get('e-1')!.targetT).toBe(0.5)
 	})
 })
 
@@ -834,6 +844,19 @@ describe('computeSpreadTValues — sourceT spreading', () => {
 		// Both within 0.35–0.65 range
 		expect(t1).toBeGreaterThanOrEqual(0.35)
 		expect(t2).toBeLessThanOrEqual(0.65)
+	})
+
+	it('keeps sourceT at 0.5 when the source is an image node', () => {
+		const source = makeNode({ nodeId: 'src', type: 'image', position: { x: 0, y: 0 }, dimensions: { width: 200, height: 600 } })
+		const target1 = makeNode({ nodeId: 'tgt-1', type: 'aiChatThread', position: { x: 300, y: 0 }, dimensions: { width: 200, height: 100 } })
+		const target2 = makeNode({ nodeId: 'tgt-2', type: 'aiChatThread', position: { x: 300, y: 200 }, dimensions: { width: 200, height: 100 } })
+
+		const edge1 = makeEdge({ edgeId: 'e-1', sourceNodeId: 'src', targetNodeId: 'tgt-1', sourceT: 0.2 })
+		const edge2 = makeEdge({ edgeId: 'e-2', sourceNodeId: 'src', targetNodeId: 'tgt-2', sourceT: 0.8 })
+		const result = computeSpreadTValues([edge1, edge2], [source, target1, target2])
+
+		expect(result.get('e-1')!.sourceT).toBe(0.5)
+		expect(result.get('e-2')!.sourceT).toBe(0.5)
 	})
 })
 
@@ -939,6 +962,41 @@ describe('WorkspaceConnectionManager — computeMessageSourceT', () => {
 
 		// render() should succeed — the message element will be found
 		expect(() => manager.render()).not.toThrow()
+	})
+
+	it('keeps image target midpoint when sourceMessageId adjusts source anchor', () => {
+		const onPixiEdgesReady = vi.fn()
+		const messageConfig = { ...createMockConfig(), onPixiEdgesReady }
+		const messageManager = new WorkspaceConnectionManager(messageConfig)
+		const chatNode = makeNode({ nodeId: 'chat-1', type: 'aiChatThread', position: { x: 0, y: 0 }, dimensions: { width: 300, height: 600 } })
+		const imgNode = makeNode({ nodeId: 'img-1', type: 'image', position: { x: 400, y: 0 }, dimensions: { width: 400, height: 400 } })
+
+		const nodeEl = document.createElement('div')
+		const messageEl = document.createElement('div')
+		messageEl.setAttribute('data-message-id', 'msg-abc')
+		nodeEl.appendChild(messageEl)
+
+		vi.spyOn(nodeEl, 'getBoundingClientRect').mockReturnValue({
+			top: 0, bottom: 600, left: 0, right: 300, width: 300, height: 600, x: 0, y: 0, toJSON: () => ({})
+		})
+		vi.spyOn(messageEl, 'getBoundingClientRect').mockReturnValue({
+			top: 500, bottom: 550, left: 0, right: 300, width: 300, height: 50, x: 0, y: 500, toJSON: () => ({})
+		})
+
+		messageManager.syncNodes([chatNode, imgNode])
+		messageManager.syncEdges([makeEdge({
+			edgeId: 'e-1',
+			sourceNodeId: 'chat-1',
+			targetNodeId: 'img-1',
+			sourceMessageId: 'msg-abc',
+		})])
+		messageManager.registerNodeElement('chat-1', nodeEl as HTMLDivElement)
+		messageManager.render()
+
+		const pixiEdges = onPixiEdgesReady.mock.calls.at(-1)?.[0] as Array<{ id: string; arrowEnd: { y: number } | null }>
+		const renderedEdge = pixiEdges.find((edge) => edge.id === 'e-1')
+
+		expect(renderedEdge?.arrowEnd?.y).toBeCloseTo(imgNode.position.y + imgNode.dimensions.height / 2, 5)
 	})
 
 	it('ignores message elements whose viewport rect is outside the registered node rect', () => {

--- a/services/web-ui/src/infographics/workspace/WorkspaceConnectionManager.ts
+++ b/services/web-ui/src/infographics/workspace/WorkspaceConnectionManager.ts
@@ -257,6 +257,14 @@ function computeTFromPointerPosition(
 	return t
 }
 
+function resolveEdgeAnchorT(node: CanvasNode | undefined, t: number | undefined): number {
+	return node?.type === 'image' ? 0.5 : t ?? 0.5
+}
+
+function canAutoAlignTargetT(node: CanvasNode | undefined): boolean {
+	return Boolean(node && node.type !== 'image')
+}
+
 function isSameConnection(
 	a: WorkspaceEdge,
 	b: { sourceNodeId: string; targetNodeId: string; sourceHandle?: string | null; targetHandle?: string | null }
@@ -307,12 +315,13 @@ export function computeSpreadTValues(
 		const sourceY = sourceNode ? sourceNode.position.y + sourceNode.dimensions.height / 2 : 0
 
 		// Default to stored T or 0.5
-		let targetT = edge.targetT ?? 0.5
+		const sourceT = resolveEdgeAnchorT(sourceNode, edge.sourceT)
+		let targetT = resolveEdgeAnchorT(targetNode, edge.targetT)
 
 		// Dynamic auto-align: If source Y hits the target node, FORCE straight line alignment
 		// This ensures that even during dragging or node moving, the line attempts to stay straight
 		// For off-axis nodes, we clamp to the nearest corner (top/bottom) instead of snapping to center
-		if (sourceNode && targetNode) {
+		if (sourceNode && canAutoAlignTargetT(targetNode)) {
 			const targetHeight = targetNode.dimensions.height
 
 			// When the target is shorter than the minimum slide height, snap to center
@@ -333,7 +342,7 @@ export function computeSpreadTValues(
 
 		// Initialize with values
 		result.set(edge.edgeId, {
-			sourceT: edge.sourceT ?? 0.5,
+			sourceT,
 			targetT,
 			laneIndex: 0,
 			laneCount: 1,
@@ -345,6 +354,7 @@ export function computeSpreadTValues(
 	// Sort by TARGET node's Y position so lines don't cross
 	for (const [, group] of sourceGroups) {
 		if (group.length <= 1) continue
+		if (nodeMap.get(group[0]?.sourceNodeId)?.type === 'image') continue
 
 		// Sort by target node Y position (smaller Y = higher on screen = smaller t)
 		group.sort((a, b) => {
@@ -526,8 +536,8 @@ export class WorkspaceConnectionManager {
 		nodeById: Map<string, CanvasNode>,
 		worldNodeMap: Map<string, NodeConfig>
 	): EdgeAnchor {
-		const resolvedT = t ?? 0.5
 		const node = nodeById.get(nodeId)
+		const resolvedT = resolveEdgeAnchorT(node, t)
 		const nodeConfig = worldNodeMap.get(nodeId)
 		const offset = this.getContextRegionAnchorOffset(node, nodeConfig, position, resolvedT)
 
@@ -735,7 +745,7 @@ export class WorkspaceConnectionManager {
 				const sourceNode = this.nodes.find(n => n.nodeId === nodeId)
 				const targetNode = this.nodes.find(n => n.nodeId === toNodeId)
 
-				if (sourceNode && targetNode) {
+				if (sourceNode && canAutoAlignTargetT(targetNode)) {
 					const sourceY = sourceNode.position.y + sourceNode.dimensions.height * sourceT
 					const targetTop = targetNode.position.y
 					const targetBottom = targetTop + targetNode.dimensions.height
@@ -989,7 +999,7 @@ export class WorkspaceConnectionManager {
 				const sourceNode = this.nodes.find(n => n.nodeId === fromNodeId)
 				const targetNode = this.nodes.find(n => n.nodeId === toNodeId)
 
-				if (sourceNode && targetNode) {
+				if (sourceNode && canAutoAlignTargetT(targetNode)) {
 					const sourceY = sourceNode.position.y + sourceNode.dimensions.height * sourceT
 					const targetTop = targetNode.position.y
 					const targetBottom = targetTop + targetNode.dimensions.height
@@ -1045,7 +1055,9 @@ export class WorkspaceConnectionManager {
 					updatedEdge.sourceNodeId = finalState.toNode.id
 					updatedEdge.sourceHandle = finalState.toHandle?.id ?? undefined
 					// Compute t from drop position
-					if (reconnectedNode && finalState.toHandle) {
+					if (reconnectedNode?.type === 'image') {
+						updatedEdge.sourceT = 0.5
+					} else if (reconnectedNode && finalState.toHandle) {
 						updatedEdge.sourceT = computeTFromPointerPosition(
 							finalState.toHandle.y,
 							reconnectedNode.position.y,
@@ -1058,7 +1070,9 @@ export class WorkspaceConnectionManager {
 					updatedEdge.targetNodeId = finalState.toNode.id
 					updatedEdge.targetHandle = finalState.toHandle?.id ?? undefined
 					// Compute t from drop position
-					if (reconnectedNode && finalState.toHandle) {
+					if (reconnectedNode?.type === 'image') {
+						updatedEdge.targetT = 0.5
+					} else if (reconnectedNode && finalState.toHandle) {
 						updatedEdge.targetT = computeTFromPointerPosition(
 							finalState.toHandle.y,
 							reconnectedNode.position.y,
@@ -1333,7 +1347,7 @@ export class WorkspaceConnectionManager {
 					// This prevents the arrow from pointing to the bottom of the target when the thread is long
 					const sourceNode = this.nodes.find(n => n.nodeId === e.sourceNodeId)
 					const targetNode = this.nodes.find(n => n.nodeId === e.targetNodeId)
-					if (sourceNode && targetNode) {
+					if (sourceNode && canAutoAlignTargetT(targetNode)) {
 						const targetHeight = targetNode.dimensions.height
 
 						if (targetHeight < webUiThemeSettings.aiChatThreadRailMinSlideHeight) {


### PR DESCRIPTION
Closes #166

## Summary

Image-node connector endpoints were landing off-center due to multiple anchor-computation paths in `WorkspaceConnectionManager` applying dynamic T values without exempting image nodes.

## Changes

Added two pure guards:

- `resolveEdgeAnchorT(node, t)` — returns `0.5` for image nodes, `t ?? 0.5` otherwise
- `canAutoAlignTargetT(node)` — returns `false` for image nodes, blocking all sliding/fan-out alignment

Applied across every anchor-computation site: initial spread values in `computeSpreadTValues`, source fan-out loop, `buildEdgeAnchor`, `onReconnectEnd`, `onConnect` handle-drag, menu-connect, and the `sourceMessageId` re-alignment block in `render`.

Non-image node behavior (AI chat thread rail sliding, margin clamping, message-level source anchoring) is unchanged.

## Tests

- Updated 7 existing `computeSpreadTValues` tests to use `document` target type (they were testing sliding behavior but used `image` targets, which would now short-circuit)
- Added: `keeps targetT at 0.5 when the target is an image node`
- Added: `keeps sourceT at 0.5 when the source is an image node`
- Added: `keeps image target midpoint when sourceMessageId adjusts source anchor` (render-level regression)

## Files

- `services/web-ui/src/infographics/workspace/WorkspaceConnectionManager.ts`
- `services/web-ui/src/infographics/workspace/WorkspaceConnectionManager.test.ts`
- `services/web-ui/src/infographics/workspace/README.md`