### PR TITLE
LIX-175 # Canvas placement, shape-aware collision, and config centralization

### DIFF
--- a/documentation/features/CANVAS-COLLISION-RESOLUTION.md
+++ b/documentation/features/CANVAS-COLLISION-RESOLUTION.md
@@ -1,0 +1,147 @@
+# Canvas Collision Resolution
+
+Canvas collision resolution keeps newly inserted and released workspace nodes from sitting on top of each other. It is a workspace-engine behavior, not a Svelte behavior. The Svelte wrapper can create domain objects after app/service work, but placement, viewport-coordinate math, shape-aware collision planning, and collision resolution belong in `services/web-ui/src/infographics/workspace` or shared infographics utilities.
+
+This document describes how collision resolution works today and where future changes should happen.
+
+## Current Status
+
+Collision resolution is implemented as two layers:
+
+- [resolveCollisions.ts](../../services/web-ui/src/infographics/utils/resolveCollisions.ts) is the shared, geometry-agnostic resolver. It accepts rectangular boxes and pushes overlapping boxes apart.
+- [WorkspaceCanvas.ts](../../services/web-ui/src/infographics/workspace/WorkspaceCanvas.ts) builds workspace-specific collision plans. It converts canvas nodes into resolver boxes, swaps context-region rectangles for CO2 cloud bounds, filters false-positive cloud overlaps, applies parent/child exclusions, and converts resolved world positions back to persisted node positions.
+
+Context-region cloud geometry comes from [contextRegionClouds.ts](../../services/web-ui/src/infographics/workspace/rendering/contextRegionClouds.ts). Collision checks use the same cloud geometry family as hit testing, connector anchoring, resize-edge detection, marquee fallback, and drop adoption. Rectangles are allowed as broad-phase boxes, but the irregular cloud outline is the interaction truth.
+
+## Architecture
+
+```mermaid
+%%{init: {'theme': 'base', 'themeVariables': { 'primaryColor': '#F6C7B3', 'primaryTextColor': '#5a3a2a', 'primaryBorderColor': '#d4956a', 'secondaryColor': '#C3DEDD', 'secondaryTextColor': '#1a3a47', 'secondaryBorderColor': '#4a8a9d', 'tertiaryColor': '#DCECE9', 'tertiaryTextColor': '#1a3a47', 'tertiaryBorderColor': '#82B2C0', 'lineColor': '#d4956a', 'textColor': '#5a3a2a'}}}%%
+flowchart TB
+    subgraph Entrypoints[Workspace collision entrypoints]
+        Insert[insertNodeAtViewportCenter]
+        Generated[generated image commit]
+        DragRelease[drag release]
+    end
+
+    Insert --> Plan[createShapeAwareCollisionPlan]
+    Generated --> Plan
+    DragRelease --> DragPlan[computeWorkspaceDragPlan]
+    DragPlan --> Plan
+
+    Plan --> World[resolve node world positions]
+    World --> Boxes[build resolver boxes]
+    Boxes --> Cloud{context region?}
+    Cloud -->|yes| CloudBounds[use CO2 cloud visual bounds<br/>and record offset]
+    Cloud -->|no| RectBox[use node dimensions rectangle]
+    CloudBounds --> Predicate[shape-aware pair predicate]
+    RectBox --> Predicate
+    Predicate --> Resolver[resolveCollisions]
+    Resolver --> Remap[map resolved boxes back<br/>to node positions]
+    Remap --> Commit[commit canvas state]
+```
+
+| Component | Responsibility |
+|---|---|
+| `insertNodeAtViewportCenter(...)` | Renderer API used by toolbar insertions. Computes viewport-centered placement inside the workspace engine and resolves top-level collisions before emitting canvas state. |
+| `computeWorkspaceDragPlan(...)` | Decides whether a drag release is allowed to run collision resolution and whether context-region descendants participate in the drag. |
+| `createShapeAwareCollisionPlan(...)` | Converts canvas nodes into resolver boxes, including context-region cloud bounds and shape-aware pair checks. |
+| `resolveCollisions(...)` | Shared rectangle resolver. It knows nothing about canvas nodes, context regions, parentage, Svelte, PIXI, or viewport state. |
+| `contextRegionClouds.ts` | Supplies the irregular cloud geometry used to avoid rectangular false positives around transparent cloud corners. |
+
+## Core Resolver
+
+`resolveCollisions(...)` is intentionally small and generic. It receives an array of boxes shaped like `{ id, x, y, width, height }` and returns a map of moved box positions by id.
+
+The resolver flow is:
+
+1. Expand each box by the requested margin.
+2. Check every pair in an O(n²) loop.
+3. Skip pairs listed in `excludePairs`.
+4. Compute overlap on the x and y axes.
+5. If both overlaps exceed the threshold, ask `shouldResolvePair(...)` whether the broad-phase overlap is real.
+6. Move both boxes apart along the smaller overlap axis.
+7. Repeat until no boxes move or the iteration limit is reached.
+8. Return only the boxes that actually moved.
+
+This resolver should stay geometry-agnostic. Do not teach it about canvas node types, context-region clouds, generated image metadata, parent-child containment, or framework state. Add workspace-specific behavior in the collision plan that feeds it.
+
+## Shape-Aware Collision Planning
+
+`WorkspaceCanvas.ts` turns persisted canvas nodes into temporary resolver boxes. The important detail is that resolver boxes are in world coordinates, while some persisted nodes may be parent-relative.
+
+For normal nodes, the resolver box is the node's world position plus persisted dimensions.
+
+For context regions, the resolver box is not the transparent DOM proxy rectangle. The planner builds a `ContextRegionCloudDatum`, asks `getContextRegionCloudBounds(...)` for the visible cloud bounds, and records the offset between the persisted node position and that cloud-bound box. After resolution, that offset is applied in reverse so the persisted node position remains the logical region position, not the cloud-bound origin.
+
+The collision plan also provides `shouldResolvePair(...)`. This predicate keeps rectangular broad-phase checks from becoming the final truth:
+
+| Pair type | Final overlap check |
+|---|---|
+| Context region + context region | `contextRegionCloudsIntersect(...)` |
+| Context region + rectangular node | `rectIntersectsContextRegionCloud(...)` |
+| Rectangular node + rectangular node | Rectangle overlap from `resolveCollisions(...)` is enough |
+
+This is why context regions can keep their irregular shape without requiring the generic resolver to understand cloud masks.
+
+## When Resolution Runs
+
+Collision resolution runs only from workspace-engine paths that own canvas behavior.
+
+| Path | Collision behavior |
+|---|---|
+| Toolbar document/image/context-region insertion | Svelte creates the node data and calls `renderer.insertNodeAtViewportCenter(...)`. The renderer computes viewport-centered placement and resolves top-level collisions. |
+| Image generation commit | The generated image is added to the canvas, parent/child pairs are excluded, and the shape-aware resolver can move colliding nodes. |
+| Image-to-image branch continuation | The new image is placed from the latest branch image, then the shape-aware resolver can move colliding nodes. |
+| Edit-thread/context-region creation beside a source image | The context region is placed next to the source image, then top-level collisions are resolved. |
+| Drag release | `computeWorkspaceDragPlan(...)` decides whether collision resolution is allowed. Single-node drags can resolve; group drags preserve rigid spacing; context-region drags resolve against top-level peers. |
+
+Do not duplicate this behavior in [WorkspaceCanvas.svelte](../../services/web-ui/src/components/WorkspaceCanvas.svelte). The Svelte file is a thin integration wrapper for DOM refs, stores, service calls, upload plumbing, and callbacks. If a future toolbar action needs collision-aware placement, expose a renderer API in `WorkspaceCanvas.ts` and reuse the workspace collision path.
+
+## Parent, Child, And Context-Region Rules
+
+Parented nodes create one special case: a region and its real children are allowed to overlap because containment is the point. Before resolving collisions in full-node flows, `WorkspaceCanvas.ts` builds `excludePairs` for parent/child pairs so the generic resolver does not push adopted children out of their container.
+
+When a resolved child position is returned from the resolver, it is converted from world coordinates back to parent-relative coordinates before being persisted. Top-level nodes keep the resolved world position directly.
+
+Context-region drag planning has additional constraints:
+
+- A context-region drag includes real parented descendants for live visual movement.
+- Generated output image nodes are excluded from context-region drag sets unless they are real selected or parented participants in a future interaction model.
+- Merely connected nodes do not move with a region.
+- Multi-node non-region drags skip global collision resolution so the selected group keeps its rigid spacing.
+
+## Configuration And Tuning
+
+The generic resolver accepts options for iteration count, overlap threshold, margin, excluded pairs, and pair filtering. Those options are call-site behavior, not user-facing theme settings by themselves.
+
+If a collision-related value becomes a product/design tuning knob, put it in [webUiThemeSettings.ts](../../services/web-ui/src/webUiThemeSettings.ts) following the canvas configuration ownership rules in [CANVAS-ENGINE.md](CANVAS-ENGINE.md). Do not add new configurable magic numbers directly to Svelte, PIXI layers, or ad hoc helper modules.
+
+## Invariants
+
+Keep these rules intact when changing collision behavior:
+
+- Collision resolution must run through [resolveCollisions.ts](../../services/web-ui/src/infographics/utils/resolveCollisions.ts). Do not create a second resolver in Svelte or a feature-specific component.
+- Workspace-specific collision knowledge belongs in `WorkspaceCanvas.ts` or a workspace utility, not in the generic resolver.
+- Context-region collisions must respect the same CO2 cloud geometry used by hit testing, resize-edge detection, connector anchoring, marquee fallback, and adoption scoring.
+- Parent/child pairs must be excluded from collision resolution so containment does not push children out of their region.
+- Persisted child positions must remain parent-relative after world-space collision resolution.
+- Group drags must preserve rigid spacing unless the drag plan explicitly allows collision resolution.
+- Generated branch images should keep their lineage placement first; collision resolution is a cleanup pass after placement, not the branch-layout algorithm.
+
+## Troubleshooting
+
+| Symptom | Likely cause | Check |
+|---|---|---|
+| A newly inserted toolbar node overlaps an existing region | Insertion bypassed `renderer.insertNodeAtViewportCenter(...)` or top-level resolution | Check [WorkspaceCanvas.svelte](../../services/web-ui/src/components/WorkspaceCanvas.svelte) for direct position/collision logic. |
+| Context regions repel nodes from transparent corners | Rectangular bounds became the final truth | Check `shouldResolvePair(...)` in [WorkspaceCanvas.ts](../../services/web-ui/src/infographics/workspace/WorkspaceCanvas.ts) and the cloud geometry calls. |
+| Children are pushed out of a context region after drop | Parent/child `excludePairs` were not passed to the resolver | Check the collision-exclusion set before `resolveCollisions(...)`. |
+| Adopted child nodes persist at wrong coordinates | Resolved world position was not converted back to parent-relative position | Check `toParentRelativePosition(...)` usage after collision resolution. |
+| Multi-selected nodes lose their spacing after drag | Drag plan allowed global collision resolution for a rigid group move | Check `computeWorkspaceDragPlan(...)` in [workspaceDragPlan.ts](../../services/web-ui/src/infographics/workspace/workspaceDragPlan.ts). |
+| A context region drag moves generated outputs unexpectedly | Generated image exclusions were removed from the drag plan | Check generated-output filtering in `includeContextRegionDescendants(...)`. |
+
+## Related Documentation
+
+- [CANVAS-ENGINE.md](CANVAS-ENGINE.md) documents the full DOM/SVG/PIXI canvas rendering architecture and canvas configuration ownership rules.
+- [CONTEXT-REGION-CLOUDS.md](CONTEXT-REGION-CLOUDS.md) documents the context-region cloud geometry used by collision filtering, hit testing, anchoring, and adoption scoring.
+- [WORKSPACE-FEATURE.md](WORKSPACE-FEATURE.md) documents the workspace feature, data flow, node types, and user-facing canvas concepts.

--- a/documentation/features/CANVAS-ENGINE.md
+++ b/documentation/features/CANVAS-ENGINE.md
@@ -19,6 +19,8 @@ For the workspace feature itself — node types, stores, services, data flow, ar
 
 For context-region cloud rendering, shape-based hit testing, adoption scoring, and performance constraints, see [CONTEXT-REGION-CLOUDS.md](CONTEXT-REGION-CLOUDS.md).
 
+For workspace collision resolution, placement cleanup, drag-release collision rules, and context-region shape-aware collision planning, see [CANVAS-COLLISION-RESOLUTION.md](CANVAS-COLLISION-RESOLUTION.md).
+
 ### Canvas implementation code
 
 The active canvas implementation lives in `services/web-ui/src/infographics/`. Key files:
@@ -26,6 +28,7 @@ The active canvas implementation lives in `services/web-ui/src/infographics/`. K
 | File | Purpose |
 |------|---------|
 | `workspace/WorkspaceCanvas.ts` | Main canvas orchestrator: DOM nodes, ProseMirror integration, drag/resize/selection, viewport, and PIXI media/context-region sync points |
+| `utils/resolveCollisions.ts` | Shared geometry-agnostic rectangle collision resolver used by workspace insertion, generated image commit, and drag-release cleanup paths |
 | `workspace/pixiMediaLayer.ts` | PIXI v8 media layer for image pixels — sprite registry, texture cache, LoD-tier loader, visibility scanner, prefetch scheduler |
 | `workspace/pixiMediaLayerLogic.ts` | Pure helpers: tier ranking, world-position math, src URL building, LoD-size param injection, world-rect math |
 | `workspace/pixiImageDecoder.ts` | Six-worker decode pool: round-robin dispatch with per-worker request tracking |
@@ -42,6 +45,16 @@ The active canvas implementation lives in `services/web-ui/src/infographics/`. K
 | `utils/zoomScaling.ts` | Zoom-compensated handle scaling |
 
 Use the incremental canvas architecture documented here as the implementation recipe: preserve the existing `infographics/workspace` entrypoint, harden the PIXI media layer, and move one renderer responsibility at a time only after parity checks pass.
+
+### Canvas Configuration Ownership
+
+All configurable workspace-canvas UI settings belong in [webUiThemeSettings.ts](../../services/web-ui/src/webUiThemeSettings.ts). This includes colors, shadows, dimensions, gaps, hit radii, animation timing, title sizing, generated-image placement spacing, and other values that product/design tuning may reasonably adjust without changing the interaction algorithm.
+
+Do not add new configurable magic-number constants directly to [WorkspaceCanvas.ts](../../services/web-ui/src/infographics/workspace/WorkspaceCanvas.ts), Svelte wrappers, PIXI rendering layers, or helper modules. If a value controls visible styling, layout, spacing, hit target size, cursor activation area, or animation feel, add it to `webUiThemeSettings` first and read it from the consuming code.
+
+`webUiThemeSettings` must stay organized by logical groups. Each top-level group is its own subsection, and a group may contain nested subsections when a domain has a clear child domain, such as `contextRegion.cloud`. Every group and nested group must have a blank line before and after it in the object literal. Every key must have a short comment explaining what the value means and how changing it affects the application.
+
+Use object getters in `webUiThemeSettings` only when a setting must compute its value from sibling keys with `this`, such as a `styles` list referencing sibling `palettes`. Static values must remain plain properties; do not use getters just to organize or label settings.
 
 ### @xyflow/system reference
 

--- a/documentation/features/CONTEXT-REGION-CLOUDS.md
+++ b/documentation/features/CONTEXT-REGION-CLOUDS.md
@@ -12,7 +12,7 @@ Context region clouds are implemented in the web UI and run as part of the hybri
 - Pure geometry, style selection, hit testing, title bounds, and adoption scoring live in [contextRegionClouds.ts](../../services/web-ui/src/infographics/workspace/rendering/contextRegionClouds.ts).
 - [WorkspaceCanvas.ts](../../services/web-ui/src/infographics/workspace/WorkspaceCanvas.ts) still owns canvas state, transparent DOM proxy nodes, drag, selection, activation, parent-child containment, and pane-level pointer routing.
 - [viewportBridge.ts](../../services/web-ui/src/infographics/workspace/rendering/viewportBridge.ts) applies the same viewport transform to DOM nodes, the PIXI media layer, and the PIXI context-region layer.
-- Theme-level cloud visual settings live together in [webUiThemeSettings.ts](../../services/web-ui/src/webUiThemeSettings.ts).
+- Theme-level context-region settings live in [webUiThemeSettings.ts](../../services/web-ui/src/webUiThemeSettings.ts), with cloud-specific settings nested under `contextRegion.cloud`.
 
 No backend schema, NATS subject, DynamoDB table, or persisted visual-style field is required. Context region clouds are a frontend rendering and interaction primitive over existing canvas nodes.
 
@@ -131,7 +131,7 @@ The texture stays square and preserves the CO2 cloud proportions. For non-square
 
 ## Visual Texture
 
-Each cloud style bakes a shared Canvas2D texture, then PIXI renders that texture as a `Sprite`. The texture size, mask threshold, gradient colors, gradient positions, cloud style variants, palette values, border, title, frame, and pulse values are configured in the separated context-region cloud section of [webUiThemeSettings.ts](../../services/web-ui/src/webUiThemeSettings.ts).
+Each cloud style bakes a shared Canvas2D texture, then PIXI renders that texture as a `Sprite`. The texture size, mask threshold, resize edge hit radius, gradient colors, gradient positions, cloud style variants, palette values, border, title, frame, and pulse values are configured in the `contextRegion.cloud` subsection of [webUiThemeSettings.ts](../../services/web-ui/src/webUiThemeSettings.ts).
 
 The current palette is seafoam, taken from `random-useful-things/image-color-analysis-tool/region-gradient-preview.html` and tuned to keep the patchy grain visible:
 
@@ -154,7 +154,7 @@ The texture pipeline is intentionally bake-heavy and runtime-light:
 4. Add translucent paint pools biased by aspect and seed.
 5. Add soft subtractive cutbacks so the cloud does not read as a solid blob.
 6. Add fine pigment speckles.
-7. Optionally add the exact vector border ring when `webUiThemeSettings.contextRegionCloudBorderEnabled` is `true`.
+7. Optionally add the exact vector border ring when `webUiThemeSettings.contextRegion.cloud.borderEnabled` is `true`.
 8. Apply the CO2 mask once at the end with `destination-in`.
 9. Convert the canvas to a PIXI `Texture` and cache it by texture version, border state, and style key.
 
@@ -162,37 +162,9 @@ The reference-like feel comes from the perimeter, uneven alpha, edge pooling, gr
 
 ## Theme Configuration
 
-All current context-region cloud visual knobs are centralized in [webUiThemeSettings.ts](../../services/web-ui/src/webUiThemeSettings.ts):
+Do not duplicate the context-region setting inventory or values in this document. The source of truth is [webUiThemeSettings.ts](../../services/web-ui/src/webUiThemeSettings.ts), specifically `webUiThemeSettings.contextRegion` and its nested `webUiThemeSettings.contextRegion.cloud` subsection.
 
-| Setting | Purpose |
-|---|---|
-| `contextRegionCloudTextureSize` | Shared baked Canvas2D texture resolution. |
-| `contextRegionCloudMaskAlphaThreshold` | Alpha cutoff used while painting cloud pixels into the CO2 mask. |
-| `contextRegionCloudMinBleed` | Minimum visual bleed around a logical region rectangle. |
-| `contextRegionCloudGradientBaseColor` | Base seafoam color mixed under the weighted gradient. |
-| `contextRegionCloudGradientColors` | Four seafoam gradient colors used by the baked texture. |
-| `contextRegionCloudGradientPositions` | Normalized positions for the four gradient color points. |
-| `contextRegionCloudStyles` | Deterministic style options: aspect, bleed ratio, title anchor, palette, and seed. |
-| `contextRegionCloudBorderEnabled` | Enables the baked exact vector border ring. |
-| `contextRegionCloudBorderMainAlpha` | Border alpha for the main CO2 cloud path. |
-| `contextRegionCloudBorderThoughtCircleAlpha` | Border alpha for the top-left thought circle. |
-| `contextRegionCloudIdleAlpha` | Default backdrop sprite alpha. |
-| `contextRegionCloudSelectedAlpha` | Backdrop sprite alpha while selected. |
-| `contextRegionCloudPulseDurationMs` | Duration for the bounded event pulse. |
-| `contextRegionCloudPulseAlphaLift` | Extra alpha applied at the peak of the pulse. |
-| `contextRegionCloudPulseLiftPx` | Screen-space lift applied at the peak of the pulse. |
-| `contextRegionCloudTitleFontFamily` | PIXI title text font family. |
-| `contextRegionCloudTitleFontSize` | PIXI title text base font size. |
-| `contextRegionCloudTitleFontWeight` | PIXI title text font weight. |
-| `contextRegionCloudTitleAlpha` | PIXI title text alpha. |
-| `contextRegionCloudTitleHeight` | Title hit/text rect height. |
-| `contextRegionCloudTitleCharWidth` | Approximate title character width for hit rect sizing. |
-| `contextRegionCloudTitleMinWidth` | Minimum title hit rect width. |
-| `contextRegionCloudTitleMaxWidth` | Maximum title hit rect width. |
-| `contextRegionCloudTitlePaddingX` | Extra horizontal title hit rect padding. |
-| `contextRegionCloudTitleMinX` | Minimum title x inset from the visual bounds. |
-| `contextRegionCloudTitleGap` | Gap between title rect and cloud visual bounds. |
-| `contextRegionImageFrameColor` | Frame color for image nodes contained by context regions. |
+Any new configurable context-region value must go through `webUiThemeSettings.ts` instead of becoming a local magic-number constant. Keep context-region settings under `contextRegion`; use nested subsections such as `contextRegion.cloud` for child domains; put a blank line before and after each logical group; and add a short comment beside every config key explaining what it means and how changing it affects the app. Use getters only when a setting needs to self-reference sibling settings through `this`, such as cloud styles referencing cloud palettes; keep ordinary static values as plain properties.
 
 CO2 path constants are still code-level geometry, not theme settings. If the cloud silhouette changes, update rendering and hit/adoption geometry together.
 
@@ -201,7 +173,7 @@ CO2 path constants are still code-level geometry, not theme settings. If the clo
 The cloud border is optional and controlled centrally:
 
 ```typescript
-webUiThemeSettings.contextRegionCloudBorderEnabled: boolean
+webUiThemeSettings.contextRegion.cloud.borderEnabled: boolean
 ```
 
 The default is `false`.
@@ -462,7 +434,7 @@ Do not treat persisted `canvasState.viewport` as authoritative during an active 
 | Long stray lines appear through arrowheads | PIXI `Graphics` path state leaked between edge path and arrowhead drawing | Check `beginPath()` / `closePath()` isolation in `pixiEdgeRenderer.ts`. |
 | A ghost cloud appears on selection | Separate selection silhouette was reintroduced | Keep selection chrome separate from a duplicate cloud sprite. |
 | Texture looks pale or flat | Gradient/overlay alpha washed out color and grain | Check seafoam gradient mix, bloom overlays, and final alpha. |
-| Border does not match the cloud | Border drawn as generic stroke or separate sprite | Use the baked exact vector ring path controlled by `contextRegionCloudBorderEnabled`. |
+| Border does not match the cloud | Border drawn as generic stroke or separate sprite | Use the baked exact vector ring path controlled by `contextRegion.cloud.borderEnabled`. |
 | Pan/zoom stutters with many regions | Runtime work moved into gestures | Look for per-region texture generation, live filters, or continuous ticker usage. |
 | Clouds or generated images jump after panning, with no node-position commit | Stale viewport-only store render replayed an older transform | Check whether the render changed only `viewport` while visual state stayed equivalent, then verify the stale viewport guard in `workspaceViewportStatePlan.ts` still preserves the live transform. |
 

--- a/documentation/features/WORKSPACE-FEATURE.md
+++ b/documentation/features/WORKSPACE-FEATURE.md
@@ -4,7 +4,7 @@ A workspace is the primary container where users organize and edit their documen
 
 > **Renderer architecture note.** The workspace canvas uses the `services/web-ui/src/infographics/workspace/WorkspaceCanvas.ts` stack for DOM interactions and PIXI v8 for high-volume visual layers. The media layer renders image pixels and workspace connector pixels through `services/web-ui/src/infographics/workspace/pixiMediaLayer.ts`; document nodes, AI chat thread nodes, prompt inputs, bubble menus, resize/drag/selection chrome, and handles stay in the DOM implementation. Image-node DOM `<img>` elements are interaction chrome and the partial-streaming surface during AI image generation. Stored image nodes leave their DOM `<img>` without `src` so the browser does not double-fetch pixels already owned by PIXI. Workspace connector hit testing and bubble-menu anchoring use cached PIXI path data.
 >
-> For the rendering pipeline, LoD strategy, texture cache, decode pool, edge diffing, and the list of remaining performance issues, see [CANVAS-ENGINE.md](CANVAS-ENGINE.md). For the CO2-shaped seafoam context-region cloud system specifically, see [CONTEXT-REGION-CLOUDS.md](CONTEXT-REGION-CLOUDS.md).
+> For the rendering pipeline, LoD strategy, texture cache, decode pool, edge diffing, and the list of remaining performance issues, see [CANVAS-ENGINE.md](CANVAS-ENGINE.md). For collision resolution, placement cleanup, drag-release collision rules, and context-region shape-aware collision planning, see [CANVAS-COLLISION-RESOLUTION.md](CANVAS-COLLISION-RESOLUTION.md). For the CO2-shaped seafoam context-region cloud system specifically, see [CONTEXT-REGION-CLOUDS.md](CONTEXT-REGION-CLOUDS.md).
 
 ## Core Concepts
 
@@ -149,8 +149,9 @@ The `WorkspaceConnectionManager` handles the visual rendering logic for edges.
 
 When an AI thread generates images, the workspace manages their placement automatically to maintain a clean layout:
 
-- **Positioning**: Images are placed 50px to the right of their source thread.
-- **Stacking**: Multiple images from the same thread are stacked vertically. The first image aligns with the top of the thread, and subsequent images are placed below the previous one with a 30px gap.
+- **Positioning**: First outputs are placed to the right of the context-region cloud's visual bounds using the spacing configured in `webUiThemeSettings.imageBranchLineage`. Image-to-image continuations use the latest image in the branch as the anchor.
+- **Scale**: Generated image nodes use the configured canvas-unit size regardless of the current zoom level.
+- **Stacking and alignment**: Multiple first-generation outputs stack next to the source region using the configured branch-lineage spacing. Image-to-image continuations stay vertically aligned with the previous image in the branch lineage.
 - **Race Condition Handling**: The layout engine tracks synchronous "partial" image states to ensure that simultaneous updates (e.g., partial stream + final completion) do not cause images to overlap or skip positional slots.
 
 ### CanvasNode
@@ -1056,7 +1057,7 @@ When nodes are connected TO an AI chat thread (incoming edges), the AI chat auto
 
 ## AI Image Generation
 
-This feature adds the ability to generate images directly from AI chat threads using OpenAI's `gpt-image-1` model via the Responses API. When a user asks the AI to create an image, the generated result appears as a separate canvas image node connected by an edge whose `sourceMessageId` links it to the specific `aiResponseMessage` that produced it. Multiple generated images stack vertically to the right of the source thread with 30px gaps.
+This feature adds the ability to generate images directly from AI chat threads using OpenAI's `gpt-image-1` model via the Responses API. When a user asks the AI to create an image, the generated result appears as a separate canvas image node connected by an edge whose `sourceMessageId` links it to the specific `aiResponseMessage` that produced it. Generated-image size and branch spacing are controlled by `webUiThemeSettings.imageBranchLineage`.
 
 In both modes, the revised prompt text is inserted as text inside the AI response message to keep the conversation readable.
 
@@ -1071,7 +1072,7 @@ Multi-turn editing is supported: users can continue refining an image within the
 5. OpenAI streams back partial images (up to 3) as the generation progresses. The first real partial removes the spinner; subsequent partials update the image progressively
 6. On completion, `IMAGE_COMPLETE` removes the animated border and spinner, finalizes the canvas node with full metadata, and updates the edge with `sourceMessageId` so the connector points back to the producing AI response.
 7. The revised prompt text appears inside the AI response message in the chat thread
-8. Multiple generated images stack vertically to the right with 30px gaps.
+8. Multiple generated images stack using the spacing configured in `webUiThemeSettings.imageBranchLineage`.
 
 ### Data Flow
 
@@ -1184,7 +1185,7 @@ When the AI generates an image:
 3. Progressive partial previews update the canvas node's image in real-time via direct DOM updates. The first real partial removes the bounce spinner.
 4. `IMAGE_COMPLETE` removes the animated border and spinner, then finalizes the canvas node with full `generatedBy` metadata: `{ aiChatThreadId, responseId, aiModel, revisedPrompt }`
 5. A `WorkspaceEdge` connects the thread to the image with `sourceMessageId` identifying the specific `aiResponseMessage` (the response node gets a unique `id` when created by `handleStreamStart`)
-6. Multiple images from the same thread stack vertically with 30px gaps
+6. Multiple images from the same thread stack vertically using spacing from `webUiThemeSettings.imageBranchLineage`
 7. Collision resolution runs after finalization to push apart any overlapping nodes
 8. The revised prompt text is inserted as a paragraph inside the AI response message in the editor
 
@@ -1192,7 +1193,7 @@ When the AI generates an image:
 
 When "Edit in New Thread" is clicked on a canvas image node:
 
-1. A new AI chat thread is created and positioned at `(imageNode.x + imageNode.width + 50, imageNode.y)`
+1. A new AI chat thread context region is created to the right of the source image using `webUiThemeSettings.contextRegion.defaultDimensions` and `webUiThemeSettings.contextRegion.adjacentNodeGap`; shape-aware collision resolution then pushes conflicting top-level nodes apart
 2. An edge connects the image (right) to the new thread (left)
 3. The connected image is automatically included in the new thread's context via `extractConnectedContext()`
 4. This forms a horizontal chain: `[Original Thread] → [Image] → [Edit Thread]`

--- a/services/web-ui/src/components/WorkspaceCanvas.svelte
+++ b/services/web-ui/src/components/WorkspaceCanvas.svelte
@@ -6,6 +6,7 @@
     } from '@xyflow/system'
     import {
         type CanvasState,
+        type DocumentCanvasNode,
         type ImageCanvasNode,
         type ContextRegionCanvasNode
     } from '@lixpi/constants'
@@ -19,6 +20,7 @@
     import { routerStore } from '$src/stores/routerStore.ts'
     import { servicesStore } from '$src/stores/servicesStore.ts'
     import AuthService from '$src/services/auth-service.ts'
+    import { webUiThemeSettings } from '$src/webUiThemeSettings.ts'
     import { createNewFileIcon, imageIcon, aiChatBubbleIcon } from '$src/svgIcons/index.ts'
     import '$src/infographics/workspace/workspace-canvas.scss'
     import '$src/infographics/workspace/feature-library-panel.scss'
@@ -47,6 +49,8 @@
     let saveDebounceTimer: ReturnType<typeof setTimeout> | null = null
     const documentService = new DocumentService()
     const aiChatThreadService = new AiChatThreadService()
+    const DEFAULT_DOCUMENT_NODE_DIMENSIONS = { width: 400, height: 350 }
+    const FALLBACK_IMAGE_DIMENSIONS = { width: 300, height: 300 }
 
     function persistCanvasState(newCanvasState: CanvasState) {
         const stateToPersist = {
@@ -114,26 +118,15 @@
             })
 
             if (doc) {
-                const existingNodes = canvasState?.nodes || []
-                const newX = 50 + (existingNodes.length % 3) * 450
-                const newY = 50 + Math.floor(existingNodes.length / 3) * 400
-
-                const newCanvasState: CanvasState = {
-                    viewport: canvasState?.viewport || { x: 0, y: 0, zoom: 1 },
-                    edges: canvasState?.edges ?? [],
-                    nodes: [
-                        ...existingNodes,
-                        {
-                            nodeId: `node-${doc.documentId}`,
-                            type: 'document',
-                            referenceId: doc.documentId,
-                            position: { x: newX, y: newY },
-                            dimensions: { width: 400, height: 350 }
-                        }
-                    ]
+                const dimensions = { ...DEFAULT_DOCUMENT_NODE_DIMENSIONS }
+                const documentNode: Omit<DocumentCanvasNode, 'position'> = {
+                    nodeId: `node-${doc.documentId}`,
+                    type: 'document',
+                    referenceId: doc.documentId,
+                    dimensions,
                 }
 
-                persistCanvasState(newCanvasState)
+                renderer?.insertNodeAtViewportCenter(documentNode)
             }
         } catch (error) {
             console.error('Error creating document:', error)
@@ -212,53 +205,39 @@
             const maxWidth = 400
             const width = Math.min(maxWidth, img.naturalWidth)
             const height = width / aspectRatio
+            const dimensions = { width, height }
 
-            const existingNodes = canvasState?.nodes || []
-            const newX = 50 + (existingNodes.length % 3) * 450
-            const newY = 50 + Math.floor(existingNodes.length / 3) * 400
             const nodeUniqueId = fileId || uuidv4()
 
-            const imageNode: ImageCanvasNode = {
+            const imageNode: Omit<ImageCanvasNode, 'position'> = {
                 nodeId: `node-${nodeUniqueId}`,
                 type: 'image',
                 fileId: nodeUniqueId,
                 workspaceId,
                 src,
                 aspectRatio,
-                position: { x: newX, y: newY },
-                dimensions: { width, height }
+                dimensions,
             }
 
-            persistCanvasState({
-                viewport: canvasState?.viewport || { x: 0, y: 0, zoom: 1 },
-                edges: canvasState?.edges ?? [],
-                nodes: [...existingNodes, imageNode]
-            })
+            renderer?.insertNodeAtViewportCenter(imageNode)
         }
 
         img.onerror = () => {
             console.error('Failed to load image for dimension calculation')
-            const existingNodes = canvasState?.nodes || []
-            const newX = 50 + (existingNodes.length % 3) * 450
-            const newY = 50 + Math.floor(existingNodes.length / 3) * 400
+            const dimensions = { ...FALLBACK_IMAGE_DIMENSIONS }
             const nodeUniqueId = fileId || uuidv4()
 
-            const imageNode: ImageCanvasNode = {
+            const imageNode: Omit<ImageCanvasNode, 'position'> = {
                 nodeId: `node-${nodeUniqueId}`,
                 type: 'image',
                 fileId: nodeUniqueId,
                 workspaceId,
                 src,
                 aspectRatio: 1,
-                position: { x: newX, y: newY },
-                dimensions: { width: 300, height: 300 }
+                dimensions,
             }
 
-            persistCanvasState({
-                viewport: canvasState?.viewport || { x: 0, y: 0, zoom: 1 },
-                edges: canvasState?.edges ?? [],
-                nodes: [...existingNodes, imageNode]
-            })
+            renderer?.insertNodeAtViewportCenter(imageNode)
         }
 
         img.src = src
@@ -298,26 +277,16 @@
             })
 
             if (thread) {
-                const existingNodes = canvasState?.nodes || []
-                const newX = 50 + (existingNodes.length % 3) * 450
-                const newY = 50 + Math.floor(existingNodes.length / 3) * 400
+                const dimensions = { ...webUiThemeSettings.contextRegion.defaultDimensions }
 
-                const contextRegionNode: ContextRegionCanvasNode = {
+                const contextRegionNode: Omit<ContextRegionCanvasNode, 'position'> = {
                     nodeId: `node-${thread.threadId}`,
                     type: 'contextRegion',
                     referenceId: thread.threadId,
-                    position: { x: newX, y: newY },
-                    dimensions: { width: 400, height: 500 }
+                    dimensions,
                 }
 
-                const newCanvasState: CanvasState = {
-                    viewport: canvasState?.viewport || { x: 0, y: 0, zoom: 1 },
-                    edges: canvasState?.edges ?? [],
-                    nodes: [...existingNodes, contextRegionNode],
-                    lastActiveAiChatThreadId: thread.threadId
-                }
-
-                persistCanvasState(newCanvasState)
+                renderer?.insertNodeAtViewportCenter(contextRegionNode, { lastActiveAiChatThreadId: thread.threadId })
             }
         } catch (error) {
             console.error('Error creating AI chat thread:', error)

--- a/services/web-ui/src/infographics/utils/resolveCollisions.test.ts
+++ b/services/web-ui/src/infographics/utils/resolveCollisions.test.ts
@@ -1,0 +1,78 @@
+'use strict'
+
+import { describe, it, expect } from 'vitest'
+import { resolveCollisions } from '$src/infographics/utils/resolveCollisions.ts'
+
+// =============================================================================
+// GENERIC COLLISION RESOLUTION
+// =============================================================================
+
+describe('resolveCollisions', () => {
+	it('returns no changes when boxes do not overlap', () => {
+		const result = resolveCollisions([
+			{ id: 'a', x: 0, y: 0, width: 100, height: 100 },
+			{ id: 'b', x: 140, y: 0, width: 100, height: 100 },
+		], { margin: 0 })
+
+		expect(result.hasChanges).toBe(false)
+		expect(result.nodes.size).toBe(0)
+	})
+
+	it('pushes overlapping boxes apart along the smallest overlap axis', () => {
+		const result = resolveCollisions([
+			{ id: 'a', x: 0, y: 0, width: 100, height: 100 },
+			{ id: 'b', x: 80, y: 0, width: 100, height: 100 },
+		], { margin: 0, overlapThreshold: 0.5, iterations: 1 })
+
+		expect(result.hasChanges).toBe(true)
+		expect(result.nodes.get('a')).toEqual({ x: -10, y: 0 })
+		expect(result.nodes.get('b')).toEqual({ x: 90, y: 0 })
+	})
+
+	it('treats margin as required breathing room around boxes', () => {
+		const result = resolveCollisions([
+			{ id: 'a', x: 0, y: 0, width: 100, height: 100 },
+			{ id: 'b', x: 110, y: 0, width: 100, height: 100 },
+		], { margin: 10, overlapThreshold: 0.5, iterations: 1 })
+
+		expect(result.hasChanges).toBe(true)
+		expect(result.nodes.get('a')).toEqual({ x: -5, y: 0 })
+		expect(result.nodes.get('b')).toEqual({ x: 115, y: 0 })
+	})
+
+	it('honors excluded node pairs even when boxes overlap', () => {
+		const result = resolveCollisions([
+			{ id: 'parent', x: 0, y: 0, width: 200, height: 200 },
+			{ id: 'child', x: 40, y: 40, width: 80, height: 80 },
+		], {
+			margin: 0,
+			excludePairs: new Set(['parent-child']),
+		})
+
+		expect(result.hasChanges).toBe(false)
+		expect(result.nodes.size).toBe(0)
+	})
+
+	it('lets callers veto broad-phase overlaps with original unexpanded boxes', () => {
+		const seenPairs: Array<{ a: unknown; b: unknown }> = []
+		const result = resolveCollisions([
+			{ id: 'a', x: 0, y: 0, width: 100, height: 100 },
+			{ id: 'b', x: 90, y: 0, width: 100, height: 100 },
+		], {
+			margin: 20,
+			shouldResolvePair: (a, b) => {
+				seenPairs.push({ a, b })
+				return false
+			},
+		})
+
+		expect(seenPairs).toEqual([
+			{
+				a: { id: 'a', x: 0, y: 0, width: 100, height: 100 },
+				b: { id: 'b', x: 90, y: 0, width: 100, height: 100 },
+			},
+		])
+		expect(result.hasChanges).toBe(false)
+		expect(result.nodes.size).toBe(0)
+	})
+})

--- a/services/web-ui/src/infographics/utils/resolveCollisions.ts
+++ b/services/web-ui/src/infographics/utils/resolveCollisions.ts
@@ -14,6 +14,7 @@ type CollisionOptions = {
     overlapThreshold?: number  // Minimum overlap to trigger resolution (default: 0.5)
     margin?: number            // Extra spacing around nodes (default: 20)
     excludePairs?: Set<string> // Set of "nodeIdA-nodeIdB" pairs to skip collision resolution for
+    shouldResolvePair?: (a: NodeBox, b: NodeBox) => boolean
 }
 
 type CollisionResult = {
@@ -30,7 +31,8 @@ export function resolveCollisions(
         iterations = 50,
         overlapThreshold = 0.5,
         margin = 20,
-        excludePairs
+        excludePairs,
+        shouldResolvePair,
     } = options
 
     // Create mutable boxes with margin applied
@@ -76,6 +78,22 @@ export function resolveCollisions(
 
                 // Check if there's significant overlap on BOTH axes
                 if (px > overlapThreshold && py > overlapThreshold) {
+                    const originalA = {
+                        id: A.id,
+                        x: A.x + margin,
+                        y: A.y + margin,
+                        width: A.width - margin * 2,
+                        height: A.height - margin * 2,
+                    }
+                    const originalB = {
+                        id: B.id,
+                        x: B.x + margin,
+                        y: B.y + margin,
+                        width: B.width - margin * 2,
+                        height: B.height - margin * 2,
+                    }
+                    if (shouldResolvePair && !shouldResolvePair(originalA, originalB)) continue
+
                     A.moved = B.moved = moved = true
 
                     // Resolve along the SMALLEST overlap axis (minimum translation)

--- a/services/web-ui/src/infographics/workspace/README.md
+++ b/services/web-ui/src/infographics/workspace/README.md
@@ -6,8 +6,11 @@ This module renders the main workspace view—a zoomable, pannable canvas where 
 >
 > - For the rendering architecture (DOM interaction layer + PIXI v8 media/edge layers), the LoD-tier loader, the texture cache, the 6-worker decode pool, and the list of remaining performance issues, read [`documentation/features/CANVAS-ENGINE.md`](../../../../../documentation/features/CANVAS-ENGINE.md). That document is the source of truth for any rendering or perf work.
 > - For context-region cloud rendering, CO2-mask hit testing, adoption scoring, theme toggles, and gotchas, read [`documentation/features/CONTEXT-REGION-CLOUDS.md`](../../../../../documentation/features/CONTEXT-REGION-CLOUDS.md).
+> - For collision resolution, viewport-centered insertion cleanup, drag-release collision rules, and context-region shape-aware collision planning, read [`documentation/features/CANVAS-COLLISION-RESOLUTION.md`](../../../../../documentation/features/CANVAS-COLLISION-RESOLUTION.md).
 > - For workspace data flow (stores, services, NATS subjects, AI chat context extraction, image generation), read [`documentation/features/WORKSPACE-FEATURE.md`](../../../../../documentation/features/WORKSPACE-FEATURE.md).
 > - This README documents the local code shape — file roles, DOM structure, click and selection rules, AI chat thread layout, edge connection UX.
+
+> **Configuration rule.** Workspace-canvas values that are meant to be tuned — colors, shadows, dimensions, gaps, hit radii, resize cursor activation areas, animation timing, and generated-image placement spacing — belong in [`webUiThemeSettings.ts`](../../webUiThemeSettings.ts). Keep them in logical top-level subsections such as `imageNode`, `contextRegion`, and `imageBranchLineage`; use nested subsections for child domains such as `contextRegion.cloud`; separate every group with a blank line before and after; and document every key with what changing it does. Use getters only when a setting needs to self-reference sibling settings through `this`; keep ordinary static values as plain properties.
 
 ## What It Does
 
@@ -31,7 +34,7 @@ When you open a workspace, you see a canvas. On that canvas are nodes (documents
 - **Select edges** by clicking the connector line
 - **Delete edges** using Delete/Backspace (when an edge is selected), or by dragging an endpoint to empty space
 
-All of this happens without the Svelte component knowing the details. It just passes DOM refs and gets callbacks when things change.
+All of this happens without the Svelte component knowing the details. It just passes DOM refs, performs app/service integration, and gets callbacks when things change. Canvas behavior such as placement, collision resolution, shape-aware context-region geometry, drag/resize planning, and viewport-coordinate math belongs in this `infographics/workspace` module or its utilities, not in `services/web-ui/src/components/WorkspaceCanvas.svelte`.
 
 ## Node Types
 
@@ -66,7 +69,7 @@ All of this happens without the Svelte component knowing the details. It just pa
     - **Menu-driven connect snap** — the image-node “Connect to node” action snaps against that same full rail geometry, including the floating input area for empty threads, and only commits the edge on mouse release so the snap preview is visible before creation. The snap distance is configurable via `webUiSettings.menuConnectionSnapRadius`
     - **Floating panel resize** — the canvas-owned AI chat panel reuses the same full-height outer rail on its left edge as the horizontal resize target. Dragging that rail changes `--workspace-ai-chat-sidebar-width`, keeping the panel right edge fixed and preserving the zoom indicator offset
     - The horizontal offset from the node edge is configurable via `aiChatThreadRailOffset` in `webUiThemeSettings.ts` (default -2px). Negative values move the rail inside the node boundary; the rail is rendered at z-index 9990 (above all nodes, below floating inputs) to ensure it stays visible regardless of node layering
-- **AI-generated images** appear as independent canvas nodes positioned to the right of the source thread, connected by an edge with `sourceMessageId` tracking which `aiResponseMessage` produced the image. Generated output images stay freely draggable and are not adopted into context regions during drag release.
+- **AI-generated images** appear as independent canvas nodes positioned to the right of the source thread, source context-region cloud bounds, or previous image in the branch lineage, with generous canvas-space breathing room. Their insertion dimensions are fixed canvas units regardless of the current zoom, so generated outputs arrive at the same logical size as a 100% zoom insertion. Generated outputs are connected by an edge with `sourceMessageId` tracking which `aiResponseMessage` produced the image, stay freely draggable, and are not adopted into context regions during drag release.
         - Progressive partial previews update the canvas node in real-time during generation, and the finalized response inserts the revised prompt plus a small `aiGeneratedImage` thumbnail that references the same stored image (`imageUrl`, `fileId`, and `workspaceId`) as the canvas node.
     - Drag membership is planned by `workspaceDragPlan.ts`, so context-region drags move only the region and real `parentId` descendants. Generated-image adoption rules live in `workspaceImageNodePlan.ts`, which keeps generated outputs independent unless a future interaction model explicitly makes them real region children.
         - Render-state reconciliation is planned by `workspaceRenderStatePlan.ts`. When the active AI chat panel emits a stale metadata render while a local drag commit is still waiting for store acknowledgement, the canvas preserves the locally committed node and edge positions until the store acknowledges the visual state.
@@ -76,7 +79,7 @@ All of this happens without the Svelte component knowing the details. It just pa
     - Keep a transparent DOM node with `data-node-id` as a geometry proxy for existing drag, selection, connection-manager, and parent-child state paths.
     - Route empty-region clicks and drags through `contextRegionLayer.hitTest()` from the pane background handler; transparent cloud corners are not treated as region body hits.
     - Use `rendering/contextRegionClouds.ts` for shared style selection, CO2 SVG-mask hit geometry, title hit zones, and adoption scoring. The drag-release adoption path uses the same cloud mask as click hit-testing.
-    - Read all context-region cloud visual options from the separated `contextRegionCloud*` section in `webUiThemeSettings.ts`.
+    - Read all context-region cloud visual and hit-target options from `webUiThemeSettings.contextRegion.cloud`.
     - Pulse subtly on selection, panel activation, and AI submit. PIXI's ticker remains off; the pulse is a bounded requestAnimationFrame animation.
     - Open the singleton canvas-owned floating chat panel when clicked. The region itself is context grouping chrome, not an embedded ProseMirror editor.
     - See [`documentation/features/CONTEXT-REGION-CLOUDS.md`](../../../../../documentation/features/CONTEXT-REGION-CLOUDS.md) for the deeper architecture, research context, and implementation constraints.
@@ -418,7 +421,7 @@ Menu items are defined in `canvasBubbleMenuItems.ts`. The core `BubbleMenu` clas
 | `workspace-canvas.scss` | All styles for canvas, nodes, handles, edges, editors, the `workspace-image-node--pixi-owned` opacity rule, and the transparent context-region proxy |
 | `canvasImageLifecycle.ts` | Tracks image nodes and deletes orphaned images from storage |
 | `canvasBubbleMenuItems.ts` | Bubble menu item definitions for canvas elements (image and edge actions) |
-| `imagePositioning.ts` | Computes generated image placement positions next to source threads |
+| `imagePositioning.ts` | Computes viewport-normalized insertion dimensions and generated image placement positions next to source threads |
 | `workspaceImageNodePlan.ts` | Pure helpers for generated image node adoption rules |
 | `nodeLayering.ts` | Z-index management for bringing nodes to front |
 

--- a/services/web-ui/src/infographics/workspace/WorkspaceCanvas.ts
+++ b/services/web-ui/src/infographics/workspace/WorkspaceCanvas.ts
@@ -35,7 +35,10 @@ import { WorkspaceConnectionManager } from '$src/infographics/workspace/Workspac
 import { getCanvasChromeZoomMultiplier, getResizeHandleScaledSizes } from '$src/infographics/utils/zoomScaling.ts'
 import { html, applyStyle } from '$src/utils/domTemplates.ts'
 import { resolveCollisions } from '$src/infographics/utils/resolveCollisions.ts'
-import { computeImagePositionNextToThread, countExistingImagesForThread } from '$src/infographics/workspace/imagePositioning.ts'
+import {
+    computeStackedPositionToRightOfRect,
+    computeViewportCenterInsertionPosition,
+} from '$src/infographics/workspace/imagePositioning.ts'
 import { createNodeLayerManager } from '$src/infographics/workspace/nodeLayering.ts'
 import { computeWorkspaceDragPlan } from '$src/infographics/workspace/workspaceDragPlan.ts'
 import {
@@ -83,6 +86,13 @@ import { select } from 'd3-selection'
 
 type ResizeCorner = 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right'
 type ResizeHandle = ResizeCorner | ContextRegionCloudResizeHandle
+type CollisionBox = { id: string; x: number; y: number; width: number; height: number }
+type CollisionEntry = { node: CanvasNode; offset: { x: number; y: number } }
+type CollisionPlan = {
+    nodeBoxes: CollisionBox[]
+    entries: Map<string, CollisionEntry>
+    shouldResolvePair: (a: CollisionBox, b: CollisionBox) => boolean
+}
 
 const RESIZE_CORNERS: ResizeCorner[] = ['top-left', 'top-right', 'bottom-left', 'bottom-right']
 const CONTEXT_REGION_IMAGE_CLASS = 'workspace-image-node--context-region-child'
@@ -122,6 +132,14 @@ type WorkspaceCanvasCallbacks = {
     onDocumentTitleChange?: (params: { documentId: string; title: string }) => void
     onAiChatThreadContentChange?: (params: { workspaceId: string; threadId: string; content: any }) => void
 }
+
+type WorkspaceCanvasNodeInsertion =
+    | Omit<DocumentCanvasNode, 'position'>
+    | Omit<ImageCanvasNode, 'position'>
+    | Omit<AiChatThreadCanvasNode, 'position'>
+    | Omit<ContextRegionCanvasNode, 'position'>
+
+type WorkspaceCanvasInsertionStatePatch = Omit<Partial<CanvasState>, 'nodes' | 'edges' | 'viewport'>
 
 type WorkspaceCanvasOptions = {
     paneEl: HTMLDivElement
@@ -715,9 +733,8 @@ export function createWorkspaceCanvas(options: WorkspaceCanvasOptions) {
         })
     }
 
-    function getRegionGeneratedImageSize(region: CanvasNode): number {
-        const availableWidth = Math.max(120, region.dimensions.width - 48)
-        return Math.min(220, availableWidth)
+    function getGeneratedImageInsertionSize(): number {
+        return webUiThemeSettings.imageBranchLineage.generatedImageSize
     }
 
     function getNextRegionChildPosition(region: CanvasNode, childWidth: number, childHeight: number, nodes: CanvasNode[]): { x: number; y: number } {
@@ -734,20 +751,132 @@ export function createWorkspaceCanvas(options: WorkspaceCanvasOptions) {
         }
     }
 
-    function getNextRegionOutputPosition(region: ContextRegionNode, childWidth: number, childHeight: number, nodes: CanvasNode[]): { x: number; y: number } {
+    function getNextRegionOutputPosition(region: ContextRegionNode, childHeight: number, nodes: CanvasNode[]): { x: number; y: number } {
         const nodesById = getCanvasNodesById(nodes)
-        const regionPosition = getNodeWorldPosition(region, nodesById)
-        const gap = 72
+        const threadMap = new Map<string, AiChatThread>(currentAiChatThreads.map((thread) => [thread.threadId, thread]))
+        const regionDatum = getContextRegionCloudDatum(region, threadMap.get(region.referenceId), nodesById)
+        const cloudBounds = getContextRegionCloudBounds(regionDatum)
+        const gap = webUiThemeSettings.imageBranchLineage.contextRegionOutputGap
         const existingOutputs = nodes.filter((node: CanvasNode) => {
             if (node.type !== 'image' || node.parentId) return false
             return (node as ImageCanvasNode).generatedBy?.aiChatThreadId === region.referenceId
         })
-        const index = existingOutputs.length
 
+        return computeStackedPositionToRightOfRect(cloudBounds, existingOutputs.length, childHeight, gap)
+    }
+
+    function getInsertionPaneSize(): { width: number; height: number } {
+        const rect = paneRect ?? paneEl.getBoundingClientRect()
+        return { width: rect.width, height: rect.height }
+    }
+
+    function getCenteredInsertionPosition(dimensions: { width: number; height: number }): { x: number; y: number } {
+        return computeViewportCenterInsertionPosition(dimensions, getLiveViewport(), getInsertionPaneSize())
+    }
+
+    function getContextRegionCollisionDatum(
+        node: ContextRegionNode,
+        position: { x: number; y: number },
+        threadMap: Map<string, AiChatThread>
+    ): ContextRegionCloudDatum {
         return {
-            x: regionPosition.x + region.dimensions.width + gap,
-            y: regionPosition.y + index * (childHeight + gap),
+            nodeId: node.nodeId,
+            referenceId: node.referenceId,
+            x: position.x,
+            y: position.y,
+            width: node.dimensions.width,
+            height: node.dimensions.height,
+            title: getAiChatThreadTitle(threadMap.get(node.referenceId)),
+            selected: selectedNodeIds.has(node.nodeId),
         }
+    }
+
+    function getContextRegionCollisionDatumFromBox(
+        entry: CollisionEntry,
+        box: CollisionBox,
+        threadMap: Map<string, AiChatThread>
+    ): ContextRegionCloudDatum | null {
+        if (!isContextRegionCanvasNode(entry.node)) return null
+        return getContextRegionCollisionDatum(entry.node, {
+            x: box.x + entry.offset.x,
+            y: box.y + entry.offset.y,
+        }, threadMap)
+    }
+
+    function getResolvedNodePositionFromCollisionBox(node: CanvasNode, box: { x: number; y: number }, entries: Map<string, CollisionEntry>): { x: number; y: number } {
+        const entry = entries.get(node.nodeId)
+        if (!entry) return box
+        return {
+            x: box.x + entry.offset.x,
+            y: box.y + entry.offset.y,
+        }
+    }
+
+    function createShapeAwareCollisionPlan(nodes: CanvasNode[], topLevelOnly = false): CollisionPlan {
+        const collisionNodes = topLevelOnly
+            ? nodes.filter((node: CanvasNode) => !node.parentId)
+            : nodes
+        const nodesById = getCanvasNodesById(nodes)
+        const threadMap = new Map<string, AiChatThread>(currentAiChatThreads.map((thread) => [thread.threadId, thread]))
+        const entries = new Map<string, CollisionEntry>()
+
+        const nodeBoxes = collisionNodes.map((node: CanvasNode) => {
+            const worldPosition = getNodeWorldPosition(node, nodesById)
+            if (isContextRegionCanvasNode(node)) {
+                const datum = getContextRegionCollisionDatum(node, worldPosition, threadMap)
+                const cloudBounds = getContextRegionCloudBounds(datum)
+                entries.set(node.nodeId, {
+                    node,
+                    offset: {
+                        x: worldPosition.x - cloudBounds.x,
+                        y: worldPosition.y - cloudBounds.y,
+                    },
+                })
+                return { id: node.nodeId, ...cloudBounds }
+            }
+
+            entries.set(node.nodeId, { node, offset: { x: 0, y: 0 } })
+            return {
+                id: node.nodeId,
+                x: worldPosition.x,
+                y: worldPosition.y,
+                width: node.dimensions.width,
+                height: node.dimensions.height,
+            }
+        })
+
+        const shouldResolvePair = (a: CollisionBox, b: CollisionBox): boolean => {
+            const entryA = entries.get(a.id)
+            const entryB = entries.get(b.id)
+            if (!entryA || !entryB) return true
+
+            const datumA = getContextRegionCollisionDatumFromBox(entryA, a, threadMap)
+            const datumB = getContextRegionCollisionDatumFromBox(entryB, b, threadMap)
+            if (datumA && datumB) return contextRegionCloudGeometry.contextRegionCloudsIntersect(datumA, datumB)
+            if (datumA) return contextRegionCloudGeometry.rectIntersectsContextRegionCloud(datumA, b)
+            if (datumB) return contextRegionCloudGeometry.rectIntersectsContextRegionCloud(datumB, a)
+            return true
+        }
+
+        return { nodeBoxes, entries, shouldResolvePair }
+    }
+
+    function resolveTopLevelNodeCollisions(nodes: CanvasNode[]): CanvasNode[] {
+        const collisionPlan = createShapeAwareCollisionPlan(nodes, true)
+        const collisionResult = resolveCollisions(collisionPlan.nodeBoxes, {
+            iterations: 50,
+            overlapThreshold: 0.5,
+            margin: 32,
+            shouldResolvePair: collisionPlan.shouldResolvePair,
+        })
+
+        if (!collisionResult.hasChanges) return nodes
+
+        return nodes.map((node: CanvasNode) => {
+            if (node.parentId) return node
+            const movedPosition = collisionResult.nodes.get(node.nodeId)
+            return movedPosition ? { ...node, position: getResolvedNodePositionFromCollisionBox(node, movedPosition, collisionPlan.entries) } : node
+        })
     }
 
     function getNodesForConnectionManager(nodes: CanvasNode[]): CanvasNode[] {
@@ -2300,24 +2429,35 @@ export function createWorkspaceCanvas(options: WorkspaceCanvasOptions) {
         )
     }
 
-    function getNextGeneratedImagePosition(sourceNode: CanvasNode, sourceThread: ContextRegionNode, imageWidth: number, imageHeight: number): { x: number; y: number } {
+    function getGeneratedChildOutputs(sourceNode: CanvasNode, nodes: CanvasNode[], edges: WorkspaceEdge[]): ImageCanvasNode[] {
+        return nodes.filter((node: CanvasNode): node is ImageCanvasNode => {
+            if (node.type !== 'image' || node.parentId) return false
+            return edges.some((edge: WorkspaceEdge) => edge.sourceNodeId === sourceNode.nodeId && edge.targetNodeId === node.nodeId)
+        })
+    }
+
+    function getMostRecentGeneratedChildOutput(outputs: ImageCanvasNode[]): ImageCanvasNode | undefined {
+        return [...outputs].sort((a: ImageCanvasNode, b: ImageCanvasNode) => {
+            const createdAtDelta = (a.generatedBy?.createdAt ?? 0) - (b.generatedBy?.createdAt ?? 0)
+            if (createdAtDelta !== 0) return createdAtDelta
+            return a.position.x - b.position.x
+        }).at(-1)
+    }
+
+    function getNextGeneratedImagePosition(sourceNode: CanvasNode, imageHeight: number): { x: number; y: number } {
         const nodes = currentCanvasState?.nodes || []
         if (isContextRegionCanvasNode(sourceNode)) {
-            return getNextRegionOutputPosition(sourceThread, imageWidth, imageHeight, nodes)
+            return getNextRegionOutputPosition(sourceNode, imageHeight, nodes)
         }
 
-        const sourceRect = getNodeWorldRect(sourceNode)
-        const gap = 72
-        const existingChildOutputs = nodes.filter((node: CanvasNode) => {
-            if (node.type !== 'image' || node.parentId) return false
-            return currentCanvasState?.edges.some((edge: WorkspaceEdge) =>
-                edge.sourceNodeId === sourceNode.nodeId && edge.targetNodeId === node.nodeId
-            ) ?? false
-        })
+        const edges = currentCanvasState?.edges ?? []
+        const existingChildOutputs = getGeneratedChildOutputs(sourceNode, nodes, edges)
+        const previousOutput = getMostRecentGeneratedChildOutput(existingChildOutputs)
+        const anchorRect = previousOutput ? getNodeWorldRect(previousOutput) : getNodeWorldRect(sourceNode)
 
         return {
-            x: sourceRect.x + sourceRect.width + gap,
-            y: sourceRect.y + existingChildOutputs.length * (imageHeight + gap),
+            x: anchorRect.x + anchorRect.width + webUiThemeSettings.imageBranchLineage.imageToImageGap,
+            y: anchorRect.y,
         }
     }
 
@@ -2476,11 +2616,11 @@ export function createWorkspaceCanvas(options: WorkspaceCanvasOptions) {
                 }
             }
 
-            const width = sourceThreadNode ? getRegionGeneratedImageSize(sourceThreadNode) : 400
+            const width = getGeneratedImageInsertionSize()
             const height = width
             const position = sourceThreadNode
-                ? getNextRegionOutputPosition(sourceThreadNode, width, height, existingNodes)
-                : { x: 50 + (existingNodes.length % 3) * 450, y: 50 + Math.floor(existingNodes.length / 3) * 400 }
+                ? getNextRegionOutputPosition(sourceThreadNode, height, existingNodes)
+                : getCenteredInsertionPosition({ width, height })
 
             const imageNode: ImageCanvasNode = {
                 nodeId: `node-${fileId}`,
@@ -2618,9 +2758,9 @@ export function createWorkspaceCanvas(options: WorkspaceCanvasOptions) {
             const API_BASE_URL = import.meta.env.VITE_API_URL || ''
             const imageSrc = buildImageSrc(imageUrl, API_BASE_URL, token)
 
-            const imageWidth = getRegionGeneratedImageSize(sourceThread)
+            const imageWidth = getGeneratedImageInsertionSize()
             const imageHeight = imageWidth
-            const position = getNextGeneratedImagePosition(sourceNode, sourceThread, imageWidth, imageHeight)
+            const position = getNextGeneratedImagePosition(sourceNode, imageHeight)
 
             const imageNode: ImageCanvasNode = {
                 nodeId,
@@ -2713,26 +2853,20 @@ export function createWorkspaceCanvas(options: WorkspaceCanvasOptions) {
                 for (const child of nodes) {
                     if (child.parentId) collisionExclusions.add(`${child.parentId}-${child.nodeId}`)
                 }
-                const nodesById = getCanvasNodesById(nodes)
-                const nodeBoxes = nodes.map((n: CanvasNode) => {
-                    const worldPosition = getNodeWorldPosition(n, nodesById)
-                    return {
-                        id: n.nodeId,
-                        x: worldPosition.x,
-                        y: worldPosition.y,
-                        width: n.dimensions.width,
-                        height: n.dimensions.height,
-                    }
+                const collisionPlan = createShapeAwareCollisionPlan(nodes)
+                const collisionResult = resolveCollisions(collisionPlan.nodeBoxes, {
+                    excludePairs: collisionExclusions.size > 0 ? collisionExclusions : undefined,
+                    shouldResolvePair: collisionPlan.shouldResolvePair,
                 })
-                const collisionResult = resolveCollisions(nodeBoxes, { excludePairs: collisionExclusions.size > 0 ? collisionExclusions : undefined })
 
                 const resolvedNodes = collisionResult.hasChanges
                     ? nodes.map((n: CanvasNode) => {
                         const resolved = collisionResult.nodes.get(n.nodeId)
                         if (!resolved) return n
+                        const resolvedPosition = getResolvedNodePositionFromCollisionBox(n, resolved, collisionPlan.entries)
                         const position = n.parentId
-                            ? toParentRelativePosition({ x: resolved.x, y: resolved.y }, n.parentId, getCanvasNodesById(nodes))
-                            : { x: resolved.x, y: resolved.y }
+                            ? toParentRelativePosition(resolvedPosition, n.parentId, getCanvasNodesById(nodes))
+                            : resolvedPosition
                         return { ...n, position }
                     })
                     : nodes
@@ -2777,9 +2911,9 @@ export function createWorkspaceCanvas(options: WorkspaceCanvasOptions) {
 
                 const nodeId = `node-${fileId || uuidv4()}`
 
-                const imageWidth = getRegionGeneratedImageSize(sourceThread)
+                const imageWidth = getGeneratedImageInsertionSize()
                 const imageHeight = imageWidth
-                const position = getNextGeneratedImagePosition(sourceNode, sourceThread, imageWidth, imageHeight)
+                const position = getNextGeneratedImagePosition(sourceNode, imageHeight)
 
                 const imageNode: ImageCanvasNode = {
                     nodeId,
@@ -2815,26 +2949,20 @@ export function createWorkspaceCanvas(options: WorkspaceCanvasOptions) {
                 for (const child of allNodes) {
                     if (child.parentId) collisionExclusions.add(`${child.parentId}-${child.nodeId}`)
                 }
-                const allNodesById = getCanvasNodesById(allNodes)
-                const nodeBoxes = allNodes.map((n: CanvasNode) => {
-                    const worldPosition = getNodeWorldPosition(n, allNodesById)
-                    return {
-                        id: n.nodeId,
-                        x: worldPosition.x,
-                        y: worldPosition.y,
-                        width: n.dimensions.width,
-                        height: n.dimensions.height,
-                    }
+                const collisionPlan = createShapeAwareCollisionPlan(allNodes)
+                const collisionResult = resolveCollisions(collisionPlan.nodeBoxes, {
+                    excludePairs: collisionExclusions.size > 0 ? collisionExclusions : undefined,
+                    shouldResolvePair: collisionPlan.shouldResolvePair,
                 })
-                const collisionResult = resolveCollisions(nodeBoxes, { excludePairs: collisionExclusions.size > 0 ? collisionExclusions : undefined })
 
                 const resolvedNodes = collisionResult.hasChanges
                     ? allNodes.map((n: CanvasNode) => {
                         const resolved = collisionResult.nodes.get(n.nodeId)
                         if (!resolved) return n
+                        const resolvedPosition = getResolvedNodePositionFromCollisionBox(n, resolved, collisionPlan.entries)
                         const position = n.parentId
-                            ? toParentRelativePosition({ x: resolved.x, y: resolved.y }, n.parentId, getCanvasNodesById(allNodes))
-                            : { x: resolved.x, y: resolved.y }
+                            ? toParentRelativePosition(resolvedPosition, n.parentId, getCanvasNodesById(allNodes))
+                            : resolvedPosition
                         return { ...n, position }
                     })
                     : allNodes
@@ -2916,26 +3044,25 @@ export function createWorkspaceCanvas(options: WorkspaceCanvasOptions) {
                         }
                     }
 
-                    // Calculate position to the right of the source image
-                    const newX = sourceImageNode
-                        ? sourceImageNode.position.x + sourceImageNode.dimensions.width + 50
-                        : 50 + (existingNodes.length % 3) * 450
-                    const newY = sourceImageNode
-                        ? sourceImageNode.position.y
-                        : 50 + Math.floor(existingNodes.length / 3) * 400
+                    const threadDimensions = { ...webUiThemeSettings.contextRegion.defaultDimensions }
+                    const fallbackPosition = getCenteredInsertionPosition(threadDimensions)
+                    const sourceImageRect = sourceImageNode ? getNodeWorldRect(sourceImageNode) : null
+                    const threadPosition = sourceImageRect
+                        ? { x: sourceImageRect.x + sourceImageRect.width + webUiThemeSettings.contextRegion.adjacentNodeGap, y: sourceImageRect.y }
+                        : fallbackPosition
 
                     const threadNode: ContextRegionCanvasNode = {
                         nodeId: `node-${thread.threadId}`,
                         type: 'contextRegion',
                         referenceId: thread.threadId,
-                        position: { x: newX, y: newY },
-                        dimensions: { width: 400, height: 500 }
+                        position: threadPosition,
+                        dimensions: threadDimensions,
                     }
 
                     const newCanvasState: CanvasState = {
                         viewport: currentCanvasState?.viewport || { x: 0, y: 0, zoom: 1 },
                         edges: currentCanvasState?.edges ?? [],
-                        nodes: [...existingNodes, threadNode]
+                        nodes: resolveTopLevelNodeCollisions([...existingNodes, threadNode])
                     }
 
                     // Create edge from source image to edit thread if we found the source
@@ -3683,37 +3810,29 @@ export function createWorkspaceCanvas(options: WorkspaceCanvasOptions) {
                     }
                 }
 
-                const updatedNodesById = getCanvasNodesById(updatedNodes)
-                const nodeBoxes = updatedNodes.map((n: CanvasNode) => {
-                    const worldPosition = getNodeWorldPosition(n, updatedNodesById)
-                    return {
-                        id: n.nodeId,
-                        x: worldPosition.x,
-                        y: worldPosition.y,
-                        width: n.dimensions.width,
-                        height: n.dimensions.height,
-                    }
-                })
+                const collisionPlan = createShapeAwareCollisionPlan(updatedNodes, dragPlan.isContextRegionDrag)
 
-                const { nodes: movedNodes, hasChanges } = resolveCollisions(nodeBoxes, {
+                const { nodes: movedNodes, hasChanges } = resolveCollisions(collisionPlan.nodeBoxes, {
                     iterations: 50,
                     overlapThreshold: 0.5,
                     margin: 20,
                     excludePairs: collisionExclusions.size > 0 ? collisionExclusions : undefined,
+                    shouldResolvePair: collisionPlan.shouldResolvePair,
                 })
 
                 if (hasChanges) {
                     updatedNodes = updatedNodes.map((n: CanvasNode) => {
                         const newPos = movedNodes.get(n.nodeId)
                         if (newPos) {
+                            const resolvedPosition = getResolvedNodePositionFromCollisionBox(n, newPos, collisionPlan.entries)
                             const movedNodeEl = viewportEl?.querySelector(`[data-node-id="${n.nodeId}"]`) as HTMLElement
                             if (movedNodeEl) {
-                                applyStyle(movedNodeEl, { left: `${newPos.x}px`, top: `${newPos.y}px` })
+                                applyStyle(movedNodeEl, { left: `${resolvedPosition.x}px`, top: `${resolvedPosition.y}px` })
                             }
-                            pixiMediaLayer?.setNodeLiveTransform(n.nodeId, newPos, n.dimensions)
+                            pixiMediaLayer?.setNodeLiveTransform(n.nodeId, resolvedPosition, n.dimensions)
                             const nextPosition = n.parentId
-                                ? toParentRelativePosition(newPos, n.parentId, getCanvasNodesById(updatedNodes))
-                                : newPos
+                                ? toParentRelativePosition(resolvedPosition, n.parentId, getCanvasNodesById(updatedNodes))
+                                : resolvedPosition
                             return { ...n, position: nextPosition }
                         }
                         return n
@@ -4632,6 +4751,27 @@ export function createWorkspaceCanvas(options: WorkspaceCanvasOptions) {
     renderNodes()
 
     return {
+        insertNodeAtViewportCenter(node: WorkspaceCanvasNodeInsertion, statePatch: WorkspaceCanvasInsertionStatePatch = {}) {
+            const baseCanvasState: CanvasState = currentCanvasState ?? {
+                viewport: getLiveViewport(),
+                edges: [],
+                nodes: [],
+            }
+            const positionedNode = {
+                ...node,
+                position: getCenteredInsertionPosition(node.dimensions),
+            } as CanvasNode
+            const newCanvasState: CanvasState = {
+                ...baseCanvasState,
+                ...statePatch,
+                viewport: baseCanvasState.viewport,
+                edges: baseCanvasState.edges ?? [],
+                nodes: resolveTopLevelNodeCollisions([...baseCanvasState.nodes, positionedNode]),
+            }
+
+            onCanvasStateChange?.(newCanvasState)
+            return newCanvasState
+        },
         render(newCanvasState: CanvasState | null, newDocuments: Document[], newAiChatThreads: AiChatThread[] = [], newWorkspaceId?: string) {
             const workspaceChanged = Boolean(newWorkspaceId && newWorkspaceId !== workspaceId)
             if (newWorkspaceId) workspaceId = newWorkspaceId

--- a/services/web-ui/src/infographics/workspace/canvasCollisionDocumentation.test.ts
+++ b/services/web-ui/src/infographics/workspace/canvasCollisionDocumentation.test.ts
@@ -1,0 +1,46 @@
+'use strict'
+
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+
+function readWorkspaceReadme(): string {
+	return readFileSync(resolve(__dirname, 'README.md'), 'utf-8')
+}
+
+function expectSourceToContain(source: string, snippet: string, label: string): void {
+	expect(
+		source.includes(snippet),
+		`${label} should contain:\n${snippet}`
+	).toBe(true)
+}
+
+function expectSourceNotToContain(source: string, snippet: string, label: string): void {
+	expect(
+		source.includes(snippet),
+		`${label} should not contain:\n${snippet}`
+	).toBe(false)
+}
+
+// =============================================================================
+// WORKSPACE COLLISION DOCUMENTATION LINKS
+// =============================================================================
+
+describe('canvas collision documentation', () => {
+	const workspaceReadme = readWorkspaceReadme()
+
+	it('links to the repository-level collision feature documentation', () => {
+		expectSourceToContain(workspaceReadme, 'documentation/features/CANVAS-COLLISION-RESOLUTION.md', 'workspace README')
+		expectSourceToContain(workspaceReadme, 'collision resolution, viewport-centered insertion cleanup, drag-release collision rules, and context-region shape-aware collision planning', 'workspace README')
+	})
+
+	it('keeps collision ownership out of the Svelte wrapper in local documentation', () => {
+		expectSourceToContain(workspaceReadme, 'Canvas behavior such as placement, collision resolution, shape-aware context-region geometry, drag/resize planning, and viewport-coordinate math belongs in this `infographics/workspace` module or its utilities', 'workspace README')
+	})
+
+	it('keeps local docs free of stale flat context-region cloud config names', () => {
+		expectSourceNotToContain(workspaceReadme, 'contextRegionCloud*', 'workspace README')
+		expectSourceNotToContain(workspaceReadme, 'contextRegionCloudStyles', 'workspace README')
+		expectSourceNotToContain(workspaceReadme, 'contextRegionCloudGradientColors', 'workspace README')
+	})
+})

--- a/services/web-ui/src/infographics/workspace/imagePositioning.test.ts
+++ b/services/web-ui/src/infographics/workspace/imagePositioning.test.ts
@@ -2,7 +2,15 @@
 
 import { describe, it, expect } from 'vitest'
 import type { CanvasNode, AiChatThreadCanvasNode, ImageCanvasNode } from '@lixpi/constants'
-import { computeImagePositionNextToThread, countExistingImagesForThread } from '$src/infographics/workspace/imagePositioning.ts'
+import {
+	computeImagePositionNextToThread,
+	computeStackedPositionToRightOfRect,
+	computeViewportCenterInsertionPosition,
+	computeViewportGridInsertionPosition,
+	countExistingImagesForThread,
+	screenDimensionsToWorldDimensions,
+	screenSizeToWorldSize,
+} from '$src/infographics/workspace/imagePositioning.ts'
 
 // =============================================================================
 // HELPERS
@@ -37,6 +45,73 @@ function makeImageNode(overrides: Partial<ImageCanvasNode> & { nodeId: string })
 		...overrides,
 	}
 }
+
+// =============================================================================
+// ZOOM-NORMALIZED INSERTION HELPERS
+// =============================================================================
+
+describe('screenSizeToWorldSize', () => {
+	it('keeps 100% insertion scale at zoom 1', () => {
+		expect(screenSizeToWorldSize(400, 1)).toBe(400)
+	})
+
+	it('expands world size at lower zoom so inserted nodes appear at 100% screen scale', () => {
+		expect(screenSizeToWorldSize(400, 0.5)).toBe(800)
+	})
+
+	it('falls back to zoom 1 for invalid zoom values', () => {
+		expect(screenSizeToWorldSize(400, 0)).toBe(400)
+		expect(screenSizeToWorldSize(400, Number.NaN)).toBe(400)
+	})
+})
+
+describe('screenDimensionsToWorldDimensions', () => {
+	it('normalizes both dimensions against the current viewport zoom', () => {
+		expect(screenDimensionsToWorldDimensions({ width: 400, height: 500 }, 0.25)).toEqual({
+			width: 1600,
+			height: 2000,
+		})
+	})
+})
+
+describe('computeViewportGridInsertionPosition', () => {
+	it('places inserted nodes at stable screen offsets in the current viewport', () => {
+		const position = computeViewportGridInsertionPosition(0, { x: -200, y: -100, zoom: 0.5 })
+
+		expect(position).toEqual({ x: 500, y: 300 })
+	})
+
+	it('keeps the existing three-column insertion pattern in screen space', () => {
+		const position = computeViewportGridInsertionPosition(4, { x: 0, y: 0, zoom: 2 })
+
+		expect(position).toEqual({ x: 250, y: 225 })
+	})
+})
+
+describe('computeViewportCenterInsertionPosition', () => {
+	it('centers fixed canvas-unit dimensions in the current viewport', () => {
+		const position = computeViewportCenterInsertionPosition(
+			{ width: 400, height: 300 },
+			{ x: -100, y: -50, zoom: 0.5 },
+			{ width: 1000, height: 800 }
+		)
+
+		expect(position).toEqual({ x: 1000, y: 750 })
+	})
+})
+
+describe('computeStackedPositionToRightOfRect', () => {
+	it('places stacked outputs to the right of the supplied visual bounds', () => {
+		const position = computeStackedPositionToRightOfRect(
+			{ x: 100, y: 200, width: 520, height: 500 },
+			1,
+			400,
+			96
+		)
+
+		expect(position).toEqual({ x: 716, y: 696 })
+	})
+})
 
 // =============================================================================
 // computeImagePositionNextToThread

--- a/services/web-ui/src/infographics/workspace/imagePositioning.ts
+++ b/services/web-ui/src/infographics/workspace/imagePositioning.ts
@@ -6,6 +6,92 @@ import type {
 
 const IMAGE_GAP_X = 50
 const IMAGE_GAP_Y = 30
+const MIN_INSERTION_ZOOM = 0.01
+
+type ViewportLike = { x: number; y: number; zoom: number }
+type Dimensions = { width: number; height: number }
+type RectLike = { x: number; y: number; width: number; height: number }
+type Point = { x: number; y: number }
+type PaneSize = { width: number; height: number }
+type GridInsertionOptions = {
+    columns?: number
+    startX?: number
+    startY?: number
+    columnGap?: number
+    rowGap?: number
+}
+
+export function getSafeInsertionZoom(zoom: number | undefined): number {
+    if (!Number.isFinite(zoom) || !zoom || zoom <= 0) return 1
+    return Math.max(zoom, MIN_INSERTION_ZOOM)
+}
+
+export function screenSizeToWorldSize(size: number, zoom: number | undefined): number {
+    return size / getSafeInsertionZoom(zoom)
+}
+
+export function screenDimensionsToWorldDimensions(dimensions: Dimensions, zoom: number | undefined): Dimensions {
+    const safeZoom = getSafeInsertionZoom(zoom)
+    return {
+        width: dimensions.width / safeZoom,
+        height: dimensions.height / safeZoom,
+    }
+}
+
+export function screenPointToWorldPoint(point: Point, viewport: ViewportLike): Point {
+    const safeZoom = getSafeInsertionZoom(viewport.zoom)
+    return {
+        x: (point.x - viewport.x) / safeZoom,
+        y: (point.y - viewport.y) / safeZoom,
+    }
+}
+
+export function computeViewportGridInsertionPosition(
+    existingNodeCount: number,
+    viewport: ViewportLike,
+    options: GridInsertionOptions = {}
+): Point {
+    const columns = options.columns ?? 3
+    const startX = options.startX ?? 50
+    const startY = options.startY ?? 50
+    const columnGap = options.columnGap ?? 450
+    const rowGap = options.rowGap ?? 400
+    const column = existingNodeCount % columns
+    const row = Math.floor(existingNodeCount / columns)
+
+    return screenPointToWorldPoint({
+        x: startX + column * columnGap,
+        y: startY + row * rowGap,
+    }, viewport)
+}
+
+export function computeViewportCenterInsertionPosition(
+    dimensions: Dimensions,
+    viewport: ViewportLike,
+    paneSize: PaneSize
+): Point {
+    const center = screenPointToWorldPoint({
+        x: paneSize.width / 2,
+        y: paneSize.height / 2,
+    }, viewport)
+
+    return {
+        x: center.x - dimensions.width / 2,
+        y: center.y - dimensions.height / 2,
+    }
+}
+
+export function computeStackedPositionToRightOfRect(
+    rect: RectLike,
+    existingItemCount: number,
+    itemHeight: number,
+    gap: number
+): Point {
+    return {
+        x: rect.x + rect.width + gap,
+        y: rect.y + existingItemCount * (itemHeight + gap),
+    }
+}
 
 export function computeImagePositionNextToThread(
     threadNode: AiChatThreadCanvasNode,

--- a/services/web-ui/src/infographics/workspace/rendering/contextRegionClouds.ts
+++ b/services/web-ui/src/infographics/workspace/rendering/contextRegionClouds.ts
@@ -50,10 +50,10 @@ const CO2_CLOUD_MAIN_PATH = 'm482.856 229.936c12.391-15.534 19.801-35.216 19.801
 const CO2_CLOUD_CIRCLES = [
     { x: 74.302, y: 30.905, radius: 30.905 },
 ]
-const EDGE_HIT_SCREEN_RADIUS_PX = 24
 const EDGE_ANCHOR_SAMPLE_STEPS = 128
 const EDGE_ANCHOR_BINARY_SEARCH_STEPS = 12
 const EDGE_ANCHOR_CROSS_AXIS_STEPS = 96
+const contextRegionCloudTheme = webUiThemeSettings.contextRegion.cloud
 const EDGE_SAMPLE_DIRECTIONS = [
     { x: 1, y: 0 },
     { x: -1, y: 0 },
@@ -65,7 +65,7 @@ const EDGE_SAMPLE_DIRECTIONS = [
     { x: -Math.SQRT1_2, y: -Math.SQRT1_2 },
 ]
 
-export const CONTEXT_REGION_CLOUD_STYLES: ContextRegionCloudStyle[] = webUiThemeSettings.contextRegionCloudStyles
+export const CONTEXT_REGION_CLOUD_STYLES: ContextRegionCloudStyle[] = contextRegionCloudTheme.styles
 
 function isSvgPathCommand(token: string): boolean {
     return /^[a-z]$/i.test(token)
@@ -237,7 +237,7 @@ export function getContextRegionCloudStyle(nodeId: string, width: number, height
 }
 
 export function getContextRegionCloudBleed(style: ContextRegionCloudStyle, rect: Pick<ContextRegionCloudDatum, 'width' | 'height'>): number {
-    return Math.max(webUiThemeSettings.contextRegionCloudMinBleed, Math.min(rect.width, rect.height) * style.bleedRatio)
+    return Math.max(contextRegionCloudTheme.minBleed, Math.min(rect.width, rect.height) * style.bleedRatio)
 }
 
 function getContextRegionCloudVisualBounds(datum: ContextRegionCloudDatum, style = getContextRegionCloudStyle(datum.nodeId, datum.width, datum.height)): ContextRegionCloudRect {
@@ -452,7 +452,7 @@ function isPointNearCo2CloudEdge(
     style = getContextRegionCloudStyle(datum.nodeId, datum.width, datum.height)
 ): boolean {
     const safeZoom = Math.max(zoom, 0.01)
-    const radius = EDGE_HIT_SCREEN_RADIUS_PX / safeZoom
+    const radius = contextRegionCloudTheme.resizeEdgeHitRadiusPx / safeZoom
     const inside = isPointInCo2CloudShape(datum, point, style)
 
     for (const direction of EDGE_SAMPLE_DIRECTIONS) {
@@ -506,19 +506,19 @@ export function getContextRegionCloudResizeCursor(handle: ContextRegionCloudResi
 export function getContextRegionCloudTitleRect(datum: ContextRegionCloudDatum, zoom: number): ContextRegionCloudRect {
     const style = getContextRegionCloudStyle(datum.nodeId, datum.width, datum.height)
     const bounds = getContextRegionCloudVisualBounds(datum, style)
-    const height = scaleCanvasChromeForZoom(webUiThemeSettings.contextRegionCloudTitleHeight, zoom)
-    const charWidth = scaleCanvasChromeForZoom(webUiThemeSettings.contextRegionCloudTitleCharWidth, zoom)
-    const paddingX = scaleCanvasChromeForZoom(webUiThemeSettings.contextRegionCloudTitlePaddingX, zoom)
+    const height = scaleCanvasChromeForZoom(contextRegionCloudTheme.titleHeight, zoom)
+    const charWidth = scaleCanvasChromeForZoom(contextRegionCloudTheme.titleCharWidth, zoom)
+    const paddingX = scaleCanvasChromeForZoom(contextRegionCloudTheme.titlePaddingX, zoom)
     const width = Math.min(
-        scaleCanvasChromeForZoom(webUiThemeSettings.contextRegionCloudTitleMaxWidth, zoom),
+        scaleCanvasChromeForZoom(contextRegionCloudTheme.titleMaxWidth, zoom),
         Math.max(
-            scaleCanvasChromeForZoom(webUiThemeSettings.contextRegionCloudTitleMinWidth, zoom),
+            scaleCanvasChromeForZoom(contextRegionCloudTheme.titleMinWidth, zoom),
             datum.title.length * charWidth + paddingX
         )
     )
     return {
-        x: bounds.x + Math.max(scaleCanvasChromeForZoom(webUiThemeSettings.contextRegionCloudTitleMinX, zoom), bounds.width * style.titleAnchor.x),
-        y: bounds.y - height - scaleCanvasChromeForZoom(webUiThemeSettings.contextRegionCloudTitleGap, zoom),
+        x: bounds.x + Math.max(scaleCanvasChromeForZoom(contextRegionCloudTheme.titleMinX, zoom), bounds.width * style.titleAnchor.x),
+        y: bounds.y - height - scaleCanvasChromeForZoom(contextRegionCloudTheme.titleGap, zoom),
         width,
         height,
     }
@@ -608,6 +608,61 @@ function circleIntersectsRect(circle: ContextRegionCloudCircle, rect: ContextReg
     return dx * dx + dy * dy <= circle.radius * circle.radius
 }
 
+function distancePointToSegmentSquared(point: ContextRegionCloudPoint, a: ContextRegionCloudPoint, b: ContextRegionCloudPoint): number {
+    const dx = b.x - a.x
+    const dy = b.y - a.y
+    const lengthSquared = dx * dx + dy * dy
+    if (lengthSquared === 0) {
+        const pointDx = point.x - a.x
+        const pointDy = point.y - a.y
+        return pointDx * pointDx + pointDy * pointDy
+    }
+
+    const t = clamp(((point.x - a.x) * dx + (point.y - a.y) * dy) / lengthSquared, 0, 1)
+    const closest = { x: a.x + t * dx, y: a.y + t * dy }
+    const closestDx = point.x - closest.x
+    const closestDy = point.y - closest.y
+    return closestDx * closestDx + closestDy * closestDy
+}
+
+function circlesIntersect(a: ContextRegionCloudCircle, b: ContextRegionCloudCircle): boolean {
+    const dx = a.x - b.x
+    const dy = a.y - b.y
+    const radius = a.radius + b.radius
+    return dx * dx + dy * dy <= radius * radius
+}
+
+function circleIntersectsPolygon(circle: ContextRegionCloudCircle, polygon: ContextRegionCloudPoint[]): boolean {
+    const center = { x: circle.x, y: circle.y }
+    if (isPointInPolygon(center, polygon)) return true
+
+    const radiusSquared = circle.radius * circle.radius
+    for (let i = 0; i < polygon.length; i++) {
+        const current = polygon[i]
+        const next = polygon[(i + 1) % polygon.length]
+        if (distancePointToSegmentSquared(center, current, next) <= radiusSquared) return true
+    }
+
+    return false
+}
+
+function polygonsIntersect(a: ContextRegionCloudPoint[], b: ContextRegionCloudPoint[]): boolean {
+    if (a.some((point) => isPointInPolygon(point, b))) return true
+    if (b.some((point) => isPointInPolygon(point, a))) return true
+
+    for (let i = 0; i < a.length; i++) {
+        const aCurrent = a[i]
+        const aNext = a[(i + 1) % a.length]
+        for (let j = 0; j < b.length; j++) {
+            const bCurrent = b[j]
+            const bNext = b[(j + 1) % b.length]
+            if (segmentsIntersect(aCurrent, aNext, bCurrent, bNext)) return true
+        }
+    }
+
+    return false
+}
+
 export function rectIntersectsContextRegionCloud(datum: ContextRegionCloudDatum, rect: ContextRegionCloudRect): boolean {
     const style = getContextRegionCloudStyle(datum.nodeId, datum.width, datum.height)
     const bounds = getContextRegionCloudBounds(datum, style)
@@ -616,6 +671,20 @@ export function rectIntersectsContextRegionCloud(datum: ContextRegionCloudDatum,
     const outline = getContextRegionCloudOutline(datum, style)
     return outline.circles.some((circle) => circleIntersectsRect(circle, rect)) ||
         outline.polygons.some((polygon) => polygonIntersectsRect(polygon, rect))
+}
+
+export function contextRegionCloudsIntersect(a: ContextRegionCloudDatum, b: ContextRegionCloudDatum): boolean {
+    const aBounds = getContextRegionCloudBounds(a)
+    const bBounds = getContextRegionCloudBounds(b)
+    if (!rectsIntersect(aBounds, bBounds)) return false
+
+    const aOutline = getContextRegionCloudOutline(a)
+    const bOutline = getContextRegionCloudOutline(b)
+
+    return aOutline.circles.some((aCircle) => bOutline.circles.some((bCircle) => circlesIntersect(aCircle, bCircle))) ||
+        aOutline.circles.some((circle) => bOutline.polygons.some((polygon) => circleIntersectsPolygon(circle, polygon))) ||
+        bOutline.circles.some((circle) => aOutline.polygons.some((polygon) => circleIntersectsPolygon(circle, polygon))) ||
+        aOutline.polygons.some((aPolygon) => bOutline.polygons.some((bPolygon) => polygonsIntersect(aPolygon, bPolygon)))
 }
 
 function getRectSamplePoints(rect: ContextRegionCloudRect): ContextRegionCloudPoint[] {

--- a/services/web-ui/src/infographics/workspace/rendering/pixiContextRegionLayer.ts
+++ b/services/web-ui/src/infographics/workspace/rendering/pixiContextRegionLayer.ts
@@ -62,6 +62,7 @@ type WatercolorTextureSize = { width: number; height: number }
 
 const VISIBILITY_MARGIN = 1600
 const CONTEXT_REGION_TEXTURE_VERSION = 4
+const contextRegionCloudTheme = webUiThemeSettings.contextRegion.cloud
 const CO2_CLOUD_VIEWBOX_SIZE = 512
 const CO2_CLOUD_MAIN_PATH = 'm482.856 229.936c12.391-15.534 19.801-35.216 19.801-56.63 0-50.198-40.694-90.892-90.892-90.892-5.966 0-11.796.581-17.441 1.679-25.94-49.959-78.143-84.093-138.324-84.093s-112.384 34.134-138.324 84.093c-5.645-1.097-11.475-1.679-17.441-1.679-50.198 0-90.892 40.694-90.892 90.892 0 21.415 7.41 41.096 19.801 56.63-18.325 25.172-29.144 56.158-29.144 89.676 0 84.244 68.293 152.538 152.537 152.538 5.374 0 10.683-.282 15.914-.824 21.017 24.873 52.435 40.674 87.549 40.674s66.532-15.801 87.549-40.674c5.231.542 10.539.824 15.914.824 84.244 0 152.537-68.294 152.537-152.538 0-33.518-10.819-64.504-29.144-89.676z'
 const CO2_CLOUD_CIRCLES = [
@@ -158,7 +159,7 @@ function rgba(hex: string, alpha: number): string {
 }
 
 function getTemplateSize(): WatercolorTextureSize {
-    return webUiThemeSettings.contextRegionCloudTextureSize
+    return contextRegionCloudTheme.textureSize
 }
 
 function drawGradientEllipse(
@@ -360,8 +361,8 @@ function addExactCo2CloudBorder(ctx: CanvasRenderingContext2D, style: ContextReg
     const ringCtx = ringCanvas.getContext('2d')
     if (!ringCtx) return
 
-    fillCo2MainCloudShape(ringCtx, size, rgba(style.palette.edge, webUiThemeSettings.contextRegionCloudBorderMainAlpha))
-    fillCo2ThoughtCircles(ringCtx, size, rgba(style.palette.edge, webUiThemeSettings.contextRegionCloudBorderThoughtCircleAlpha))
+    fillCo2MainCloudShape(ringCtx, size, rgba(style.palette.edge, contextRegionCloudTheme.borderMainAlpha))
+    fillCo2ThoughtCircles(ringCtx, size, rgba(style.palette.edge, contextRegionCloudTheme.borderThoughtCircleAlpha))
 
     ringCtx.globalCompositeOperation = 'destination-out'
     fillCo2MainCloudShape(ringCtx, size, 'rgba(0, 0, 0, 1)', 0.965)
@@ -504,10 +505,10 @@ function paintWatercolorPixels(ctx: CanvasRenderingContext2D, style: ContextRegi
     const pool = hexToRgb(style.palette.pool)
     const bloom = hexToRgb(style.palette.bloom)
     const edge = hexToRgb(style.palette.edge)
-    const gradientBaseColor = hexToRgb(webUiThemeSettings.contextRegionCloudGradientBaseColor)
-    const gradientColors = webUiThemeSettings.contextRegionCloudGradientColors.map(hexToRgb)
-    const gradientPositions = webUiThemeSettings.contextRegionCloudGradientPositions
-    const maskAlphaThreshold = webUiThemeSettings.contextRegionCloudMaskAlphaThreshold
+    const gradientBaseColor = hexToRgb(contextRegionCloudTheme.gradientBaseColor)
+    const gradientColors = contextRegionCloudTheme.gradientColors.map(hexToRgb)
+    const gradientPositions = contextRegionCloudTheme.gradientPositions
+    const maskAlphaThreshold = contextRegionCloudTheme.maskAlphaThreshold
     const seed = style.seed
     const minSize = Math.min(width, height)
 
@@ -637,7 +638,7 @@ function createWatercolorTexture(style: ContextRegionCloudStyle): Texture {
     addCo2CloudPaintPools(ctx, style, size, random)
     addWatercolorCutbacks(ctx, style, size, random)
     addWatercolorPigmentSpeckles(ctx, style, size, random)
-    if (webUiThemeSettings.contextRegionCloudBorderEnabled) addExactCo2CloudBorder(ctx, style, size)
+    if (contextRegionCloudTheme.borderEnabled) addExactCo2CloudBorder(ctx, style, size)
     applyCo2CloudMask(ctx, size)
 
     return Texture.from(canvas)
@@ -667,13 +668,13 @@ function drawTitle(text: Text, datum: ContextRegionCloudDatum, style: ContextReg
     text.text = datum.title
     text.style = {
         fill: colorNumber(style.palette.ink),
-        fontFamily: webUiThemeSettings.contextRegionCloudTitleFontFamily,
-        fontSize: scaleCanvasChromeForZoom(webUiThemeSettings.contextRegionCloudTitleFontSize, zoom),
-        fontWeight: webUiThemeSettings.contextRegionCloudTitleFontWeight,
+        fontFamily: contextRegionCloudTheme.titleFontFamily,
+        fontSize: scaleCanvasChromeForZoom(contextRegionCloudTheme.titleFontSize, zoom),
+        fontWeight: contextRegionCloudTheme.titleFontWeight,
     }
     text.position.set(rect.x, rect.y)
     text.scale.set(1)
-    text.alpha = webUiThemeSettings.contextRegionCloudTitleAlpha
+    text.alpha = contextRegionCloudTheme.titleAlpha
 }
 
 function drawChrome(entry: PixiContextRegionEntry, viewport: ContextRegionViewport): void {
@@ -737,7 +738,7 @@ export function createPixiContextRegionLayer(options: PixiContextRegionLayerOpti
     }
 
     function getTexture(style: ContextRegionCloudStyle): Texture {
-        const borderKey = webUiThemeSettings.contextRegionCloudBorderEnabled ? 'border' : 'no-border'
+        const borderKey = contextRegionCloudTheme.borderEnabled ? 'border' : 'no-border'
         const textureKey = `${CONTEXT_REGION_TEXTURE_VERSION}:${borderKey}:${style.key}`
         const existing = textureCache.get(textureKey)
         if (existing) return existing
@@ -795,7 +796,7 @@ export function createPixiContextRegionLayer(options: PixiContextRegionLayerOpti
         entry.backdrop.position.set(backdropRect.x, backdropRect.y)
         entry.backdrop.width = backdropRect.size
         entry.backdrop.height = backdropRect.size
-        entry.backdrop.alpha = datum.selected ? webUiThemeSettings.contextRegionCloudSelectedAlpha : webUiThemeSettings.contextRegionCloudIdleAlpha
+        entry.backdrop.alpha = datum.selected ? contextRegionCloudTheme.selectedAlpha : contextRegionCloudTheme.idleAlpha
 
         const geometryKey = getGeometryKey(datum, currentViewport)
         if (entry.geometryKey !== geometryKey) {
@@ -865,13 +866,13 @@ export function createPixiContextRegionLayer(options: PixiContextRegionLayerOpti
         for (const entry of entries.values()) {
             if (entry.pulseStartedAt === null) continue
             const elapsed = now - entry.pulseStartedAt
-            const progress = Math.min(1, elapsed / webUiThemeSettings.contextRegionCloudPulseDurationMs)
+            const progress = Math.min(1, elapsed / contextRegionCloudTheme.pulseDurationMs)
             const lift = Math.sin(progress * Math.PI)
             const style = getContextRegionCloudStyle(entry.datum.nodeId, entry.datum.width, entry.datum.height)
             const backdropRect = getBackdropRect(entry.datum, style)
-            const baseAlpha = entry.datum.selected ? webUiThemeSettings.contextRegionCloudSelectedAlpha : webUiThemeSettings.contextRegionCloudIdleAlpha
-            entry.backdrop.alpha = baseAlpha + lift * webUiThemeSettings.contextRegionCloudPulseAlphaLift
-            entry.backdrop.position.set(backdropRect.x, backdropRect.y)
+            const baseAlpha = entry.datum.selected ? contextRegionCloudTheme.selectedAlpha : contextRegionCloudTheme.idleAlpha
+            entry.backdrop.alpha = baseAlpha + lift * contextRegionCloudTheme.pulseAlphaLift
+            entry.backdrop.position.set(backdropRect.x, backdropRect.y - lift * contextRegionCloudTheme.pulseLiftPx)
             if (progress >= 1) {
                 entry.pulseStartedAt = null
                 entry.backdrop.alpha = baseAlpha

--- a/services/web-ui/src/infographics/workspace/workspace-canvas.test.ts
+++ b/services/web-ui/src/infographics/workspace/workspace-canvas.test.ts
@@ -780,10 +780,16 @@ describe('AI chat region PIXI cloud layer', () => {
 	it('keeps context region DOM nodes as non-visual PIXI-owned proxies', () => {
 		expectSourceToContain(ts, 'workspace-context-region-node--pixi-owned')
 		expectSourceNotToContain(themeSettings, 'contextRegionAreaShiftingGradientColors')
-		expectSourceToContain(themeSettings, 'contextRegionCloudGradientColors')
-		expectSourceToContain(themeSettings, 'contextRegionCloudStyles')
-		expectSourceToContain(cloudTs, 'webUiThemeSettings.contextRegionCloudStyles')
-		expectSourceToContain(cloudLayerTs, 'webUiThemeSettings.contextRegionCloudGradientColors')
+		expectSourceToContain(themeSettings, 'contextRegion: WebUiContextRegionThemeSettings')
+		expectSourceToContain(themeSettings, 'cloud: WebUiContextRegionCloudThemeSettings')
+		expectSourceToContain(themeSettings, 'palettes: ContextRegionCloudThemePalettes')
+		expectSourceToContain(cloudTs, 'const contextRegionCloudTheme = webUiThemeSettings.contextRegion.cloud')
+		expectSourceToContain(cloudLayerTs, 'const contextRegionCloudTheme = webUiThemeSettings.contextRegion.cloud')
+		expectSourceNotToContain(themeSettings, 'contextRegionCloudStyles')
+		expectSourceNotToContain(themeSettings, 'contextRegionCloudGradientColors')
+		expectSourceNotToContain(themeSettings, 'contextRegionCloudPalettes')
+		expectSourceNotToContain(cloudTs, 'webUiThemeSettings.contextRegionCloud')
+		expectSourceNotToContain(cloudLayerTs, 'webUiThemeSettings.contextRegionCloud')
 		expectSourceNotToContain(ts, 'workspace-ai-chat-thread-region__title-bar')
 		expectSourceToContain(scss, 'pointer-events: none')
 		expectSourceToContain(scss, 'background: transparent')
@@ -810,7 +816,8 @@ describe('AI chat region PIXI cloud layer', () => {
 	})
 
 	it('uses shared cloud styles for hit testing and adoption scoring', () => {
-		expectSourceToContain(cloudTs, 'export const CONTEXT_REGION_CLOUD_STYLES')
+		expectSourceToContain(cloudTs, 'const contextRegionCloudTheme = webUiThemeSettings.contextRegion.cloud')
+		expectSourceToContain(cloudTs, 'export const CONTEXT_REGION_CLOUD_STYLES: ContextRegionCloudStyle[] = contextRegionCloudTheme.styles')
 		expectSourceToContain(cloudTs, 'hitTestContextRegionCloud')
 		expectSourceToContain(cloudTs, 'rectIntersectsContextRegionCloud')
 		expectSourceToContain(cloudTs, 'scoreRectAgainstContextRegionCloud')
@@ -1514,7 +1521,7 @@ describe('Workspace canvas — multi-selection and group drag', () => {
 
 	it('group drag skips collision resolution for multi-node moves to preserve rigid spacing', () => {
 		expectSourceToContain(ts, 'if (dragPlan.allowCollisionResolution) {')
-		expectSourceToContain(ts, 'resolveCollisions(nodeBoxes')
+		expectSourceToContain(ts, 'resolveCollisions(collisionPlan.nodeBoxes')
 	})
 
 	it('context-region drag skips proximity checks during movement', () => {
@@ -1524,6 +1531,63 @@ describe('Workspace canvas — multi-selection and group drag', () => {
 
 		expect(fnBody).toContain('if (dragPlan.allowProximityConnection) {')
 		expect(fnBody).toContain('connectionManager?.checkProximity(resolvedNodeId, currentPos, currentDims)')
+	})
+})
+
+// =============================================================================
+// Collision resolution ownership
+// =============================================================================
+
+describe('Workspace canvas — collision resolution ownership', () => {
+	const ts = loadTs()
+	const svelte = loadWorkspaceCanvasSvelte()
+	const collisionTs = readSourceFile('../utils/resolveCollisions.ts', 'utils/resolveCollisions.ts')
+
+	it('keeps toolbar insertion collision logic out of the Svelte wrapper', () => {
+		expectSourceToContain(svelte, 'renderer?.insertNodeAtViewportCenter(documentNode)')
+		expectSourceToContain(svelte, 'renderer?.insertNodeAtViewportCenter(imageNode)')
+		expectSourceToContain(svelte, 'renderer?.insertNodeAtViewportCenter(contextRegionNode, { lastActiveAiChatThreadId: thread.threadId })')
+		expectSourceNotToContain(svelte, "from '$src/infographics/utils/resolveCollisions.ts'")
+		expectSourceNotToContain(svelte, 'resolveInsertionCollisions')
+		expectSourceNotToContain(svelte, 'computeViewportCenterInsertionPosition')
+		expectSourceNotToContain(svelte, 'contextRegionCloudsIntersect')
+		expectSourceNotToContain(svelte, 'rectIntersectsContextRegionCloud')
+	})
+
+	it('routes toolbar insertion through the workspace renderer collision path', () => {
+		expectSourceToContain(ts, 'insertNodeAtViewportCenter(node: WorkspaceCanvasNodeInsertion, statePatch: WorkspaceCanvasInsertionStatePatch = {})')
+		expectSourceToContain(ts, 'position: getCenteredInsertionPosition(node.dimensions),')
+		expectSourceToContain(ts, 'nodes: resolveTopLevelNodeCollisions([...baseCanvasState.nodes, positionedNode]),')
+		expectSourceToContain(ts, 'onCanvasStateChange?.(newCanvasState)')
+		expectSourceNotToContain(ts, 'screenDimensionsToWorldDimensions(node.dimensions')
+	})
+
+	it('builds shape-aware collision boxes around context-region cloud bounds', () => {
+		expectSourceToContain(ts, 'function createShapeAwareCollisionPlan(nodes: CanvasNode[], topLevelOnly = false): CollisionPlan')
+		expectSourceToContain(ts, 'const worldPosition = getNodeWorldPosition(node, nodesById)')
+		expectSourceToContain(ts, 'const cloudBounds = getContextRegionCloudBounds(datum)')
+		expectSourceToContain(ts, 'x: worldPosition.x - cloudBounds.x')
+		expectSourceToContain(ts, 'return { id: node.nodeId, ...cloudBounds }')
+	})
+
+	it('filters broad-phase overlaps through context-region cloud geometry', () => {
+		expectSourceToContain(ts, 'const shouldResolvePair = (a: CollisionBox, b: CollisionBox): boolean => {')
+		expectSourceToContain(ts, 'contextRegionCloudGeometry.contextRegionCloudsIntersect(datumA, datumB)')
+		expectSourceToContain(ts, 'contextRegionCloudGeometry.rectIntersectsContextRegionCloud(datumA, b)')
+		expectSourceToContain(ts, 'contextRegionCloudGeometry.rectIntersectsContextRegionCloud(datumB, a)')
+	})
+
+	it('uses the shared generic resolver rather than a workspace-specific duplicate', () => {
+		expectSourceToContain(collisionTs, 'export function resolveCollisions(')
+		expectSourceToContain(collisionTs, 'shouldResolvePair?: (a: NodeBox, b: NodeBox) => boolean')
+		expectSourceToContain(ts, "import { resolveCollisions } from '$src/infographics/utils/resolveCollisions.ts'")
+		expectSourceToContain(ts, 'resolveCollisions(collisionPlan.nodeBoxes')
+	})
+
+	it('keeps parent-child containment out of collision pushes', () => {
+		expectSourceToContain(ts, 'if (child.parentId) collisionExclusions.add(`${child.parentId}-${child.nodeId}`)')
+		expectSourceToContain(ts, 'excludePairs: collisionExclusions.size > 0 ? collisionExclusions : undefined')
+		expectSourceToContain(ts, 'toParentRelativePosition(resolvedPosition, n.parentId, getCanvasNodesById(updatedNodes))')
 	})
 })
 

--- a/services/web-ui/src/infographics/workspace/workspaceDragPlan.test.ts
+++ b/services/web-ui/src/infographics/workspace/workspaceDragPlan.test.ts
@@ -152,7 +152,7 @@ describe('computeWorkspaceDragPlan — context region drags', () => {
         })
 
         expect(result.draggedNodeIds).toEqual(['active-region'])
-        expect(result.allowCollisionResolution).toBe(false)
+        expect(result.allowCollisionResolution).toBe(true)
     })
 
     it('moves every selected context region as one group', () => {
@@ -168,7 +168,7 @@ describe('computeWorkspaceDragPlan — context region drags', () => {
         expect(result.resolvedNodeId).toBe('region-b')
         expect(result.draggedNodeIds).toEqual(['region-a', 'region-b'])
         expect(result.allowProximityConnection).toBe(false)
-        expect(result.allowCollisionResolution).toBe(false)
+        expect(result.allowCollisionResolution).toBe(true)
     })
 
     it('moves selected regions with their real children but not unrelated leaves', () => {
@@ -210,10 +210,10 @@ describe('computeWorkspaceDragPlan — context region drags', () => {
 
         expect(result.draggedNodeIds).toEqual(['region-1', 'doc-1'])
         expect(result.draggedNodeIds).not.toContain('generated-output')
-        expect(result.allowCollisionResolution).toBe(false)
+        expect(result.allowCollisionResolution).toBe(true)
     })
 
-    it('disables global collision resolution for context region release', () => {
+    it('enables top-level collision resolution for context region release', () => {
         const result = plan({
             nodes: [makeRegion({ nodeId: 'region-1' })],
             primaryNodeId: 'region-1',
@@ -221,7 +221,7 @@ describe('computeWorkspaceDragPlan — context region drags', () => {
 
         expect(result.isContextRegionDrag).toBe(true)
         expect(result.allowProximityConnection).toBe(false)
-        expect(result.allowCollisionResolution).toBe(false)
+        expect(result.allowCollisionResolution).toBe(true)
     })
 })
 

--- a/services/web-ui/src/infographics/workspace/workspaceDragPlan.ts
+++ b/services/web-ui/src/infographics/workspace/workspaceDragPlan.ts
@@ -68,7 +68,7 @@ export function computeWorkspaceDragPlan(input: WorkspaceDragPlanInput): Workspa
         draggedNodeIds,
         isContextRegionDrag,
         allowProximityConnection: !isContextRegionDrag,
-        allowCollisionResolution: draggedNodeIds.length === 1 && !isContextRegionDrag,
+        allowCollisionResolution: draggedNodeIds.length === 1 || isContextRegionDrag,
     }
 }
 

--- a/services/web-ui/src/services/ai-prompt-input-controller.ts
+++ b/services/web-ui/src/services/ai-prompt-input-controller.ts
@@ -11,6 +11,7 @@ import type {
 } from '@lixpi/constants'
 
 import { USE_AI_CHAT_META } from '$src/components/proseMirror/plugins/aiChatThreadPlugin/aiChatThreadPluginConstants.ts'
+import { webUiThemeSettings } from '$src/webUiThemeSettings.ts'
 
 type ThreadEditorEntry = {
     editorView: EditorView
@@ -305,9 +306,11 @@ export class AiPromptInputController {
             const targetCanvasNode = canvasState.nodes.find((n: CanvasNode) => n.nodeId === targetNodeId)
             if (!targetCanvasNode) return
 
+            const threadDimensions = { ...webUiThemeSettings.contextRegion.defaultDimensions }
+
             // Position the new thread to the right of the target node
             const threadPosition = {
-                x: targetCanvasNode.position.x + (targetCanvasNode.dimensions?.width ?? 400) + 50,
+                x: targetCanvasNode.position.x + (targetCanvasNode.dimensions?.width ?? 400) + webUiThemeSettings.contextRegion.adjacentNodeGap,
                 y: targetCanvasNode.position.y
             }
 
@@ -316,7 +319,7 @@ export class AiPromptInputController {
                 type: 'contextRegion',
                 referenceId: threadId,
                 position: threadPosition,
-                dimensions: { width: 400, height: 500 }
+                dimensions: threadDimensions,
             }
 
             const edge: WorkspaceEdge = {

--- a/services/web-ui/src/webUiThemeSettings.test.ts
+++ b/services/web-ui/src/webUiThemeSettings.test.ts
@@ -1,0 +1,64 @@
+'use strict'
+
+import { describe, it, expect } from 'vitest'
+import { webUiThemeSettings } from '$src/webUiThemeSettings.ts'
+
+function collectGetterPaths(value: unknown, prefix = ''): string[] {
+	if (!value || typeof value !== 'object' || Array.isArray(value)) return []
+
+	const paths: string[] = []
+	for (const [key, descriptor] of Object.entries(Object.getOwnPropertyDescriptors(value))) {
+		const path = prefix ? `${prefix}.${key}` : key
+		if (typeof descriptor.get === 'function') {
+			paths.push(path)
+			continue
+		}
+
+		if ('value' in descriptor) {
+			paths.push(...collectGetterPaths(descriptor.value, path))
+		}
+	}
+
+	return paths
+}
+
+// =============================================================================
+// CONTEXT REGION THEME SETTINGS
+// =============================================================================
+
+describe('webUiThemeSettings — context region configuration', () => {
+	it('keeps context-region cloud palettes inside contextRegion.cloud', () => {
+		expect(webUiThemeSettings.contextRegion.cloud.palettes.mist).toEqual({
+			pool: '#C7DAD4',
+			bloom: '#EEF8F5',
+			edge: '#A1C3BA',
+			ink: '#1F2937',
+		})
+		expect(webUiThemeSettings.contextRegion.cloud.palettes.seafoam.edge).toBe('#8FB5AB')
+		expect(Object.hasOwn(webUiThemeSettings, 'contextRegionCloudPalettes')).toBe(false)
+	})
+
+	it('uses a getter only where cloud styles need sibling palettes', () => {
+		const cloudSettings = webUiThemeSettings.contextRegion.cloud
+		const descriptor = Object.getOwnPropertyDescriptor(cloudSettings, 'styles')
+
+		expect(typeof descriptor?.get).toBe('function')
+		expect(cloudSettings.styles[0].palette).toBe(cloudSettings.palettes.mist)
+		expect(cloudSettings.styles.some((style) => style.palette === cloudSettings.palettes.seafoam)).toBe(true)
+	})
+
+	it('does not use getters for ordinary static settings', () => {
+		expect(collectGetterPaths(webUiThemeSettings)).toEqual(['contextRegion.cloud.styles'])
+	})
+
+	it('keeps branch lineage and context-region layout knobs in grouped subsections', () => {
+		expect(webUiThemeSettings.contextRegion.defaultDimensions.width).toBeGreaterThan(0)
+		expect(webUiThemeSettings.contextRegion.defaultDimensions.height).toBeGreaterThan(0)
+		expect(webUiThemeSettings.contextRegion.adjacentNodeGap).toBeGreaterThanOrEqual(0)
+		expect(webUiThemeSettings.imageBranchLineage.generatedImageSize).toBeGreaterThan(0)
+		expect(webUiThemeSettings.imageBranchLineage.contextRegionOutputGap).toBeGreaterThanOrEqual(0)
+		expect(webUiThemeSettings.imageBranchLineage.imageToImageGap).toBeGreaterThanOrEqual(0)
+		expect(Object.hasOwn(webUiThemeSettings.contextRegion, 'cloud')).toBe(true)
+		expect(Object.hasOwn(webUiThemeSettings, 'imageBranchLineage')).toBe(true)
+	})
+})

--- a/services/web-ui/src/webUiThemeSettings.ts
+++ b/services/web-ui/src/webUiThemeSettings.ts
@@ -16,6 +16,11 @@ export type ContextRegionCloudThemePalette = {
     ink: string
 }
 
+export type ContextRegionCloudThemePalettes = {
+    mist: ContextRegionCloudThemePalette
+    seafoam: ContextRegionCloudThemePalette
+}
+
 export type ContextRegionCloudThemeStyle = {
     key: string
     aspect: 'wide' | 'square' | 'tall'
@@ -30,6 +35,49 @@ export type WebUiImageNodeThemeSettings = {
     contextRegionChildImageFrameColor: string
     contextRegionChildImageDropShadow: string
     modelBadgeBoxShadow: string
+}
+
+export type WebUiContextRegionThemeSettings = {
+    defaultDimensions: ContextRegionCloudThemeSize
+    adjacentNodeGap: number
+    cloud: WebUiContextRegionCloudThemeSettings
+}
+
+export type WebUiImageBranchLineageThemeSettings = {
+    generatedImageSize: number
+    contextRegionOutputGap: number
+    imageToImageGap: number
+}
+
+export type WebUiContextRegionCloudThemeSettings = {
+    palettes: ContextRegionCloudThemePalettes
+    textureSize: ContextRegionCloudThemeSize
+    maskAlphaThreshold: number
+    minBleed: number
+    resizeEdgeHitRadiusPx: number
+    gradientBaseColor: string
+    gradientColors: [string, string, string, string]
+    gradientPositions: ContextRegionCloudThemeGradientPositions
+    styles: ContextRegionCloudThemeStyle[]
+    borderEnabled: boolean
+    borderMainAlpha: number
+    borderThoughtCircleAlpha: number
+    idleAlpha: number
+    selectedAlpha: number
+    pulseDurationMs: number
+    pulseAlphaLift: number
+    pulseLiftPx: number
+    titleFontFamily: string
+    titleFontSize: number
+    titleFontWeight: string
+    titleAlpha: number
+    titleHeight: number
+    titleCharWidth: number
+    titleMinWidth: number
+    titleMaxWidth: number
+    titlePaddingX: number
+    titleMinX: number
+    titleGap: number
 }
 
 export type WebUiThemeSettings = {
@@ -56,56 +104,17 @@ export type WebUiThemeSettings = {
     // context selection).
     // Hex strings. The shifting gradient renderer converts these to RGB internally.
     shiftingGradientColors: [string, string, string, string]
+
     imageNode: WebUiImageNodeThemeSettings
 
+    contextRegion: WebUiContextRegionThemeSettings
 
-    // Context region cloud visual settings.
-    contextRegionCloudTextureSize: ContextRegionCloudThemeSize
-    contextRegionCloudMaskAlphaThreshold: number
-    contextRegionCloudMinBleed: number
-    contextRegionCloudGradientBaseColor: string
-    contextRegionCloudGradientColors: [string, string, string, string]
-    contextRegionCloudGradientPositions: ContextRegionCloudThemeGradientPositions
-    contextRegionCloudStyles: ContextRegionCloudThemeStyle[]
-    contextRegionCloudBorderEnabled: boolean
-    contextRegionCloudBorderMainAlpha: number
-    contextRegionCloudBorderThoughtCircleAlpha: number
-    contextRegionCloudIdleAlpha: number
-    contextRegionCloudSelectedAlpha: number
-    contextRegionCloudPulseDurationMs: number
-    contextRegionCloudPulseAlphaLift: number
-    contextRegionCloudPulseLiftPx: number
-    contextRegionCloudTitleFontFamily: string
-    contextRegionCloudTitleFontSize: number
-    contextRegionCloudTitleFontWeight: string
-    contextRegionCloudTitleAlpha: number
-    contextRegionCloudTitleHeight: number
-    contextRegionCloudTitleCharWidth: number
-    contextRegionCloudTitleMinWidth: number
-    contextRegionCloudTitleMaxWidth: number
-    contextRegionCloudTitlePaddingX: number
-    contextRegionCloudTitleMinX: number
-    contextRegionCloudTitleGap: number
+    imageBranchLineage: WebUiImageBranchLineageThemeSettings
 }
 
 const brandColors = {
     steelBlue: '#5d656d'
 }
-
-const contextRegionCloudPalettes = {
-    mist: {
-        pool: '#C7DAD4',
-        bloom: '#EEF8F5',
-        edge: '#A1C3BA',
-        ink: '#1F2937',
-    },
-    seafoam: {
-        pool: '#C7DAD4',
-        bloom: '#EEF8F5',
-        edge: '#8FB5AB',
-        ink: '#1F2937',
-    },
-} satisfies Record<string, ContextRegionCloudThemePalette>
 
 export const webUiThemeSettings: WebUiThemeSettings = {
     // Background color for AI response message bubbles and their pigtail (speech bubble tail).
@@ -155,54 +164,126 @@ export const webUiThemeSettings: WebUiThemeSettings = {
     // Dreamy sky pastel palette — whisper pink, lavender, periwinkle, orchid.
     shiftingGradientColors: ['#FFF5FA', '#F5EFF9', '#E6E9F6', '#F3E4F2'],
 
-    // Canvas image node styles
+    // Canvas image node settings. These values style image-node chrome and selection states.
     imageNode: {
+        // Box shadow applied when an image node is selected. Increasing this makes selected images read as more prominent on the canvas.
         selectedBoxShadow: '0 2px 12px rgba(0, 0, 0, 0.3)',
+        // Frame color used for image nodes parented inside a context region. Changing it updates the card-like surface around adopted images.
         contextRegionChildImageFrameColor: '#FCFCFA',
+        // Drop shadow used by image nodes parented inside a context region. Larger shadows make child images feel more lifted from the cloud.
         contextRegionChildImageDropShadow: '0 10px 24px rgba(31, 49, 42, 0.16), 0 1px 2px rgba(31, 49, 42, 0.08)',
+        // Shadow behind the generated-image model badge. Increasing it improves badge separation on busy image pixels.
         modelBadgeBoxShadow: '0 1px 3px rgba(0, 0, 0, 0.15)',
     },
 
 
-    // Context region cloud visual settings.
-    // Pale seafoam palette fit to the region backdrop in gradient-sample.png.
-    // The center needs visible depth without collapsing into a gray block.
-    contextRegionCloudTextureSize: { width: 1080, height: 1080 },
-    contextRegionCloudMaskAlphaThreshold: 0.045,
-    contextRegionCloudMinBleed: 28,
-    contextRegionCloudGradientBaseColor: '#E5F2EE',
-    contextRegionCloudGradientColors: ['#DDECE7', '#C7DAD4', '#EEF8F5', '#D6E7E1'],
-    contextRegionCloudGradientPositions: [
-        { x: 0.2, y: 0.9 },
-        { x: 0.65, y: 0.75 },
-        { x: 0.8, y: 0.1 },
-        { x: 0.35, y: 0.25 },
-    ],
-    contextRegionCloudStyles: [
-        { key: 'seafoam-wide-a', aspect: 'wide', bleedRatio: 0.30, titleAnchor: { x: 0.12, y: 0.12 }, palette: contextRegionCloudPalettes.mist, seed: 1103 },
-        { key: 'seafoam-wide-b', aspect: 'wide', bleedRatio: 0.32, titleAnchor: { x: 0.10, y: 0.12 }, palette: contextRegionCloudPalettes.seafoam, seed: 1291 },
-        { key: 'seafoam-square-a', aspect: 'square', bleedRatio: 0.30, titleAnchor: { x: 0.12, y: 0.12 }, palette: contextRegionCloudPalettes.mist, seed: 1427 },
-        { key: 'seafoam-square-b', aspect: 'square', bleedRatio: 0.31, titleAnchor: { x: 0.13, y: 0.12 }, palette: contextRegionCloudPalettes.seafoam, seed: 1559 },
-        { key: 'seafoam-tall-a', aspect: 'tall', bleedRatio: 0.30, titleAnchor: { x: 0.14, y: 0.12 }, palette: contextRegionCloudPalettes.mist, seed: 1667 },
-        { key: 'seafoam-tall-b', aspect: 'tall', bleedRatio: 0.30, titleAnchor: { x: 0.13, y: 0.12 }, palette: contextRegionCloudPalettes.seafoam, seed: 1789 },
-    ],
-    contextRegionCloudBorderEnabled: false,
-    contextRegionCloudBorderMainAlpha: 0.22,
-    contextRegionCloudBorderThoughtCircleAlpha: 0.20,
-    contextRegionCloudIdleAlpha: 0.98,
-    contextRegionCloudSelectedAlpha: 1,
-    contextRegionCloudPulseDurationMs: 700,
-    contextRegionCloudPulseAlphaLift: 0.02,
-    contextRegionCloudPulseLiftPx: 3,
-    contextRegionCloudTitleFontFamily: 'Inter, ui-sans-serif, system-ui, sans-serif',
-    contextRegionCloudTitleFontSize: 20,
-    contextRegionCloudTitleFontWeight: '650',
-    contextRegionCloudTitleAlpha: 0.80,
-    contextRegionCloudTitleHeight: 30,
-    contextRegionCloudTitleCharWidth: 8.25,
-    contextRegionCloudTitleMinWidth: 112,
-    contextRegionCloudTitleMaxWidth: 280,
-    contextRegionCloudTitlePaddingX: 20,
-    contextRegionCloudTitleMinX: 22,
-    contextRegionCloudTitleGap: 10,
+    // Context region layout settings. These values affect newly created context-region nodes, not regions already persisted in canvas state.
+    contextRegion: {
+        // Default canvas-unit size for newly created context regions. Increasing it creates larger starter clouds across toolbar, prompt, and edit-thread flows.
+        defaultDimensions: { width: 640, height: 480 },
+        // Canvas-unit gap when a new context region is placed next to an existing node. Increasing it puts more breathing room between source images and new edit regions.
+        adjacentNodeGap: 50,
+
+        // Context region cloud visual settings. These values control the PIXI-rendered CO2 cloud surface, hit geometry padding, title placement, and pulse behavior.
+        cloud: {
+            // Reusable color palettes referenced by cloud style variants. Add new palettes here before assigning them to styles.
+            palettes: {
+                // Softer mist palette for lighter, lower-contrast cloud variants.
+                mist: {
+                    pool: '#C7DAD4',
+                    bloom: '#EEF8F5',
+                    edge: '#A1C3BA',
+                    ink: '#1F2937',
+                },
+                // Slightly stronger seafoam palette for variants that need a clearer cloud edge.
+                seafoam: {
+                    pool: '#C7DAD4',
+                    bloom: '#EEF8F5',
+                    edge: '#8FB5AB',
+                    ink: '#1F2937',
+                },
+            },
+
+            // Pixel size of the offscreen watercolor texture template. Larger values can look crisper but use more memory and texture upload time.
+            textureSize: { width: 1080, height: 1080 },
+            // Alpha cutoff used when building the cloud mask. Raising it trims faint edges; lowering it keeps more soft transparent edge pixels.
+            maskAlphaThreshold: 0.045,
+            // Minimum canvas-unit bleed beyond the logical context-region rectangle. Increasing it expands the visible cloud and its placement/collision bounds.
+            minBleed: 28,
+            // Screen-pixel radius around the visible cloud edge that activates resize handles and resize cursors. Increasing it makes edge resize easier to trigger; lowering it requires more precise pointer placement.
+            resizeEdgeHitRadiusPx: 24,
+            // Base underpaint color for the cloud texture. Changing it shifts the overall tint before watercolor colors are blended in.
+            gradientBaseColor: '#E5F2EE',
+            // Watercolor colors mixed across the cloud surface. Changing these alters the main visible cloud palette.
+            gradientColors: ['#DDECE7', '#C7DAD4', '#EEF8F5', '#D6E7E1'],
+            // Normalized color anchor positions for the cloud gradient. Moving a point changes where its matching gradient color blooms on the cloud.
+            gradientPositions: [
+                { x: 0.2, y: 0.9 },
+                { x: 0.65, y: 0.75 },
+                { x: 0.8, y: 0.1 },
+                { x: 0.35, y: 0.25 },
+            ],
+            // Shape variants chosen by aspect ratio and node id. This is a getter only because styles self-reference sibling palettes through `this`; do not use getters for static settings.
+            get styles(): ContextRegionCloudThemeStyle[] {
+                return [
+                    { key: 'seafoam-wide-a', aspect: 'wide', bleedRatio: 0.30, titleAnchor: { x: 0.12, y: 0.12 }, palette: this.palettes.mist, seed: 1103 },
+                    { key: 'seafoam-wide-b', aspect: 'wide', bleedRatio: 0.32, titleAnchor: { x: 0.10, y: 0.12 }, palette: this.palettes.seafoam, seed: 1291 },
+                    { key: 'seafoam-square-a', aspect: 'square', bleedRatio: 0.30, titleAnchor: { x: 0.12, y: 0.12 }, palette: this.palettes.mist, seed: 1427 },
+                    { key: 'seafoam-square-b', aspect: 'square', bleedRatio: 0.31, titleAnchor: { x: 0.13, y: 0.12 }, palette: this.palettes.seafoam, seed: 1559 },
+                    { key: 'seafoam-tall-a', aspect: 'tall', bleedRatio: 0.30, titleAnchor: { x: 0.14, y: 0.12 }, palette: this.palettes.mist, seed: 1667 },
+                    { key: 'seafoam-tall-b', aspect: 'tall', bleedRatio: 0.30, titleAnchor: { x: 0.13, y: 0.12 }, palette: this.palettes.seafoam, seed: 1789 },
+                ]
+            },
+            // Enables an exact CO2-shape border around the cloud. Turning it on makes region boundaries more explicit.
+            borderEnabled: false,
+            // Alpha for the optional main cloud border. Increasing it makes the large cloud outline stronger when borders are enabled.
+            borderMainAlpha: 0.22,
+            // Alpha for the optional thought-circle borders. Increasing it makes the small detached circles read more clearly when borders are enabled.
+            borderThoughtCircleAlpha: 0.20,
+            // Base opacity for unselected clouds. Lower values make inactive context regions recede into the canvas.
+            idleAlpha: 0.98,
+            // Base opacity for selected clouds. Lower values make selected context regions less visually dominant.
+            selectedAlpha: 1,
+            // Duration of the context-region pulse animation in milliseconds. Increasing it makes selection/submission feedback linger longer.
+            pulseDurationMs: 700,
+            // Extra opacity added during a pulse. Increasing it makes pulse feedback more noticeable.
+            pulseAlphaLift: 0.02,
+            // Upward canvas-pixel lift during a pulse. Increasing it makes the cloud visibly bob more during feedback.
+            pulseLiftPx: 3,
+            // Font family for context-region titles. Changing it affects all PIXI-rendered cloud labels.
+            titleFontFamily: 'Inter, ui-sans-serif, system-ui, sans-serif',
+            // Base title font size before zoom compensation. Increasing it makes context-region labels larger on screen.
+            titleFontSize: 20,
+            // Font weight for context-region titles. Increasing it makes labels heavier and more prominent.
+            titleFontWeight: '650',
+            // Opacity for context-region title text. Lower values make labels softer against the canvas.
+            titleAlpha: 0.80,
+            // Reserved title hit/render height before zoom compensation. Increasing it creates more vertical room for label hit testing and placement.
+            titleHeight: 30,
+            // Approximate character width used to estimate title label width. Increasing it reserves more horizontal label space per character.
+            titleCharWidth: 8.25,
+            // Minimum title label width before zoom compensation. Increasing it prevents short titles from becoming too narrow.
+            titleMinWidth: 112,
+            // Maximum title label width before zoom compensation. Increasing it lets longer titles occupy more space before clamping.
+            titleMaxWidth: 280,
+            // Horizontal title padding before zoom compensation. Increasing it gives text more breathing room inside the title hit area.
+            titlePaddingX: 20,
+            // Minimum title x-offset from the cloud visual bounds. Increasing it pushes labels farther right from the cloud's left edge.
+            titleMinX: 22,
+            // Vertical gap between the cloud visual bounds and the title. Increasing it moves labels farther above the cloud.
+            titleGap: 10,
+        },
+
+    },
+
+
+    // Image branch lineage placement settings. These values control where newly generated image nodes appear in relation to regions and previous branch images.
+    imageBranchLineage: {
+        // Canvas-unit width and height for new generated image nodes. Increasing it makes each generated branch image larger when inserted.
+        generatedImageSize: 800,
+        // Canvas-unit horizontal gap between a context-region cloud's visual bounds and the first generated image in that branch. Increasing it moves first outputs farther right.
+        contextRegionOutputGap: 384,
+        // Canvas-unit horizontal gap between consecutive generated images in the same branch lineage. Increasing it stretches image-to-image branch spacing.
+        imageToImageGap: 192,
+    },
 }


### PR DESCRIPTION
Closes #175

## Summary

Three tightly related improvements to the canvas engine:

1. **Viewport-centered insertion at logical canvas dimensions** — new nodes always appear at 100% scale regardless of current zoom
2. **Shape-aware collision** — context-region collision uses the real irregular cloud geometry (same as resize/marquee/anchoring) instead of rectangular proxies
3. **Config centralization** — all canvas/workspace tuning knobs live in `webUiThemeSettings.ts` with a clear nesting convention

See #175 for the full change breakdown.

## Architecture boundary enforced

`WorkspaceCanvas.svelte` is now a thin Svelte wrapper only. All placement, collision, viewport math, and shape-aware planning lives in `WorkspaceCanvas.ts` and utilities. Svelte delegates via `renderer.insertNodeAtViewportCenter(...)`.

## Tests

727 tests passing (30 test files).