### PR TITLE
LIX-187 # Redesign feature extraction timeline UI, unify markdown rendering, harden extraction pipeline

### DIFF
--- a/documentation/coding-style-guides/MARKDOWN-RENDERING.md
+++ b/documentation/coding-style-guides/MARKDOWN-RENDERING.md
@@ -1,54 +1,7 @@
 # Markdown Rendering Coding Style Guide
 
-This guide applies to any code that displays markdown anywhere in the web UI.
+This guide applies to any code that displays markdown in the web UI.
 
-## The Rule
+**Rule:** all markdown rendering MUST go through `@lixpi/markdown-stream-parser`. Editable ProseMirror content uses the `aiChatThreadPlugin` (`StreamingInserter`); every other (non-editable) surface MUST use the unified `MarkdownStreamRenderer` (`services/web-ui/src/utils/markdownStreamRenderer.ts`). Never hand-roll markdown→HTML, render raw markdown as plain text, add another markdown library, or fork the segment→DOM mapping.
 
-**All markdown rendering MUST go through `@lixpi/markdown-stream-parser`.** Never hand-roll markdown→HTML, never render raw markdown as plain text, and never add a second markdown library (`marked`, `markdown-it`, `remark`, etc.). The parser is the single source of truth for how markdown is tokenized into segments; rendering is the application of styles to those segments.
-
-There are exactly two rendering paths, and you must use the one that matches the surface:
-
-| Surface | Renderer | Where |
-|---------|----------|-------|
-| **Editable** ProseMirror content (AI chat threads) | The ProseMirror plugin's `StreamingInserter` | [`aiChatThreadPlugin.ts`](../../services/web-ui/src/components/proseMirror/plugins/aiChatThreadPlugin/aiChatThreadPlugin.ts) |
-| **Non-editable** content (everything else) | The unified `MarkdownStreamRenderer` | [`markdownStreamRenderer.ts`](../../services/web-ui/src/utils/markdownStreamRenderer.ts) |
-
-Both consume the same parser and the same segment shape. Do not write a third segment→DOM mapping. If a new surface needs markdown, reuse one of these two — extend them if needed, never fork them.
-
-## Non-editable rendering: `MarkdownStreamRenderer`
-
-`src/utils/markdownStreamRenderer.ts` is the **only** approved way to render markdown outside ProseMirror. It feeds tokens to the parser and applies styles to the emitted segments as plain DOM (built with the `html` helper from `domTemplates.ts`).
-
-**Streaming** (tokens arrive over time — e.g. live model output). The renderer owns its `contentEl`, so it survives container re-renders; re-attach `contentEl` after a rebuild instead of recreating it:
-
-```typescript
-import { MarkdownStreamRenderer } from '$src/utils/markdownStreamRenderer.ts'
-
-const renderer = new MarkdownStreamRenderer(`${runId}:${stage}`, 'my-scroll-box lixpi-markdown')
-container.appendChild(renderer.contentEl)
-// for each streamed chunk:
-renderer.push(chunk)
-// when the stream ends:
-renderer.finalize()
-```
-
-**Static** (the full string is already available — e.g. a saved feature's instructions, a prompt preview):
-
-```typescript
-import { renderMarkdownStatic } from '$src/utils/markdownStreamRenderer.ts'
-
-mountEl.appendChild(renderMarkdownStatic(feature.instructions, `feature:${feature.featureId}`, 'feature-library-instructions-body lixpi-markdown'))
-```
-
-The `instanceId` must be unique per concurrent render (the parser is a singleton keyed by id). The optional `className` is applied to the content element; always include `lixpi-markdown` so the global styles apply, plus any surface-specific scroll/layout class.
-
-## Styles
-
-Markdown element styles are **global** and live in [`src/sass/_markdown.scss`](../../services/web-ui/src/sass/_markdown.scss) under `.lixpi-markdown` / `.lixpi-md-*`. They are global on purpose so the renderer is styled consistently on every surface. Do not redefine markdown element styles in a component stylesheet — only add surface-specific container styles (scroll box, max-height, background) on your own class alongside `lixpi-markdown`.
-
-## Forbidden
-
-- `element.innerHTML = someMarkdown` or any string-built markdown HTML.
-- Rendering markdown source as text (`<pre>${markdown}</pre>`, `${feature.instructions}` straight into the DOM).
-- Importing a markdown library other than `@lixpi/markdown-stream-parser`.
-- Copying the segment→DOM mapping into a new file instead of using `MarkdownStreamRenderer`.
+The authoritative reference — architecture, the two render paths, the parser contract, usage examples, styles, and the full do/don't list — lives in [documentation/features/MARKDOWN-RENDERING.md](../features/MARKDOWN-RENDERING.md). Read it before adding or changing any markdown rendering.

--- a/documentation/coding-style-guides/MARKDOWN-RENDERING.md
+++ b/documentation/coding-style-guides/MARKDOWN-RENDERING.md
@@ -1,0 +1,54 @@
+# Markdown Rendering Coding Style Guide
+
+This guide applies to any code that displays markdown anywhere in the web UI.
+
+## The Rule
+
+**All markdown rendering MUST go through `@lixpi/markdown-stream-parser`.** Never hand-roll markdown→HTML, never render raw markdown as plain text, and never add a second markdown library (`marked`, `markdown-it`, `remark`, etc.). The parser is the single source of truth for how markdown is tokenized into segments; rendering is the application of styles to those segments.
+
+There are exactly two rendering paths, and you must use the one that matches the surface:
+
+| Surface | Renderer | Where |
+|---------|----------|-------|
+| **Editable** ProseMirror content (AI chat threads) | The ProseMirror plugin's `StreamingInserter` | [`aiChatThreadPlugin.ts`](../../services/web-ui/src/components/proseMirror/plugins/aiChatThreadPlugin/aiChatThreadPlugin.ts) |
+| **Non-editable** content (everything else) | The unified `MarkdownStreamRenderer` | [`markdownStreamRenderer.ts`](../../services/web-ui/src/utils/markdownStreamRenderer.ts) |
+
+Both consume the same parser and the same segment shape. Do not write a third segment→DOM mapping. If a new surface needs markdown, reuse one of these two — extend them if needed, never fork them.
+
+## Non-editable rendering: `MarkdownStreamRenderer`
+
+`src/utils/markdownStreamRenderer.ts` is the **only** approved way to render markdown outside ProseMirror. It feeds tokens to the parser and applies styles to the emitted segments as plain DOM (built with the `html` helper from `domTemplates.ts`).
+
+**Streaming** (tokens arrive over time — e.g. live model output). The renderer owns its `contentEl`, so it survives container re-renders; re-attach `contentEl` after a rebuild instead of recreating it:
+
+```typescript
+import { MarkdownStreamRenderer } from '$src/utils/markdownStreamRenderer.ts'
+
+const renderer = new MarkdownStreamRenderer(`${runId}:${stage}`, 'my-scroll-box lixpi-markdown')
+container.appendChild(renderer.contentEl)
+// for each streamed chunk:
+renderer.push(chunk)
+// when the stream ends:
+renderer.finalize()
+```
+
+**Static** (the full string is already available — e.g. a saved feature's instructions, a prompt preview):
+
+```typescript
+import { renderMarkdownStatic } from '$src/utils/markdownStreamRenderer.ts'
+
+mountEl.appendChild(renderMarkdownStatic(feature.instructions, `feature:${feature.featureId}`, 'feature-library-instructions-body lixpi-markdown'))
+```
+
+The `instanceId` must be unique per concurrent render (the parser is a singleton keyed by id). The optional `className` is applied to the content element; always include `lixpi-markdown` so the global styles apply, plus any surface-specific scroll/layout class.
+
+## Styles
+
+Markdown element styles are **global** and live in [`src/sass/_markdown.scss`](../../services/web-ui/src/sass/_markdown.scss) under `.lixpi-markdown` / `.lixpi-md-*`. They are global on purpose so the renderer is styled consistently on every surface. Do not redefine markdown element styles in a component stylesheet — only add surface-specific container styles (scroll box, max-height, background) on your own class alongside `lixpi-markdown`.
+
+## Forbidden
+
+- `element.innerHTML = someMarkdown` or any string-built markdown HTML.
+- Rendering markdown source as text (`<pre>${markdown}</pre>`, `${feature.instructions}` straight into the DOM).
+- Importing a markdown library other than `@lixpi/markdown-stream-parser`.
+- Copying the segment→DOM mapping into a new file instead of using `MarkdownStreamRenderer`.

--- a/documentation/features/MARKDOWN-RENDERING.md
+++ b/documentation/features/MARKDOWN-RENDERING.md
@@ -70,6 +70,10 @@ Both consume the same parser and the same segment shape. If a new surface needs 
 
 Instance lifecycle: `MarkdownStreamParser.getInstance(id)` → `subscribeToTokenParse(cb)` → `startParsing()` → `parseToken(chunk)` per chunk → `stopParsing()` (flushes the last block and emits `END_STREAM`) → `removeInstance(id)`.
 
+The segment/token TypeScript shapes (`MarkdownParsedSegment`, `MarkdownStreamToken`) currently live in [`@lixpi/constants`](../../packages/lixpi/constants/ts/types.ts) because the published parser version defines its segment internally but does not export it (`subscribeToTokenParse` is typed `any`).
+
+> **Note:** a newer version of `@lixpi/markdown-stream-parser` is in development that **exports proper segment types**. Once it is released, drop the `@lixpi/constants` copies and import the types directly from the package.
+
 ## Non-editable rendering: `MarkdownStreamRenderer`
 
 [`src/utils/markdownStreamRenderer.ts`](../../services/web-ui/src/utils/markdownStreamRenderer.ts) is the **only** approved way to render markdown outside ProseMirror. It owns its `contentEl`, drives the parser, and applies styles to each segment as plain DOM (built with the `html` helper from `domTemplates.ts`).

--- a/documentation/features/MARKDOWN-RENDERING.md
+++ b/documentation/features/MARKDOWN-RENDERING.md
@@ -1,0 +1,120 @@
+# Markdown Rendering
+
+Markdown shows up in many places in the web UI — AI chat responses, the feature-extraction tab (prompt previews and streamed model output), the Media Library (saved feature instructions), and any future surface that displays model text. To keep all of it consistent and to avoid scattering markdown parsers across the codebase, Lixpi has **one rule**: every piece of markdown is tokenized by the same parser, and there are exactly two renderers that turn those tokens into UI.
+
+## The rule
+
+**All markdown rendering MUST go through [`@lixpi/markdown-stream-parser`](https://github.com/Lixpi/markdown-stream-parser).** The parser is the single source of truth for how markdown is tokenized into segments; a renderer's only job is to apply styles to those segments. Never hand-roll markdown→HTML, never render raw markdown as plain text, never add a second markdown library (`marked`, `markdown-it`, `remark`, …), and never fork the segment→DOM mapping into a new file.
+
+There are exactly two renderers, chosen by whether the surface is editable:
+
+```mermaid
+%%{init: {'theme': 'base', 'themeVariables': { 'primaryColor': '#F6C7B3', 'primaryTextColor': '#5a3a2a', 'primaryBorderColor': '#d4956a', 'secondaryColor': '#C3DEDD', 'secondaryTextColor': '#1a3a47', 'secondaryBorderColor': '#4a8a9d', 'tertiaryColor': '#DCECE9', 'tertiaryTextColor': '#1a3a47', 'tertiaryBorderColor': '#82B2C0', 'lineColor': '#d4956a', 'textColor': '#5a3a2a'}}}%%
+graph TB
+    subgraph "Source"
+        MD[Markdown text<br/>stream or full string]
+    end
+
+    subgraph "Parser — single source of truth"
+        Parser["@lixpi/markdown-stream-parser<br/>MarkdownStreamParser"]
+        Seg[Parsed segments<br/>type + styles + level]
+    end
+
+    subgraph "Renderers"
+        PM[ProseMirror plugin<br/>StreamingInserter<br/>EDITABLE]
+        Unified[MarkdownStreamRenderer<br/>utils/markdownStreamRenderer.ts<br/>NON-EDITABLE]
+    end
+
+    subgraph "Surfaces"
+        Chat[AI chat threads]
+        Ext[Extraction tab<br/>prompt preview + model output]
+        Lib[Media Library<br/>feature instructions]
+    end
+
+    MD --> Parser
+    Parser --> Seg
+    Seg --> PM
+    Seg --> Unified
+    PM --> Chat
+    Unified --> Ext
+    Unified --> Lib
+```
+
+| Surface | Renderer | Source |
+|---------|----------|--------|
+| **Editable** ProseMirror content (AI chat threads) | The ProseMirror plugin's `StreamingInserter` | [`aiChatThreadPlugin.ts`](../../services/web-ui/src/components/proseMirror/plugins/aiChatThreadPlugin/aiChatThreadPlugin.ts) |
+| **Non-editable** content (everything else) | The unified `MarkdownStreamRenderer` | [`markdownStreamRenderer.ts`](../../services/web-ui/src/utils/markdownStreamRenderer.ts) |
+
+Both consume the same parser and the same segment shape. If a new surface needs markdown, reuse one of these two — extend them if needed, never fork them.
+
+## The parser contract
+
+`MarkdownStreamParser` is a streaming, instance-per-stream singleton. Each emitted segment has the shape:
+
+```typescript
+{
+    status: 'STREAMING' | 'END_STREAM'
+    segment: {
+        segment: string          // the text content
+        styles: string[]         // inline styles on this run
+        type: string             // block type
+        level?: number           // heading level (1–6) when type === 'header'
+        isBlockDefining: boolean  // true when a new block starts
+        isProcessingNewLine: boolean
+    }
+}
+```
+
+- **Block types:** `paragraph`, `header` (with `level` 1–6), `code` (fenced code block).
+- **Inline styles:** `bold`, `italic`, `strikethrough`, `code`.
+
+Instance lifecycle: `MarkdownStreamParser.getInstance(id)` → `subscribeToTokenParse(cb)` → `startParsing()` → `parseToken(chunk)` per chunk → `stopParsing()` (flushes the last block and emits `END_STREAM`) → `removeInstance(id)`.
+
+## Non-editable rendering: `MarkdownStreamRenderer`
+
+[`src/utils/markdownStreamRenderer.ts`](../../services/web-ui/src/utils/markdownStreamRenderer.ts) is the **only** approved way to render markdown outside ProseMirror. It owns its `contentEl`, drives the parser, and applies styles to each segment as plain DOM (built with the `html` helper from `domTemplates.ts`).
+
+**Streaming** (tokens arrive over time — e.g. live model output). Because the renderer owns `contentEl`, it survives container re-renders; re-attach `contentEl` after a rebuild instead of recreating it:
+
+```typescript
+import { MarkdownStreamRenderer } from '$src/utils/markdownStreamRenderer.ts'
+
+const renderer = new MarkdownStreamRenderer(`${runId}:${stage}`, 'my-scroll-box lixpi-markdown')
+container.appendChild(renderer.contentEl)
+// for each streamed chunk:
+renderer.push(chunk)
+// when the stream ends:
+renderer.finalize()
+```
+
+**Static** (the full string is already available — e.g. a saved feature's instructions, a prompt preview):
+
+```typescript
+import { renderMarkdownStatic } from '$src/utils/markdownStreamRenderer.ts'
+
+mountEl.appendChild(renderMarkdownStatic(feature.instructions, `feature:${feature.featureId}`, 'feature-library-instructions-body lixpi-markdown'))
+```
+
+- The `instanceId` must be unique per concurrent render (the parser is a singleton keyed by id).
+- The optional `className` is applied to the content element; always include `lixpi-markdown` so the global styles apply, plus any surface-specific scroll/layout class.
+
+## Styles
+
+Markdown element styles are **global** and live in [`src/sass/_markdown.scss`](../../services/web-ui/src/sass/_markdown.scss) under `.lixpi-markdown` / `.lixpi-md-*` (imported by `src/sass/styles.scss`). They are global on purpose so the renderer looks the same on every surface. Do not redefine markdown element styles in a component stylesheet — only add surface-specific container styles (scroll box, max-height, background) on your own class alongside `lixpi-markdown`.
+
+## Forbidden
+
+- `element.innerHTML = someMarkdown`, or any string-built markdown HTML.
+- Rendering markdown source as text (`<pre>${markdown}</pre>`, `${feature.instructions}` straight into the DOM).
+- Importing a markdown library other than `@lixpi/markdown-stream-parser`.
+- Copying the segment→DOM mapping into a new file instead of using `MarkdownStreamRenderer`.
+
+## Current consumers
+
+| Consumer | What it renders | How |
+|----------|-----------------|-----|
+| AI chat thread | Streamed assistant responses | `aiChatThreadPlugin` (editable / ProseMirror) |
+| Feature-extraction tab | Stage prompt previews, streamed model output | `MarkdownStreamRenderer` / `renderMarkdownStatic` |
+| Media Library | Saved feature instructions ("Application notes") | `renderMarkdownStatic` |
+
+See also: [FEATURE-EXTRACTION-AND-LIBRARY.md](FEATURE-EXTRACTION-AND-LIBRARY.md), [MEDIA-LIBRARY.md](MEDIA-LIBRARY.md), and the coding-style pointer at [`documentation/coding-style-guides/MARKDOWN-RENDERING.md`](../coding-style-guides/MARKDOWN-RENDERING.md).

--- a/packages/lixpi/constants/ts/types.ts
+++ b/packages/lixpi/constants/ts/types.ts
@@ -451,6 +451,28 @@ export type StageTraceEvent = {
     metricTags?: Record<string, string | number>
 }
 
+// Markdown stream parser segment shapes. These mirror what @lixpi/markdown-stream-parser
+// emits from subscribeToTokenParse — the package defines the segment internally but does
+// not export it (the callback is typed `any`), so the shape is centralized here and shared
+// by every consumer (the ProseMirror aiChatThreadPlugin and the unified MarkdownStreamRenderer).
+// See documentation/features/MARKDOWN-RENDERING.md.
+export type MarkdownParsedSegment = {
+    segment: string
+    styles: string[]
+    type: string
+    level?: number
+    isBlockDefining: boolean
+    isProcessingNewLine?: boolean
+    content?: string
+    language?: string
+    origin?: string
+}
+
+export type MarkdownStreamToken = {
+    status: 'STREAMING' | 'END_STREAM'
+    segment?: MarkdownParsedSegment
+}
+
 export type FeatureSourceContext = {
     extractionRunId: string
     sourceWorkspaceId: string

--- a/packages/lixpi/constants/ts/types.ts
+++ b/packages/lixpi/constants/ts/types.ts
@@ -455,6 +455,11 @@ export type StageTraceEvent = {
 // emits from subscribeToTokenParse — the package defines the segment internally but does
 // not export it (the callback is typed `any`), so the shape is centralized here and shared
 // by every consumer (the ProseMirror aiChatThreadPlugin and the unified MarkdownStreamRenderer).
+//
+// TODO: a newer version of @lixpi/markdown-stream-parser is in development that EXPORTS proper
+// segment types. Once that version is released, delete these definitions and import the types
+// directly from @lixpi/markdown-stream-parser instead.
+//
 // See documentation/features/MARKDOWN-RENDERING.md.
 export type MarkdownParsedSegment = {
     segment: string

--- a/packages/lixpi/constants/ts/types.ts
+++ b/packages/lixpi/constants/ts/types.ts
@@ -440,7 +440,10 @@ export type StageTraceEvent = {
     startedAt: number
     finishedAt: number
     durationMs: number
-    status: 'ok' | 'error' | 'skipped'
+    // 'running' is a publish-only, in-flight marker streamed when a stage starts so
+    // the UI can show a live spinner. Only the terminal event ('ok' | 'error' | 'skipped')
+    // is persisted to ExtractionRun.trace.
+    status: 'running' | 'ok' | 'error' | 'skipped'
     errorMessage?: string
     inputSummary?: string
     outputSummary?: string
@@ -645,6 +648,9 @@ export type CanvasFeatureExtractionState = {
     aiProvider?: string
     stepDetails?: Record<string, string>
     reasoningText?: string
+    // Streamed model output (thinking/reasoning) keyed by the stage that produced it,
+    // so the extraction tab can show live output under each in-progress substep.
+    stageReasoning?: Record<string, string>
     featureCard?: Record<string, any>
     traceEvents?: StageTraceEvent[]
     error?: string

--- a/services/api/src/llm/extraction/stage2-extractors.ts
+++ b/services/api/src/llm/extraction/stage2-extractors.ts
@@ -1,5 +1,7 @@
 'use strict'
 
+import * as process from 'process'
+
 import { warn } from '@lixpi/debug-tools'
 import type { AxisExtraction } from '@lixpi/constants'
 
@@ -7,6 +9,33 @@ import { getExtractors } from './extractors/registry.ts'
 import type { ExtractionDeps, ExtractionState, StageLogger } from './types.ts'
 
 const DEFAULT_DOMINANCE_FLOOR = 0.3
+
+// Cap on simultaneous extractor VLM calls. Firing all ~10 axes at once opened too many
+// concurrent streaming connections to the provider and several were dropped mid-stream
+// ("Connection error."). Batching keeps the connection count sane; tune via env.
+const EXTRACTOR_CONCURRENCY = Math.max(1, Number(process.env.FEATURE_EXTRACTOR_CONCURRENCY) || 4)
+
+// Runs `worker` over `items` with at most `limit` in flight, preserving input order and
+// isolating failures (same result shape as Promise.allSettled).
+const runWithConcurrency = async <T, R>(
+    items: T[],
+    limit: number,
+    worker: (item: T, index: number) => Promise<R>,
+): Promise<PromiseSettledResult<R>[]> => {
+    const results: PromiseSettledResult<R>[] = new Array(items.length)
+    let cursor = 0
+    const runner = async (): Promise<void> => {
+        for (let index = cursor++; index < items.length; index = cursor++) {
+            try {
+                results[index] = { status: 'fulfilled', value: await worker(items[index]!, index) }
+            } catch (reason) {
+                results[index] = { status: 'rejected', reason }
+            }
+        }
+    }
+    await Promise.all(Array.from({ length: Math.min(limit, items.length) }, runner))
+    return results
+}
 
 // Stage 2 — Parallel modular extractors.
 // Selects every registered extractor whose dominance score from the router
@@ -30,14 +59,14 @@ export const runExtractors = async (state: ExtractionState, logger: StageLogger,
             return { axisExtractions: {}, failedAxes: [] }
         }
 
-        const results = await Promise.allSettled(selected.map((ext) =>
+        const results = await runWithConcurrency(selected, EXTRACTOR_CONCURRENCY, (ext) =>
             logger.span(`extractor:${ext.axis}`, state.input.analysisModel.modelVersion, () =>
                 ext.extract({ scene, state, logger, deps })
             , {
                 inputSummary: `axis=${ext.axis} dominance=${scene.axisDominance[ext.axis] ?? 0}`,
                 outputSummarizer: (axis: AxisExtraction) => `axis=${axis.axis} fieldKeys=[${Object.keys(axis.fields ?? {}).slice(0, 6).join(',')}]`,
             }),
-        ))
+        )
 
         const axisExtractions: Record<string, AxisExtraction> = {}
         const failedAxes: Array<{ axis: string; error: string }> = []

--- a/services/api/src/llm/extraction/stage6-persist.ts
+++ b/services/api/src/llm/extraction/stage6-persist.ts
@@ -7,7 +7,6 @@ import { info, err } from '@lixpi/debug-tools'
 
 import Feature from '../../models/feature.ts'
 import ExtractionRun from '../../models/extraction-run.ts'
-import { StreamPublisher } from '../graph/stream-publisher.ts'
 import type { ExtractionDeps, ExtractionState, StageLogger } from './types.ts'
 
 export const persistFeature = async (state: ExtractionState, logger: StageLogger, _deps: ExtractionDeps): Promise<Partial<ExtractionState>> => {
@@ -65,29 +64,18 @@ export const persistFeature = async (state: ExtractionState, logger: StageLogger
             err(`Failed to publish FEATURE_SUBJECTS.CREATE: ${e instanceof Error ? e.message : String(e)}`)
         }
 
-        // Stream a feature_card block so the extraction tab can render the result.
-        try {
-            const publisher = new StreamPublisher(
-                NATS_Service.getInstance()!,
-                state.input.workspaceId,
-                state.input.extractionRunId,
-                state.input.analysisProvider,
-            )
-            publisher.chunk(JSON.stringify({
-                type: 'feature_card',
-                feature: {
-                    featureId: feature.featureId,
-                    name: feature.name,
-                    category: feature.category,
-                    scope: feature.scope,
-                    summary: feature.summary,
-                    tags: feature.tags,
-                    sampleImages: feature.sampleImages,
-                },
-            }))
-        } catch (e) {
-            err(`Failed to stream feature_card: ${e instanceof Error ? e.message : String(e)}`)
-        }
+        // Stream the feature as structured content so the extraction tab can render it.
+        // Goes through logger.featureCard (not the token text stream) so it can't be
+        // truncated by TagAwareStream's tail buffering.
+        logger.featureCard({
+            featureId: feature.featureId,
+            name: feature.name,
+            category: feature.category,
+            scope: feature.scope,
+            summary: feature.summary,
+            tags: feature.tags,
+            sampleImages: feature.sampleImages,
+        })
 
         info(`Feature extraction complete: ${featureId} (${feature.name}) — ${orderedSamples.length} sample refs`)
         return { featureId, feature }

--- a/services/api/src/llm/extraction/trace.ts
+++ b/services/api/src/llm/extraction/trace.ts
@@ -21,9 +21,12 @@ export const createStageLogger = (args: {
 }): StageLogger => {
     const { extractionRunId, workspaceId, publisher } = args
 
-    const emit = (event: StageTraceEvent): void => {
+    // persist defaults to true. The publish-only 'running' marker passes persist:false
+    // so the durable trace keeps just one terminal event per stage (no running/ok pairs).
+    const emit = (event: StageTraceEvent, persist = true): void => {
         info(`[extraction:${extractionRunId}] stage=${event.stage} model=${event.modelName ?? '-'} status=${event.status} duration=${event.durationMs}ms ${event.outputSummary ?? ''}`)
         try { publisher.stageTrace(event) } catch (e) { err('stageTrace publish failed:', e) }
+        if (!persist) return
         // Persist async without blocking. The model is best-effort: trace is observability,
         // not the primary persistence path. Errors are logged inside appendTrace.
         void ExtractionRun.appendTrace({ extractionRunId, workspaceId, event })
@@ -34,8 +37,26 @@ export const createStageLogger = (args: {
         try { publisher.chunk(text) } catch (e) { err('chunk publish failed:', e) }
     }
 
+    const featureCard = (payload: Record<string, any>): void => {
+        try { publisher.featureCard(payload) } catch (e) { err('featureCard publish failed:', e) }
+    }
+
     const span: StageLogger['span'] = async (stage, modelName, body, opts) => {
         const startedAt = Date.now()
+        // Stream an in-flight marker so the extraction tab can light up the stage
+        // (spinner) the moment it begins, not only when it finishes.
+        emit({
+            extractionRunId,
+            stage,
+            modelName,
+            promptHash: opts?.promptPreview ? hashPrompt(opts.promptPreview) : undefined,
+            promptPreview: opts?.promptPreview ? previewPrompt(opts.promptPreview) : undefined,
+            startedAt,
+            finishedAt: 0,
+            durationMs: 0,
+            status: 'running',
+            inputSummary: opts?.inputSummary,
+        }, false)
         try {
             const result = await body()
             const finishedAt = Date.now()
@@ -73,5 +94,5 @@ export const createStageLogger = (args: {
         }
     }
 
-    return { extractionRunId, emit, chunk, span }
+    return { extractionRunId, emit, chunk, featureCard, span }
 }

--- a/services/api/src/llm/extraction/types.ts
+++ b/services/api/src/llm/extraction/types.ts
@@ -54,6 +54,8 @@ export type StageLogger = {
     // extraction-tab UI as streaming reasoning text. Use only from sequential
     // stages (router, synthesis); parallel stages would interleave.
     chunk: (text: string) => void
+    // Publishes the finished feature as structured content for the extraction tab.
+    featureCard: (payload: Record<string, any>) => void
     span: <T>(stage: string, modelName: string | undefined, body: () => Promise<T>, opts?: {
         inputSummary?: string
         outputSummarizer?: (result: T) => string | undefined

--- a/services/api/src/llm/extraction/vlm-client.ts
+++ b/services/api/src/llm/extraction/vlm-client.ts
@@ -6,7 +6,7 @@ import Anthropic from '@anthropic-ai/sdk'
 import OpenAI from 'openai'
 import { GoogleGenAI } from '@google/genai'
 import type NatsService from '@lixpi/nats-service'
-import { warn, info } from '@lixpi/debug-tools'
+import { warn, info, err } from '@lixpi/debug-tools'
 
 import type { ProviderName } from '@lixpi/constants'
 import type { ChatMessage } from '../graph/state.ts'
@@ -358,12 +358,100 @@ const callGoogle = async <T>(args: VlmCallArgs): Promise<VlmCallResult<T>> => {
 
 // ─── Public dispatcher ────────────────────────────────────────────────────────
 
+// Provider SDKs (Anthropic/OpenAI) throw APIConnectionError with a bland
+// "Connection error." message and stash the real cause (ECONNRESET, socket hang up,
+// fetch failed, timeout) on `.cause`; rate limits arrive as status=429 with a
+// retry-after header. This unwraps all of that into one readable line.
+const describeProviderError = (error: any): string => {
+    if (!error) return 'unknown error'
+    const parts: string[] = [error.name || 'Error']
+    if (error.status !== undefined) parts.push(`status=${error.status}`)
+    if (error.code !== undefined) parts.push(`code=${error.code}`)
+    const headers = error.headers
+    const getHeader = (key: string): string | undefined =>
+        typeof headers?.get === 'function' ? headers.get(key) : headers?.[key]
+    const retryAfter = getHeader('retry-after')
+    if (retryAfter) parts.push(`retry-after=${retryAfter}`)
+    const requestId = error.request_id ?? error.requestID ?? getHeader('request-id') ?? getHeader('x-request-id')
+    if (requestId) parts.push(`requestId=${requestId}`)
+    parts.push(`message="${error.message ?? String(error)}"`)
+    // Walk the cause chain — the connection error wraps the underlying network error.
+    const causes: string[] = []
+    let cause = error.cause
+    for (let depth = 0; cause && depth < 5; depth++) {
+        const code = cause.code ? ` (code=${cause.code})` : ''
+        causes.push(`${cause.name ?? 'cause'}: ${cause.message ?? String(cause)}${code}`)
+        cause = cause.cause
+    }
+    if (causes.length) parts.push(`cause=[${causes.join(' <- ')}]`)
+    return parts.join(' ')
+}
+
+const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms))
+
+// Transient = worth retrying: rate limits (429), server errors (5xx), and the
+// connection/timeout family the SDK surfaces as APIConnectionError + a network cause.
+const TRANSIENT_CAUSE_CODES = new Set([
+    'ECONNRESET', 'ECONNREFUSED', 'ETIMEDOUT', 'EPIPE', 'EAI_AGAIN', 'ENOTFOUND',
+    'UND_ERR_SOCKET', 'UND_ERR_CONNECT_TIMEOUT', 'UND_ERR_HEADERS_TIMEOUT', 'UND_ERR_BODY_TIMEOUT',
+])
+
+const isTransientError = (error: any): boolean => {
+    const status = error?.status
+    if (status === 429 || (typeof status === 'number' && status >= 500)) return true
+    if (/APIConnection(Timeout)?Error|APITimeoutError|APIConnectionError/.test(error?.name ?? '')) return true
+    let cause = error?.cause
+    for (let depth = 0; cause && depth < 5; depth++) {
+        if (cause.code && TRANSIENT_CAUSE_CODES.has(cause.code)) return true
+        cause = cause.cause
+    }
+    // Anthropic's APIConnectionError carries no status and a bland message.
+    if (status === undefined && /connection error|socket hang up|fetch failed|terminated/i.test(error?.message ?? '')) return true
+    return false
+}
+
+// Honor a retry-after header (seconds or HTTP-date) when present, capped to 30s.
+const parseRetryAfterMs = (error: any): number | undefined => {
+    const headers = error?.headers
+    const raw = typeof headers?.get === 'function' ? headers.get('retry-after') : headers?.['retry-after']
+    if (!raw) return undefined
+    const seconds = Number(raw)
+    if (!Number.isNaN(seconds)) return Math.min(seconds * 1000, 30_000)
+    const dateMs = Date.parse(raw)
+    if (!Number.isNaN(dateMs)) return Math.max(0, Math.min(dateMs - Date.now(), 30_000))
+    return undefined
+}
+
+const MAX_VLM_RETRIES = 2 // up to 3 attempts total
+
 export const callStructuredVlm = async <T>(args: VlmCallArgs): Promise<VlmCallResult<T>> => {
     const caps = detectCapabilities(args.provider, args.modelVersion)
     info(`[vlm] call provider=${args.provider} model=${args.modelVersion} thinkingMode=${caps.thinkingMode} requestThinking=${args.enableThinking === true}`)
 
-    if (args.provider === 'Anthropic') return callAnthropic<T>(args)
-    if (args.provider === 'OpenAI') return callOpenAi<T>(args)
-    if (args.provider === 'Google') return callGoogle<T>(args)
-    throw new Error(`Unsupported analysis provider for structured VLM call: ${args.provider}`)
+    const dispatch = (): Promise<VlmCallResult<T>> => {
+        if (args.provider === 'Anthropic') return callAnthropic<T>(args)
+        if (args.provider === 'OpenAI') return callOpenAi<T>(args)
+        if (args.provider === 'Google') return callGoogle<T>(args)
+        throw new Error(`Unsupported analysis provider for structured VLM call: ${args.provider}`)
+    }
+
+    for (let attempt = 0; ; attempt++) {
+        try {
+            return await dispatch()
+        } catch (error: any) {
+            const detail = describeProviderError(error)
+            const canRetry = attempt < MAX_VLM_RETRIES && isTransientError(error) && !args.abortSignal?.aborted
+            if (canRetry) {
+                // Jittered exponential backoff, or the server's retry-after when given.
+                const backoff = Math.min(1000 * 2 ** attempt, 8000) + Math.floor(Math.random() * 400)
+                const waitMs = parseRetryAfterMs(error) ?? backoff
+                warn(`[vlm] transient failure (attempt ${attempt + 1}/${MAX_VLM_RETRIES + 1}) provider=${args.provider} model=${args.modelVersion} schema=${args.schema.name}; retrying in ${waitMs}ms :: ${detail}`)
+                await sleep(waitMs)
+                continue
+            }
+            err(`[vlm] FAILED provider=${args.provider} model=${args.modelVersion} schema=${args.schema.name} after ${attempt + 1} attempt(s): ${detail}`)
+            // Re-throw with the enriched detail so the stage trace + UI substep show the real cause.
+            throw new Error(`${args.provider}/${args.modelVersion} (${args.schema.name}): ${detail}`, { cause: error })
+        }
+    }
 }

--- a/services/api/src/llm/graph/stream-publisher.ts
+++ b/services/api/src/llm/graph/stream-publisher.ts
@@ -32,6 +32,7 @@ export type ChunkPayload = {
         extractionStatus?: string
         extractionDetail?: string
         stageTraceEvent?: StageTraceEvent
+        featureCard?: Record<string, any>
     }
     aiChatThreadId: string
 }
@@ -227,6 +228,19 @@ export class StreamPublisher {
                 status: STREAM_STATUS.STREAMING,
                 aiProvider: this.provider,
                 stageTraceEvent: event,
+            },
+            aiChatThreadId: this.aiChatThreadId,
+        })
+    }
+
+    // Publishes the extracted feature as structured content. Sent this way (not as JSON
+    // embedded in the token stream) so TagAwareStream's tail buffering can't truncate it.
+    featureCard(payload: Record<string, any>): void {
+        this.nats.publish(subject(this.workspaceId, this.aiChatThreadId), {
+            content: {
+                status: STREAM_STATUS.STREAMING,
+                aiProvider: this.provider,
+                featureCard: payload,
             },
             aiChatThreadId: this.aiChatThreadId,
         })

--- a/services/api/src/models/extraction-run.ts
+++ b/services/api/src/models/extraction-run.ts
@@ -55,7 +55,12 @@ export default {
                 origin: 'ExtractionRun.appendTrace:read',
             })
             const trace: StageTraceEvent[] = Array.isArray((existing as any)?.trace) ? (existing as any).trace : []
-            trace.push(event)
+            // DynamoDB's marshaller rejects undefined values, and StageTraceEvent has many
+            // optional fields. Drop undefined keys so the trace list persists cleanly.
+            const cleanEvent = Object.fromEntries(
+                Object.entries(event).filter(([, value]) => value !== undefined),
+            ) as StageTraceEvent
+            trace.push(cleanEvent)
             await dynamoDBService.updateItem({
                 tableName: getDynamoDbTableStageName('EXTRACTION_RUNS', ORG_NAME, STAGE),
                 key: { extractionRunId, workspaceId },

--- a/services/web-ui/src/components/proseMirror/plugins/aiChatThreadPlugin/aiChatThreadPlugin.ts
+++ b/services/web-ui/src/components/proseMirror/plugins/aiChatThreadPlugin/aiChatThreadPlugin.ts
@@ -30,6 +30,7 @@ import type {
     ImageBranchVlmResolution,
     ImageGenerationTrace,
     ImageGenerationSize,
+    MarkdownParsedSegment,
     StreamStatus,
 } from '@lixpi/constants'
 
@@ -60,13 +61,7 @@ type SegmentEvent = {
     threadId?: string
     aiChatThreadId?: string
     collapsibleTitle?: string
-    segment?: {
-        segment: string
-        styles: string[]
-        type: string
-        level?: number
-        isBlockDefining: boolean
-    }
+    segment?: MarkdownParsedSegment
     imageUrl?: string
     fileId?: string
     workspaceId?: string

--- a/services/web-ui/src/components/proseMirror/plugins/aiChatThreadPlugin/aiChatThreadPlugin.ts
+++ b/services/web-ui/src/components/proseMirror/plugins/aiChatThreadPlugin/aiChatThreadPlugin.ts
@@ -61,6 +61,9 @@ type SegmentEvent = {
     threadId?: string
     aiChatThreadId?: string
     collapsibleTitle?: string
+    // Markdown segment shape from @lixpi/constants (mirrors what @lixpi/markdown-stream-parser
+    // emits). TODO: import from @lixpi/markdown-stream-parser once its in-development version
+    // exports proper segment types.
     segment?: MarkdownParsedSegment
     imageUrl?: string
     fileId?: string

--- a/services/web-ui/src/infographics/workspace/extractionTab.test.ts
+++ b/services/web-ui/src/infographics/workspace/extractionTab.test.ts
@@ -1,0 +1,237 @@
+'use strict'
+
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+import { describe, expect, it } from 'vitest'
+import type { StageTraceEvent } from '@lixpi/constants'
+
+import {
+    classifyStage,
+    computeExtractionTimelineModel,
+    formatStageDuration,
+    type PhaseView,
+} from './extractionTimelineModel.ts'
+
+const tabSource = readFileSync(resolve(__dirname, 'extractionTab.ts'), 'utf-8')
+const modelSource = readFileSync(resolve(__dirname, 'extractionTimelineModel.ts'), 'utf-8')
+const markdownSource = readFileSync(resolve(__dirname, '../../utils/markdownStreamRenderer.ts'), 'utf-8')
+const markdownStyles = readFileSync(resolve(__dirname, '../../sass/_markdown.scss'), 'utf-8')
+const styles = readFileSync(resolve(__dirname, 'media-library-panel.scss'), 'utf-8')
+
+const event = (over: Partial<StageTraceEvent> & { stage: string; status: StageTraceEvent['status'] }): StageTraceEvent => ({
+    extractionRunId: 'run-1',
+    startedAt: 0,
+    finishedAt: 0,
+    durationMs: 0,
+    ...over,
+})
+
+const phaseByKey = (phases: PhaseView[], key: string): PhaseView => {
+    const phase = phases.find((candidate) => candidate.key === key)
+    if (!phase) throw new Error(`phase ${key} not found`)
+    return phase
+}
+
+describe('computeExtractionTimelineModel', () => {
+    it('always returns the four phases in pipeline order', () => {
+        const phases = computeExtractionTimelineModel([], 'analyzing', true)
+        expect(phases.map((phase) => phase.key)).toEqual(['analyze', 'extract', 'generate', 'save'])
+        expect(phases.map((phase) => phase.label)).toEqual([
+            'Analyze input', 'Extract feature', 'Generate samples', 'Save to library',
+        ])
+    })
+
+    it('renders a live skeleton with the first phase active and the rest pending', () => {
+        const phases = computeExtractionTimelineModel([], 'analyzing', true)
+        expect(phaseByKey(phases, 'analyze').status).toBe('active')
+        expect(phaseByKey(phases, 'extract').status).toBe('pending')
+        expect(phaseByKey(phases, 'generate').status).toBe('pending')
+        expect(phaseByKey(phases, 'save').status).toBe('pending')
+        expect(phases.every((phase) => phase.substeps.length === 0)).toBe(true)
+    })
+
+    it('shows the router substep spinning while the analyze phase is active', () => {
+        const phases = computeExtractionTimelineModel([
+            event({ stage: 'router', status: 'running', startedAt: 1 }),
+        ], 'routing', true)
+        const analyze = phaseByKey(phases, 'analyze')
+        expect(analyze.status).toBe('active')
+        expect(analyze.substeps).toHaveLength(1)
+        expect(analyze.substeps[0]).toMatchObject({ stage: 'router', status: 'running', label: 'Scene assessment & router' })
+    })
+
+    it('marks a phase done on its terminal ok and makes the next phase active', () => {
+        const phases = computeExtractionTimelineModel([
+            event({ stage: 'router', status: 'ok', startedAt: 1, finishedAt: 100, durationMs: 99 }),
+        ], 'extracting_axes', true)
+        const analyze = phaseByKey(phases, 'analyze')
+        expect(analyze.status).toBe('done')
+        expect(analyze.durationMs).toBe(99)
+        expect(phaseByKey(phases, 'extract').status).toBe('active')
+    })
+
+    it('groups extractor, crops and synthesis under Extract, sorted by start time', () => {
+        const phases = computeExtractionTimelineModel([
+            event({ stage: 'router', status: 'ok', startedAt: 1, finishedAt: 5 }),
+            event({ stage: 'extractor:lighting', status: 'running', startedAt: 12 }),
+            event({ stage: 'extractor:palette', status: 'ok', startedAt: 10, finishedAt: 30 }),
+            event({ stage: 'crops', status: 'ok', startedAt: 11, finishedAt: 20 }),
+            event({ stage: 'synthesis', status: 'running', startedAt: 40 }),
+            event({ stage: 'extractors', status: 'ok', startedAt: 10, finishedAt: 35, outputSummary: 'extracted=2 failed=0' }),
+        ], 'synthesizing', true)
+        const extract = phaseByKey(phases, 'extract')
+        expect(extract.status).toBe('active')
+        // Container event ('extractors') is not a substep row — it only sets phase meta.
+        expect(extract.meta).toBe('extracted=2 failed=0')
+        expect(extract.substeps.map((substep) => substep.stage)).toEqual([
+            'extractor:palette', 'crops', 'extractor:lighting', 'synthesis',
+        ])
+        expect(extract.substeps[0].label).toBe('palette extractor')
+    })
+
+    it('counts samples, sets generate meta, and enriches sample labels with kind', () => {
+        const phases = computeExtractionTimelineModel([
+            event({ stage: 'router', status: 'ok' }),
+            event({ stage: 'synthesis', status: 'ok' }),
+            event({ stage: 'sample:0', status: 'ok', startedAt: 1, inputSummary: 'kind=palette-board subject=swatches' }),
+            event({ stage: 'sample:1', status: 'ok', startedAt: 2, inputSummary: 'kind=applied-medium-probe subject=sphere' }),
+            event({ stage: 'samples', status: 'ok', outputSummary: 'samples=2' }),
+        ], 'saving', true)
+        const generate = phaseByKey(phases, 'generate')
+        expect(generate.status).toBe('done')
+        expect(generate.substeps).toHaveLength(2)
+        expect(generate.meta).toBe('samples=2')
+        expect(generate.substeps[0].label).toBe('Sample 0 · palette-board')
+        expect(generate.substeps[1].label).toBe('Sample 1 · applied-medium-probe')
+    })
+
+    it('attaches streamed model output to the matching substep', () => {
+        const phases = computeExtractionTimelineModel([
+            event({ stage: 'router', status: 'running', startedAt: 1 }),
+        ], 'routing', true, { router: 'thinking about the scene…' })
+        const analyze = phaseByKey(phases, 'analyze')
+        expect(analyze.substeps[0].liveOutput).toBe('thinking about the scene…')
+        // Unrelated stages get no live output.
+        const extract = phaseByKey(phases, 'extract')
+        expect(extract.substeps.every((substep) => substep.liveOutput === undefined)).toBe(true)
+    })
+
+    it('marks the failing phase as error and blocks downstream phases', () => {
+        const phases = computeExtractionTimelineModel([
+            event({ stage: 'router', status: 'ok' }),
+            event({ stage: 'extractor:palette', status: 'error', errorMessage: 'palette VLM 500' }),
+        ], 'failed', true)
+        const extract = phaseByKey(phases, 'extract')
+        expect(extract.status).toBe('error')
+        expect(extract.substeps[0]).toMatchObject({ status: 'error', errorMessage: 'palette VLM 500' })
+        expect(phaseByKey(phases, 'generate').status).toBe('pending')
+        expect(phaseByKey(phases, 'save').status).toBe('pending')
+    })
+
+    it('dedupes a running marker against its terminal event by stage', () => {
+        const phases = computeExtractionTimelineModel([
+            event({ stage: 'router', status: 'running', startedAt: 1 }),
+            event({ stage: 'router', status: 'ok', startedAt: 1, finishedAt: 100, durationMs: 99 }),
+        ], 'extracting_axes', true)
+        const analyze = phaseByKey(phases, 'analyze')
+        expect(analyze.substeps).toHaveLength(1)
+        expect(analyze.substeps[0].status).toBe('ok')
+    })
+
+    it('replays persisted completed runs with every phase done and no anticipatory spinner', () => {
+        const phases = computeExtractionTimelineModel([
+            event({ stage: 'router', status: 'ok' }),
+            event({ stage: 'synthesis', status: 'ok' }),
+            event({ stage: 'samples', status: 'ok' }),
+            event({ stage: 'persist', status: 'ok' }),
+        ], 'completed', false)
+        expect(phases.every((phase) => phase.status === 'done')).toBe(true)
+    })
+
+    it('shows a completed run as fully done even when terminal events are missing', () => {
+        const phases = computeExtractionTimelineModel([], 'completed', false)
+        expect(phases.every((phase) => phase.status === 'done')).toBe(true)
+    })
+})
+
+describe('classifyStage', () => {
+    it('maps each backend stage onto the right phase', () => {
+        expect(classifyStage('router').phaseKey).toBe('analyze')
+        expect(classifyStage('extractor:palette')).toMatchObject({ phaseKey: 'extract', kind: 'substep' })
+        expect(classifyStage('extractors').kind).toBe('container')
+        expect(classifyStage('crops').phaseKey).toBe('extract')
+        expect(classifyStage('synthesis').phaseKey).toBe('extract')
+        expect(classifyStage('sample:3')).toMatchObject({ phaseKey: 'generate', kind: 'substep' })
+        expect(classifyStage('samples').kind).toBe('container')
+        expect(classifyStage('persist').phaseKey).toBe('save')
+        // Unknown stages are surfaced, never dropped.
+        expect(classifyStage('mystery-stage')).toMatchObject({ phaseKey: 'extract', kind: 'substep', label: 'mystery-stage' })
+    })
+})
+
+describe('formatStageDuration', () => {
+    it('formats milliseconds, seconds and minutes', () => {
+        expect(formatStageDuration(500)).toBe('500ms')
+        expect(formatStageDuration(1500)).toBe('1.5s')
+        expect(formatStageDuration(65_000)).toBe('1.1min')
+    })
+})
+
+describe('extraction tab DOM + style contract', () => {
+    it('renders via pure CSS — no d3 in the timeline anymore', () => {
+        expect(tabSource).not.toContain('d3-selection')
+        expect(modelSource).not.toContain('d3-selection')
+        expect(styles).toContain('@keyframes extraction-spin')
+        expect(styles).toContain('.extraction-phase-timeline')
+        expect(styles).toContain('.extraction-substep')
+    })
+
+    it('drops the old flat stage-timeline dump and the dead d3 guide', () => {
+        expect(styles).not.toContain('.extraction-stage-timeline')
+        expect(styles).not.toContain('.extraction-timeline-guide')
+        expect(tabSource).not.toContain('buildStageTimeline')
+        expect(tabSource).not.toContain('renderTimelineGuide')
+    })
+
+    it('keeps every trace field visible — nothing silenced', () => {
+        expect(tabSource).toContain('extraction-substep-summary')
+        expect(tabSource).toContain('extraction-substep-error-text')
+        expect(tabSource).toContain('extraction-substep-preview')
+        expect(tabSource).toContain('Prompt preview')
+        // Streaming reasoning is still surfaced, and explicit detail is never dropped.
+        expect(tabSource).toContain('Agent reasoning')
+        expect(tabSource).toContain('appendReasoning')
+    })
+
+    it('streams model output live into a per-substep area', () => {
+        expect(tabSource).toContain('extraction-substep-output')
+        expect(tabSource).toContain('Model output')
+        expect(tabSource).toContain('currentReasoningStage')
+        expect(tabSource).toContain('stageReasoning')
+        expect(styles).toContain('.extraction-substep-output')
+    })
+
+    it('renders prompt and model output through the unified markdown stream renderer', () => {
+        expect(markdownSource).toContain("from '@lixpi/markdown-stream-parser'")
+        expect(markdownSource).toContain('MarkdownStreamParser.getInstance')
+        expect(markdownSource).toContain('parseToken')
+        expect(markdownSource).toContain('subscribeToTokenParse')
+        // Prompt preview uses static markdown; live output uses the streaming renderer.
+        expect(tabSource).toContain('renderMarkdownStatic')
+        expect(tabSource).toContain('MarkdownStreamRenderer')
+        // Markdown element styles are global so the renderer is reusable anywhere.
+        expect(markdownStyles).toContain('.lixpi-markdown')
+        expect(markdownStyles).toContain('.lixpi-md-paragraph')
+    })
+
+    it('receives the feature card as structured content (not parsed from text)', () => {
+        expect(tabSource).toContain('content.featureCard')
+    })
+
+    it('preserves the exported integration contract used by WorkspaceCanvas', () => {
+        expect(tabSource).toContain('export async function submitExtractionRequest')
+        expect(tabSource).toContain('export function renderExtractionTabBody')
+        expect(tabSource).toContain('export function setPendingExtractionContext')
+        expect(tabSource).toContain('export function getPendingExtractionContext')
+    })
+})

--- a/services/web-ui/src/infographics/workspace/extractionTab.ts
+++ b/services/web-ui/src/infographics/workspace/extractionTab.ts
@@ -4,7 +4,13 @@ import { html, applyStyle } from '$src/utils/domTemplates.ts'
 import { NATS_SUBJECTS, STREAM_STATUS, type CanvasFeatureExtractionState, type StageTraceEvent } from '@lixpi/constants'
 import { servicesStore } from '$src/stores/servicesStore.ts'
 import AuthService from '$src/services/auth-service.ts'
-import { select } from 'd3-selection'
+import {
+    computeExtractionTimelineModel,
+    formatStageDuration,
+    type PhaseView,
+    type SubstepView,
+} from '$src/infographics/workspace/extractionTimelineModel.ts'
+import { MarkdownStreamRenderer, renderMarkdownStatic } from '$src/utils/markdownStreamRenderer.ts'
 import { aiRobotFaceIcon, claudeIcon, geminiIcon, gptAvatarIcon, stabilityIcon } from '$src/svgIcons/index.ts'
 
 const API_BASE_URL = (import.meta.env.VITE_API_URL || '').replace(/\/$/, '')
@@ -24,26 +30,10 @@ export type ExtractionTabPersistence = {
     saveState?: (state: CanvasFeatureExtractionState) => void
 }
 
-type ExtractionStep = {
-    key: string
-    label: string
-    detail: string
-}
-
-type ExtractionStepDetails = Map<string, string>
-
-const EXTRACTION_STEPS: ExtractionStep[] = [
-    { key: 'analyzing', label: 'Analyze input', detail: 'Reading the prompt and source context.' },
-    { key: 'extracting', label: 'Extract feature', detail: 'Distilling the reusable visual pattern.' },
-    { key: 'generating_samples', label: 'Generate samples', detail: 'Creating previews to validate the feature.' },
-    { key: 'saving', label: 'Save to library', detail: 'Writing the feature to your workspace library.' },
+const VALID_EXTRACTION_STATUSES: Array<CanvasFeatureExtractionState['status']> = [
+    'pending', 'analyzing', 'routing', 'extracting', 'extracting_axes',
+    'materializing_crops', 'synthesizing', 'generating_samples', 'saving', 'completed', 'failed',
 ]
-
-const EXTRACTION_STATUS_ORDER = ['pending', 'analyzing', 'extracting', 'generating_samples', 'saving', 'completed']
-const TIMELINE_ROW_HEIGHT = 76
-const TIMELINE_ROOT_X = 20
-const TIMELINE_GUIDE_WIDTH = 40
-const TIMELINE_ROW_CENTER_Y = 18
 
 const pendingContexts = new Map<string, ExtractionTabContext>()
 
@@ -55,28 +45,6 @@ export function getPendingExtractionContext(extractionRunId: string): Extraction
     return pendingContexts.get(extractionRunId)
 }
 
-function getTimelineActiveIndex(currentStatus: string): number {
-    if (currentStatus === 'completed') return EXTRACTION_STEPS.length - 1
-    const stepIndex = EXTRACTION_STEPS.findIndex((step) => step.key === currentStatus)
-    return stepIndex === -1 ? 0 : stepIndex
-}
-
-function getTimelineStepY(stepIndex: number): number {
-    return stepIndex * TIMELINE_ROW_HEIGHT + TIMELINE_ROW_CENTER_Y
-}
-
-function getStepKeyForStatus(currentStatus: string): string {
-    return EXTRACTION_STEPS[getTimelineActiveIndex(currentStatus)]?.key ?? EXTRACTION_STEPS[0].key
-}
-
-function appendStepDetail(stepDetails: ExtractionStepDetails, currentStatus: string, text: string): void {
-    if (!text) return
-
-    const stepKey = getStepKeyForStatus(currentStatus)
-    const currentText = stepDetails.get(stepKey) ?? ''
-    stepDetails.set(stepKey, `${currentText}${text}`)
-}
-
 function getExtractionDetailText(content: any): string {
     const detailText = content.extractionDetail ?? content.stepDetail ?? content.statusDetail ?? content.reasoning
     return typeof detailText === 'string' ? detailText : ''
@@ -84,169 +52,75 @@ function getExtractionDetailText(content: any): string {
 
 function normalizeExtractionStatus(status: any): CanvasFeatureExtractionState['status'] {
     const statusText = typeof status === 'string' ? status : 'analyzing'
-    if (statusText === 'failed') return 'failed'
-    return EXTRACTION_STATUS_ORDER.includes(statusText) ? statusText as CanvasFeatureExtractionState['status'] : 'analyzing'
+    return (VALID_EXTRACTION_STATUSES as string[]).includes(statusText)
+        ? statusText as CanvasFeatureExtractionState['status']
+        : 'analyzing'
 }
 
-function createStepDetailsMap(stepDetails: Record<string, string> | undefined): ExtractionStepDetails {
-    const detailsMap: ExtractionStepDetails = new Map()
-    if (!stepDetails) return detailsMap
+function buildSubstepRow(substep: SubstepView): HTMLLIElement {
+    // data-stage lets the live token stream target this row's output area without a full re-render.
+    const rowEl = html`<li className=${`extraction-substep extraction-substep-${substep.status}`} data=${{ stage: substep.stage }}>
+        <div className="extraction-substep-head">
+            <span className="extraction-substep-label">${substep.label}</span>
+            <span className="extraction-substep-aside"></span>
+        </div>
+    </li>` as HTMLLIElement
 
-    for (const step of EXTRACTION_STEPS) {
-        const detailText = stepDetails[step.key]
-        if (typeof detailText === 'string' && detailText) detailsMap.set(step.key, detailText)
+    const asideEl = rowEl.querySelector('.extraction-substep-aside') as HTMLElement
+    if (substep.model) asideEl.appendChild(html`<span className="extraction-substep-model">${substep.model}</span>` as HTMLElement)
+    if (substep.status !== 'running') asideEl.appendChild(html`<span className="extraction-substep-duration">${formatStageDuration(substep.durationMs)}</span>` as HTMLElement)
+    asideEl.appendChild(html`<span className="extraction-substep-status"></span>` as HTMLElement)
+
+    if (substep.summary) rowEl.appendChild(html`<div className="extraction-substep-summary">${substep.summary}</div>` as HTMLElement)
+    if (substep.errorMessage) rowEl.appendChild(html`<div className="extraction-substep-error-text">${substep.errorMessage}</div>` as HTMLElement)
+    if (substep.promptPreview) {
+        // Render the prompt through the markdown stream parser, not as raw text.
+        const previewDetails = html`<details className="extraction-substep-details">
+            <summary>Prompt preview</summary>
+        </details>` as HTMLElement
+        previewDetails.appendChild(renderMarkdownStatic(substep.promptPreview, `prompt:${substep.stage}`, 'extraction-substep-preview lixpi-markdown'))
+        rowEl.appendChild(previewDetails)
     }
-
-    return detailsMap
+    // The "Model output" block is attached after the timeline renders (live: a
+    // persistent MarkdownStreamRenderer that survives rebuilds; persisted: a static render).
+    return rowEl
 }
 
-function serializeStepDetails(stepDetails: ExtractionStepDetails): Record<string, string> {
-    const result: Record<string, string> = {}
-    for (const [stepKey, detailText] of stepDetails) {
-        if (detailText) result[stepKey] = detailText
-    }
-    return result
-}
-
-function renderTimelineGuide(listEl: HTMLOListElement, currentStatus: string) {
-    const activeIndex = getTimelineActiveIndex(currentStatus)
-    const lastIndex = EXTRACTION_STEPS.length - 1
-    const firstY = getTimelineStepY(0)
-    const lastY = getTimelineStepY(lastIndex)
-    const activeY = getTimelineStepY(activeIndex)
-    const svgHeight = lastY + TIMELINE_ROW_CENTER_Y
-
-    const svg = select(listEl)
-        .append('svg')
-        .attr('class', 'extraction-timeline-guide')
-        .attr('width', TIMELINE_GUIDE_WIDTH)
-        .attr('height', svgHeight)
-        .attr('viewBox', `0 0 ${TIMELINE_GUIDE_WIDTH} ${svgHeight}`)
-        .attr('preserveAspectRatio', 'xMinYMin meet')
-
-    svg.append('line')
-        .attr('class', 'extraction-timeline-path extraction-timeline-path-muted')
-        .attr('x1', TIMELINE_ROOT_X).attr('y1', firstY)
-        .attr('x2', TIMELINE_ROOT_X).attr('y2', lastY)
-
-    if (activeIndex > 0 || currentStatus === 'completed') {
-        svg.append('line')
-            .attr('class', 'extraction-timeline-path extraction-timeline-path-active')
-            .attr('x1', TIMELINE_ROOT_X).attr('y1', firstY)
-            .attr('x2', TIMELINE_ROOT_X).attr('y2', activeY)
-    }
-
-    EXTRACTION_STEPS.forEach((_step, stepIndex) => {
-        const isCompleted = currentStatus === 'completed'
-        const isDone = isCompleted || stepIndex < activeIndex
-        const isActive = !isCompleted && stepIndex === activeIndex
-        svg.append('circle')
-            .attr('class', `extraction-timeline-dot${isDone ? ' extraction-timeline-dot-done' : ''}${isActive ? ' extraction-timeline-dot-active' : ''}`)
-            .attr('cx', TIMELINE_ROOT_X)
-            .attr('cy', getTimelineStepY(stepIndex))
-            .attr('r', 7)
-
-        if (isActive) {
-            svg.append('circle')
-                .attr('class', 'extraction-timeline-dot-core')
-                .attr('cx', TIMELINE_ROOT_X)
-                .attr('cy', getTimelineStepY(stepIndex))
-                .attr('r', 3.5)
-        }
-    })
-}
-
-function formatStageLabel(stage: string): string {
-    // Turns "extractor:palette" → "Extractor • palette", "router" → "Stage 1 — Router", etc.
-    const stageMap: Record<string, string> = {
-        'router': 'Stage 1 — Scene Assessment & Router',
-        'extractors': 'Stage 2 — Parallel Extractors',
-        'crops': 'Stage 3 — Source Crop Materialization',
-        'synthesis': 'Stage 4 — Dominance-Weighted Synthesis',
-        'samples': 'Stage 5 — Sample Generation',
-        'persist': 'Stage 6 — Persist + Publish',
-    }
-    if (stageMap[stage]) return stageMap[stage]
-    if (stage.startsWith('extractor:')) return `Extractor • ${stage.slice('extractor:'.length)}`
-    if (stage.startsWith('sample:')) return `Sample • ${stage.slice('sample:'.length)}`
-    return stage
-}
-
-function formatStageDuration(ms: number): string {
-    if (ms < 1000) return `${ms}ms`
-    if (ms < 60_000) return `${(ms / 1000).toFixed(1)}s`
-    return `${(ms / 60_000).toFixed(1)}min`
-}
-
-function buildStageTimeline(
-    traceEvents: StageTraceEvent[],
-    containerEl: HTMLElement,
-    currentStatus: string,
-): void {
+function buildPhaseTimeline(phases: PhaseView[], containerEl: HTMLElement, isLive: boolean): void {
     containerEl.replaceChildren()
+    const listEl = html`<ol className=${`extraction-phase-timeline${isLive ? ' extraction-phase-timeline-live' : ''}`}></ol>` as HTMLOListElement
 
-    if (traceEvents.length === 0) {
-        const statusLabel = currentStatus === 'failed' ? 'Extraction failed' : 'Waiting for the pipeline to start…'
-        containerEl.appendChild(html`<p className="extraction-stage-timeline-empty">${statusLabel}</p>` as HTMLElement)
-        return
-    }
-
-    const listEl = html`<ol className="extraction-stage-timeline"></ol>` as HTMLOListElement
-    for (const event of traceEvents) {
-        const statusClass = event.status === 'ok'
-            ? 'extraction-stage-timeline-row-ok'
-            : event.status === 'error'
-                ? 'extraction-stage-timeline-row-error'
-                : 'extraction-stage-timeline-row-skipped'
-        const itemEl = html`<li className=${`extraction-stage-timeline-row ${statusClass}`}>
-            <div className="extraction-stage-timeline-header">
-                <span className="extraction-stage-timeline-stage">${formatStageLabel(event.stage)}</span>
-                <span className="extraction-stage-timeline-model">${event.modelName ?? '—'}</span>
-                <span className="extraction-stage-timeline-duration">${formatStageDuration(event.durationMs)}</span>
-                <span className=${`extraction-stage-timeline-status extraction-stage-timeline-status-${event.status}`}>${event.status}</span>
+    for (const phase of phases) {
+        const phaseEl = html`<li className=${`extraction-phase extraction-phase-${phase.status}`}>
+            <div className="extraction-phase-head">
+                <span className="extraction-phase-dot"></span>
+                <span className="extraction-phase-label">${phase.label}</span>
             </div>
-            <div className="extraction-stage-timeline-summary">${event.outputSummary ?? event.inputSummary ?? ''}</div>
         </li>` as HTMLLIElement
-        if (event.errorMessage) {
-            itemEl.appendChild(html`<div className="extraction-stage-timeline-error">${event.errorMessage}</div>` as HTMLElement)
+        const headEl = phaseEl.querySelector('.extraction-phase-head') as HTMLElement
+
+        if (phase.key === 'generate' && phase.substeps.length > 0) {
+            headEl.appendChild(html`<span className="extraction-phase-count">${String(phase.substeps.length)}</span>` as HTMLElement)
         }
-        if (event.promptPreview) {
-            const detailsEl = html`<details className="extraction-stage-timeline-details">
-                <summary>Prompt preview</summary>
-                <pre className="extraction-stage-timeline-preview">${event.promptPreview}</pre>
-            </details>` as HTMLElement
-            itemEl.appendChild(detailsEl)
+        if (phase.durationMs != null) {
+            headEl.appendChild(html`<span className="extraction-phase-duration">${formatStageDuration(phase.durationMs)}</span>` as HTMLElement)
         }
-        listEl.appendChild(itemEl)
+        if (phase.meta) {
+            phaseEl.appendChild(html`<div className="extraction-phase-meta">${phase.meta}</div>` as HTMLElement)
+        }
+
+        if (phase.substeps.length > 0) {
+            const substepsEl = html`<ol className="extraction-phase-substeps"></ol>` as HTMLOListElement
+            for (const substep of phase.substeps) substepsEl.appendChild(buildSubstepRow(substep))
+            phaseEl.appendChild(substepsEl)
+        } else if (phase.status === 'active') {
+            phaseEl.appendChild(html`<div className="extraction-phase-waiting">Working…</div>` as HTMLElement)
+        }
+
+        listEl.appendChild(phaseEl)
     }
+
     containerEl.appendChild(listEl)
-}
-
-function buildStepTimeline(
-    currentStatus: string,
-    containerEl: HTMLElement,
-    stepDetails: ExtractionStepDetails = new Map(),
-) {
-    const currentIndex = EXTRACTION_STATUS_ORDER.indexOf(currentStatus)
-    const normalizedCurrentIndex = currentIndex === -1 ? 0 : currentIndex
-    const listEl = html`<ol className="extraction-timeline"></ol>` as HTMLOListElement
-
-    for (const step of EXTRACTION_STEPS) {
-        const stepIndex = EXTRACTION_STATUS_ORDER.indexOf(step.key)
-        const isDone = currentStatus === 'completed' || normalizedCurrentIndex > stepIndex
-        const isActive = step.key === currentStatus && currentStatus !== 'completed'
-        const detailText = stepDetails.get(step.key)?.trim() ?? ''
-        const itemEl = html`<li className=${`extraction-timeline-item${isDone ? ' extraction-timeline-item-done' : ''}${isActive ? ' extraction-timeline-item-active' : ''}`}>
-            <span className="extraction-timeline-content">
-                <span className="extraction-timeline-label">${step.label}</span>
-                <span className="extraction-timeline-detail">${step.detail}</span>
-                <span className="extraction-timeline-live-details">${detailText || 'Waiting for live details.'}</span>
-            </span>
-        </li>` as HTMLLIElement
-        listEl.appendChild(itemEl)
-    }
-    renderTimelineGuide(listEl, currentStatus)
-    containerEl.replaceChildren(listEl)
 }
 
 function appendImageAuth(url: string, accessToken = ''): string {
@@ -358,7 +232,7 @@ function createExtractionConversationLayout(bodyEl: HTMLElement, userText: strin
     return { timelineContainer, featureCardArea, assistantContentEl }
 }
 
-function appendReasoningControls(bodyEl: HTMLElement, initialText = ''): { panelEl: HTMLElement; getText: () => string; openIfClosed: () => void } {
+function appendReasoningControls(bodyEl: HTMLElement, initialText = ''): { panelEl: HTMLElement; getText: () => string; appendText: (text: string) => void } {
     const startOpen = initialText.length > 0
     const reasoningToggle = html`<button type="button" className="extraction-tab-reasoning-toggle">${startOpen ? '▼' : '▶'} Agent reasoning</button>` as HTMLButtonElement
     const reasoningPanel = html`<div className="extraction-tab-reasoning-panel" style=${{ display: startOpen ? 'block' : 'none' }}></div>` as HTMLElement
@@ -371,26 +245,48 @@ function appendReasoningControls(bodyEl: HTMLElement, initialText = ''): { panel
     bodyEl.appendChild(reasoningToggle)
     bodyEl.appendChild(reasoningPanel)
 
+    const openIfClosed = () => {
+        if (reasoningPanel.style.display !== 'none') return
+        applyStyle(reasoningPanel, { display: 'block' })
+        reasoningToggle.textContent = '▼ Agent reasoning'
+    }
+
     return {
         panelEl: reasoningPanel,
         getText: () => reasoningPanel.textContent ?? '',
         // Auto-opens the panel the first time live reasoning arrives so the user
-        // can see streaming tokens without clicking the toggle.
-        openIfClosed: () => {
-            if (reasoningPanel.style.display !== 'none') return
-            applyStyle(reasoningPanel, { display: 'block' })
-            reasoningToggle.textContent = '▼ Agent reasoning'
+        // can see streaming tokens without clicking the toggle. No reasoning is dropped.
+        appendText: (text: string) => {
+            if (!text) return
+            openIfClosed()
+            reasoningPanel.insertAdjacentText('beforeend', text)
         },
     }
 }
 
 async function renderPersistedFeatureCard(featureCard: Record<string, any>, featureCardArea: HTMLElement, workspaceId: string) {
     try {
-        const accessToken = await AuthService.getTokenSilently()
+        const accessToken = (await AuthService.getTokenSilently()) || ''
         buildFeatureCard(featureCard, featureCardArea, accessToken, workspaceId)
     } catch (error) {
         console.warn('Failed to load auth token for persisted extraction feature card:', error)
         buildFeatureCard(featureCard, featureCardArea, '', workspaceId)
+    }
+}
+
+// Renders persisted per-stage model output statically (reload path — no live stream).
+function attachStaticStageOutputs(timelineContainer: HTMLElement, phases: PhaseView[]) {
+    for (const phase of phases) {
+        for (const substep of phase.substeps) {
+            if (!substep.liveOutput) continue
+            const sub = timelineContainer.querySelector(`.extraction-substep[data-stage="${substep.stage}"]`)
+            if (!sub) continue
+            const detailsEl = html`<details className="extraction-substep-output-details">
+                <summary>Model output</summary>
+            </details>` as HTMLElement
+            detailsEl.appendChild(renderMarkdownStatic(substep.liveOutput, `persist:${substep.stage}`, 'extraction-substep-output lixpi-markdown'))
+            sub.appendChild(detailsEl)
+        }
     }
 }
 
@@ -400,11 +296,16 @@ function renderPersistedExtractionState(bodyEl: HTMLElement, state: CanvasFeatur
         state.userText ?? 'Extract feature',
         state.aiProvider,
     )
-    buildStageTimeline(state.traceEvents ?? [], timelineContainer, state.status)
+    const phases = computeExtractionTimelineModel(state.traceEvents ?? [], state.status, false, state.stageReasoning ?? {})
+    buildPhaseTimeline(phases, timelineContainer, false)
+    attachStaticStageOutputs(timelineContainer, phases)
     if (state.featureCard) void renderPersistedFeatureCard(state.featureCard, featureCardArea, workspaceId)
     if (state.error) renderExtractionError(featureCardArea, `Feature extraction failed: ${state.error}`)
 
-    appendReasoningControls(assistantContentEl, state.reasoningText ?? '')
+    // Older runs stored a single reasoning blob instead of per-stage output — surface it
+    // in a fallback panel so historical reasoning is never lost.
+    const hasStageReasoning = !!state.stageReasoning && Object.keys(state.stageReasoning).length > 0
+    if (!hasStageReasoning && state.reasoningText) appendReasoningControls(assistantContentEl, state.reasoningText)
 }
 
 function parseFeatureCardPayload(buffer: string): any | null {
@@ -435,12 +336,15 @@ export async function submitExtractionRequest(
 ) {
     const aiProvider = getAiProviderFromModel(ctx.aiModel)
     const { timelineContainer, featureCardArea, assistantContentEl } = createExtractionConversationLayout(bodyEl, userText, aiProvider)
-    const stepDetails: ExtractionStepDetails = new Map()
     const traceEvents: StageTraceEvent[] = []
     let currentExtractionStatus: CanvasFeatureExtractionState['status'] = 'analyzing'
     let featureCard: Record<string, any> | undefined
     let extractionError: string | undefined
-    let reasoningText = ''
+    // Streamed model output keyed by stage. `currentReasoningStage` tracks the most recent
+    // in-flight stage so reasoning chunks land under the right substep. Router and synthesis
+    // are the only stages that stream thinking, and they never overlap, so this is unambiguous.
+    const stageReasoning: Record<string, string> = {}
+    let currentReasoningStage = 'router'
     let accessToken = ''
     let persistTimer: ReturnType<typeof setTimeout> | null = null
     const buildPersistedState = (): CanvasFeatureExtractionState => ({
@@ -448,8 +352,7 @@ export async function submitExtractionRequest(
         status: currentExtractionStatus,
         userText,
         aiProvider,
-        stepDetails: serializeStepDetails(stepDetails),
-        reasoningText,
+        stageReasoning,
         featureCard,
         traceEvents,
         error: extractionError,
@@ -469,10 +372,56 @@ export async function submitExtractionRequest(
             persistence.saveState?.(buildPersistedState())
         }, 600)
     }
-    const renderTimeline = () => buildStageTimeline(traceEvents, timelineContainer, currentExtractionStatus)
+    // Persistent per-stage markdown renderers for streamed "Model output". Each owns its
+    // DOM (a <details> wrapping a MarkdownStreamRenderer) so it survives full timeline rebuilds —
+    // we just re-attach it under the matching substep after every render.
+    const outputs = new Map<string, { renderer: MarkdownStreamRenderer; detailsEl: HTMLDetailsElement }>()
+    const ensureOutput = (stage: string) => {
+        let output = outputs.get(stage)
+        if (!output) {
+            const renderer = new MarkdownStreamRenderer(`${extractionRunId}:${stage}`, 'extraction-substep-output lixpi-markdown')
+            const detailsEl = html`<details className="extraction-substep-output-details">
+                <summary>Model output</summary>
+            </details>` as HTMLDetailsElement
+            detailsEl.open = true
+            detailsEl.appendChild(renderer.contentEl)
+            output = { renderer, detailsEl }
+            outputs.set(stage, output)
+        }
+        return output
+    }
+    const attachOutputs = () => {
+        for (const [stage, output] of outputs) {
+            const sub = timelineContainer.querySelector(`.extraction-substep[data-stage="${stage}"]`)
+            if (sub && output.detailsEl.parentElement !== sub) sub.appendChild(output.detailsEl)
+        }
+    }
+    const renderTimeline = () => {
+        buildPhaseTimeline(computeExtractionTimelineModel(traceEvents, currentExtractionStatus, true, stageReasoning), timelineContainer, true)
+        attachOutputs()
+    }
     renderTimeline()
 
-    const reasoningControls = appendReasoningControls(assistantContentEl)
+    // Streams a reasoning chunk into the active stage's "Model output" through the markdown
+    // parser. The renderer appends incrementally, so there's no full re-render per token.
+    const appendReasoning = (text: string) => {
+        if (!text) return
+        const stage = currentReasoningStage
+        stageReasoning[stage] = (stageReasoning[stage] ?? '') + text
+        const isNew = !outputs.has(stage)
+        const output = ensureOutput(stage)
+        if (isNew) renderTimeline()
+        output.renderer.push(text)
+        output.renderer.contentEl.scrollTop = output.renderer.contentEl.scrollHeight
+        schedulePersist()
+    }
+    // Upsert by stage: the publish-only 'running' marker is replaced by its terminal
+    // event, keeping one row per stage and a clean persisted trace.
+    const upsertTraceEvent = (event: StageTraceEvent) => {
+        const existingIndex = traceEvents.findIndex((existing) => existing.stage === event.stage)
+        if (existingIndex >= 0) traceEvents[existingIndex] = event
+        else traceEvents.push(event)
+    }
     persistNow()
 
     const messages: Array<{ role: string; content: any }> = []
@@ -508,6 +457,7 @@ export async function submitExtractionRequest(
     const handleExtractionError = (error: unknown) => {
         currentExtractionStatus = 'failed'
         extractionError = String(error)
+        renderTimeline()
         renderExtractionError(featureCardArea, `Feature extraction failed: ${extractionError}`)
         persistNow()
     }
@@ -520,7 +470,17 @@ export async function submitExtractionRequest(
         const { content } = data
         if (content.stageTraceEvent) {
             const event = content.stageTraceEvent as StageTraceEvent
-            traceEvents.push(event)
+            upsertTraceEvent(event)
+            if (event.status === 'running') {
+                currentReasoningStage = event.stage
+            } else {
+                // Stage finished — flush and collapse its streamed output if it had any.
+                const output = outputs.get(event.stage)
+                if (output) {
+                    output.renderer.finalize()
+                    output.detailsEl.open = false
+                }
+            }
             if (event.stage === 'persist' && event.status === 'ok') currentExtractionStatus = 'completed'
             renderTimeline()
             schedulePersist()
@@ -530,11 +490,15 @@ export async function submitExtractionRequest(
             renderTimeline()
             schedulePersist()
         }
-        const explicitStepDetail = getExtractionDetailText(content)
-        if (explicitStepDetail) {
-            appendStepDetail(stepDetails, currentExtractionStatus, `${explicitStepDetail}\n`)
-            schedulePersist()
+        // Feature card is delivered as structured content (not embedded in the text stream).
+        if (content.featureCard) {
+            featureCard = content.featureCard
+            buildFeatureCard(content.featureCard, featureCardArea, accessToken, workspaceId)
+            persistNow()
         }
+        // Defensive: any explicit progress detail still surfaces in the reasoning panel.
+        const explicitStepDetail = getExtractionDetailText(content)
+        if (explicitStepDetail) appendReasoning(`${explicitStepDetail}\n`)
         if (content.status === STREAM_STATUS.STREAMING && content.text) {
             const text = String(content.text)
             if (isCapturingFeatureCard || text.trimStart().startsWith('{"type":"feature_card"')) {
@@ -550,11 +514,7 @@ export async function submitExtractionRequest(
                 }
                 return
             }
-            appendStepDetail(stepDetails, currentExtractionStatus, text)
-            reasoningText += text
-            reasoningControls.openIfClosed()
-            reasoningControls.panelEl.insertAdjacentText('beforeend', text)
-            schedulePersist()
+            appendReasoning(text)
         }
         if (content.status === STREAM_STATUS.END_STREAM) {
             if (currentExtractionStatus !== 'failed') {
@@ -574,7 +534,7 @@ export async function submitExtractionRequest(
 
     try {
         const token = await AuthService.getTokenSilently()
-        accessToken = token
+        accessToken = token || ''
         nats.publish(NATS_SUBJECTS.AI_INTERACTION_SUBJECTS.FEATURE_EXTRACT.START, {
             token, workspaceId, organizationId: '', extractionRunId, messages,
             aiModel: ctx.aiModel,

--- a/services/web-ui/src/infographics/workspace/extractionTimelineModel.ts
+++ b/services/web-ui/src/infographics/workspace/extractionTimelineModel.ts
@@ -1,0 +1,175 @@
+'use strict'
+
+import type { CanvasFeatureExtractionState, StageTraceEvent } from '@lixpi/constants'
+
+// Pure, DOM-free reducer that folds the backend's StageTraceEvent stream into the
+// four user-facing phases the extraction tab renders. Kept separate from the DOM
+// rendering in extractionTab.ts so it can be unit-tested in isolation.
+//
+// The backend runs a fixed 6-stage graph (router → extractors ‖ crops → synthesis
+// → samples → persist). Those stages map onto four phases; `terminal` is the stage
+// whose 'ok' marks a phase complete. Stages 2 and 5 are parallel fan-outs whose
+// children (extractor:<axis>, sample:<idx>) become the phase's substeps.
+
+export type SubstepStatus = StageTraceEvent['status']
+export type PhaseStatus = 'pending' | 'active' | 'done' | 'error'
+
+export type SubstepView = {
+    stage: string
+    label: string
+    model?: string
+    durationMs: number
+    status: SubstepStatus
+    summary?: string
+    promptPreview?: string
+    errorMessage?: string
+    // Live streamed model output (thinking tokens) for this stage, if any.
+    liveOutput?: string
+}
+
+export type PhaseView = {
+    key: string
+    label: string
+    status: PhaseStatus
+    durationMs?: number
+    meta?: string
+    substeps: SubstepView[]
+}
+
+type ExtractionPhaseConfig = { key: string; label: string; terminal: string }
+
+export const EXTRACTION_PHASES: ExtractionPhaseConfig[] = [
+    { key: 'analyze', label: 'Analyze input', terminal: 'router' },
+    { key: 'extract', label: 'Extract feature', terminal: 'synthesis' },
+    { key: 'generate', label: 'Generate samples', terminal: 'samples' },
+    { key: 'save', label: 'Save to library', terminal: 'persist' },
+]
+
+// Maps a backend stage name to the phase it belongs to and how it is rendered.
+// `container` events are the outer fan-out spans ('extractors', 'samples') — their
+// children are the real substeps, so the container only contributes a phase summary.
+type StageClassification = { phaseKey: string; kind: 'substep' | 'container'; label: string }
+
+export function classifyStage(stage: string): StageClassification {
+    if (stage === 'router') return { phaseKey: 'analyze', kind: 'substep', label: 'Scene assessment & router' }
+    if (stage.startsWith('extractor:')) return { phaseKey: 'extract', kind: 'substep', label: `${stage.slice('extractor:'.length)} extractor` }
+    if (stage === 'extractors') return { phaseKey: 'extract', kind: 'container', label: 'Parallel extractors' }
+    if (stage === 'crops') return { phaseKey: 'extract', kind: 'substep', label: 'Source crop materialization' }
+    if (stage === 'synthesis') return { phaseKey: 'extract', kind: 'substep', label: 'Dominance-weighted synthesis' }
+    if (stage.startsWith('sample:')) return { phaseKey: 'generate', kind: 'substep', label: `Sample ${stage.slice('sample:'.length)}` }
+    if (stage === 'samples') return { phaseKey: 'generate', kind: 'container', label: 'Sample generation' }
+    if (stage === 'persist') return { phaseKey: 'save', kind: 'substep', label: 'Persist & publish' }
+    // Unknown stage — surface it under Extract rather than dropping it. Nothing is silenced.
+    return { phaseKey: 'extract', kind: 'substep', label: stage }
+}
+
+export function formatStageDuration(ms: number): string {
+    if (ms < 1000) return `${ms}ms`
+    if (ms < 60_000) return `${(ms / 1000).toFixed(1)}s`
+    return `${(ms / 60_000).toFixed(1)}min`
+}
+
+function buildSubstepView(event: StageTraceEvent): SubstepView {
+    const classification = classifyStage(event.stage)
+    let label = classification.label
+    // Enrich sample substeps with their kind ('palette-board', 'applied-medium-probe', …).
+    if (event.stage.startsWith('sample:')) {
+        const kind = /kind=([\w-]+)/.exec(event.inputSummary ?? '')?.[1]
+        if (kind) label = `${label} · ${kind}`
+    }
+    return {
+        stage: event.stage,
+        label,
+        model: event.modelName || undefined,
+        durationMs: event.durationMs,
+        status: event.status,
+        summary: event.outputSummary || event.inputSummary || undefined,
+        promptPreview: event.promptPreview || undefined,
+        errorMessage: event.errorMessage || undefined,
+    }
+}
+
+// Folds the trace-event stream into the four-phase view model. `isLive` enables
+// anticipatory "active" state (so a not-yet-started phase can spin while streaming)
+// and is false when replaying persisted state on reload (no perpetual spinners).
+export function computeExtractionTimelineModel(
+    traceEvents: StageTraceEvent[],
+    currentStatus: CanvasFeatureExtractionState['status'],
+    isLive: boolean,
+    stageReasoning: Record<string, string> = {},
+): PhaseView[] {
+    const buckets = new Map<string, { substeps: Map<string, StageTraceEvent>; container?: StageTraceEvent }>()
+    for (const phase of EXTRACTION_PHASES) buckets.set(phase.key, { substeps: new Map() })
+
+    for (const event of traceEvents) {
+        const classification = classifyStage(event.stage)
+        const bucket = buckets.get(classification.phaseKey)!
+        // Upsert by stage so a 'running' marker is replaced by its terminal event.
+        if (classification.kind === 'container') bucket.container = event
+        else bucket.substeps.set(event.stage, event)
+    }
+
+    const failed = currentStatus === 'failed'
+    const completed = currentStatus === 'completed'
+    let blocked = false
+    let previousDone = true
+    const phases: PhaseView[] = []
+
+    for (const phase of EXTRACTION_PHASES) {
+        const bucket = buckets.get(phase.key)!
+        const events = [...bucket.substeps.values()]
+        if (bucket.container) events.push(bucket.container)
+
+        const terminalEvent = bucket.container?.stage === phase.terminal
+            ? bucket.container
+            : bucket.substeps.get(phase.terminal)
+        const hasError = events.some((event) => event.status === 'error')
+        const hasRunning = events.some((event) => event.status === 'running')
+        const present = events.length > 0
+        const terminalOk = terminalEvent?.status === 'ok'
+
+        let status: PhaseStatus
+        if (hasError) {
+            status = 'error'
+            blocked = true
+        } else if (completed) {
+            // A completed run finished the whole pipeline; show every phase done even
+            // if an older persisted run is missing some terminal trace events.
+            status = 'done'
+        } else if (terminalOk) {
+            status = 'done'
+        } else if (blocked) {
+            status = 'pending'
+        } else if (present) {
+            status = (hasRunning || isLive) ? 'active' : 'pending'
+        } else if (previousDone && isLive && !failed && !completed) {
+            status = 'active'
+        } else {
+            status = 'pending'
+        }
+
+        const substeps = [...bucket.substeps.values()]
+            .sort((a, b) => a.startedAt - b.startedAt)
+            .map((substepEvent) => ({
+                ...buildSubstepView(substepEvent),
+                liveOutput: stageReasoning[substepEvent.stage] || undefined,
+            }))
+
+        const finished = events.filter((event) => event.finishedAt > 0)
+        const durationMs = status === 'done' && finished.length > 0
+            ? Math.max(...finished.map((event) => event.finishedAt)) - Math.min(...finished.map((event) => event.startedAt))
+            : undefined
+
+        phases.push({
+            key: phase.key,
+            label: phase.label,
+            status,
+            durationMs,
+            meta: bucket.container?.outputSummary || undefined,
+            substeps,
+        })
+        previousDone = status === 'done'
+    }
+
+    return phases
+}

--- a/services/web-ui/src/infographics/workspace/media-library-panel.scss
+++ b/services/web-ui/src/infographics/workspace/media-library-panel.scss
@@ -571,7 +571,6 @@
     color: rgba(26, 39, 68, 0.68);
     font-size: 11px;
     line-height: 1.48;
-    white-space: pre-wrap;
     overflow-wrap: anywhere;
 }
 
@@ -793,243 +792,278 @@
     padding: 12px 2px 6px;
 }
 
-.extraction-timeline {
+// ----- Phase timeline (4 phases, each with backend-stage substeps) -----
+// The vertical connector is a per-phase ::before line; consecutive phase <li>s are
+// flush, so the segments read as one continuous progress rail. Completed phases
+// colour their segment, the active phase dot spins, substeps branch to the right.
+@keyframes extraction-spin {
+    to { transform: rotate(360deg); }
+}
+
+.extraction-phase-timeline {
     position: relative;
-    display: grid;
-    gap: 0;
     margin: 0;
     padding: 0;
     list-style: none;
 }
 
-.extraction-timeline-item {
+.extraction-phase {
     position: relative;
-    display: grid;
-    grid-template-columns: minmax(0, 1fr);
-    min-height: 76px;
-    padding: 0 0 16px 54px;
-    color: rgba(26, 39, 68, 0.46);
+    padding: 0 0 16px 30px;
 }
 
-.extraction-timeline-item-active {
-    color: #1a2744;
-}
-
-.extraction-timeline-item-done {
-    color: #1a2744;
-}
-
-.extraction-timeline-guide {
+.extraction-phase::before {
+    content: '';
     position: absolute;
+    left: 9px;
     top: 0;
-    left: 0;
-    width: 40px;
-    height: auto;
-    overflow: visible;
-    pointer-events: none;
+    bottom: 0;
+    width: 2px;
+    background: rgba(26, 39, 68, 0.12);
 }
 
-.extraction-timeline-path {
-    fill: none;
-    stroke-linecap: round;
-    stroke-linejoin: round;
-    stroke-width: 2;
-    vector-effect: non-scaling-stroke;
+.extraction-phase:first-child::before {
+    top: 10px;
 }
 
-.extraction-timeline-path-muted {
-    stroke: rgba(26, 39, 68, 0.12);
+.extraction-phase:last-child::before {
+    bottom: auto;
+    height: 10px;
 }
 
-.extraction-timeline-path-active {
-    stroke: #7357b8;
-    stroke-width: 2.1;
-    vector-effect: non-scaling-stroke;
+.extraction-phase-done::before {
+    background: rgba(115, 87, 184, 0.5);
 }
 
-.extraction-timeline-dot {
-    fill: #fff;
-    stroke: rgba(26, 39, 68, 0.42);
-    stroke-width: 2.2;
-    vector-effect: non-scaling-stroke;
+.extraction-phase-dot {
+    position: absolute;
+    left: 1px;
+    top: 1px;
+    width: 18px;
+    height: 18px;
+    box-sizing: border-box;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border: 2px solid rgba(26, 39, 68, 0.3);
+    border-radius: 50%;
+    background: #fff;
 }
 
-.extraction-timeline-dot-done {
-    fill: #7357b8;
-    stroke: #7357b8;
+.extraction-phase-done .extraction-phase-dot {
+    border-color: #7357b8;
+    background: #7357b8;
 }
 
-.extraction-timeline-dot-active {
-    fill: #fff;
-    stroke: #7357b8;
-    stroke-width: 3;
-}
-
-.extraction-timeline-dot-core {
-    fill: #7357b8;
-}
-
-.extraction-timeline-content {
-    display: grid;
-    gap: 5px;
-    min-width: 0;
-}
-
-.extraction-timeline-label {
-    font-size: 15px;
-    font-weight: 500;
-    line-height: 1.25;
-    color: currentColor;
-}
-
-.extraction-timeline-detail {
-    font-size: 12px;
-    line-height: 1.4;
-    color: rgba(26, 39, 68, 0.48);
-}
-
-.extraction-timeline-item-active .extraction-timeline-detail,
-.extraction-timeline-item-done .extraction-timeline-detail {
-    color: rgba(26, 39, 68, 0.58);
-}
-
-.extraction-timeline-details-toggle {
-    justify-self: start;
-    margin-top: 2px;
-    padding: 0;
-    border: 0;
-    background: none;
-    color: rgba(26, 39, 68, 0.52);
-    cursor: pointer;
+.extraction-phase-done .extraction-phase-dot::after {
+    content: '✓';
+    color: #fff;
     font-size: 11px;
-    font-weight: 600;
-
-    &:hover:not(:disabled) {
-        color: #1a2744;
-    }
-
-    &:disabled {
-        cursor: default;
-        opacity: 0.42;
-    }
+    font-weight: 700;
+    line-height: 1;
 }
 
-.extraction-timeline-live-details {
-    max-width: 100%;
-    margin-top: 2px;
-    padding: 8px 10px;
-    border-left: 2px solid rgba(115, 87, 184, 0.34);
-    border-radius: 0 6px 6px 0;
-    background: rgba(115, 87, 184, 0.06);
-    color: rgba(26, 39, 68, 0.72);
-    font-size: 11px;
-    line-height: 1.45;
-    white-space: pre-wrap;
+.extraction-phase-error .extraction-phase-dot {
+    border-color: #b84d4d;
+    background: #b84d4d;
 }
 
-.extraction-stage-timeline {
-    margin: 0;
-    padding: 0;
-    list-style: none;
-    display: grid;
-    gap: 6px;
-}
-
-.extraction-stage-timeline-empty {
-    margin: 12px 4px;
-    color: rgba(26, 39, 68, 0.5);
-    font-size: 12px;
-}
-
-.extraction-stage-timeline-row {
-    padding: 8px 10px;
-    border-radius: 6px;
-    border-left: 3px solid rgba(115, 87, 184, 0.34);
-    background: rgba(115, 87, 184, 0.05);
-    font-size: 12px;
-    line-height: 1.45;
-}
-
-.extraction-stage-timeline-row-ok {
-    border-left-color: rgba(63, 135, 109, 0.55);
-    background: rgba(63, 135, 109, 0.05);
-}
-
-.extraction-stage-timeline-row-error {
-    border-left-color: rgba(220, 80, 80, 0.55);
-    background: rgba(220, 80, 80, 0.05);
-}
-
-.extraction-stage-timeline-row-skipped {
-    opacity: 0.6;
-    border-left-color: rgba(26, 39, 68, 0.16);
-    background: rgba(26, 39, 68, 0.03);
-}
-
-.extraction-stage-timeline-header {
-    display: grid;
-    grid-template-columns: minmax(0, 1fr) auto auto auto;
-    gap: 8px;
-    align-items: baseline;
-}
-
-.extraction-stage-timeline-stage {
-    font-weight: 600;
-    color: #1a2744;
-    min-width: 0;
-    overflow-wrap: anywhere;
-}
-
-.extraction-stage-timeline-model {
-    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-    font-size: 11px;
-    color: rgba(26, 39, 68, 0.66);
-}
-
-.extraction-stage-timeline-duration {
-    font-variant-numeric: tabular-nums;
-    font-size: 11px;
-    color: rgba(26, 39, 68, 0.66);
-}
-
-.extraction-stage-timeline-status {
+.extraction-phase-error .extraction-phase-dot::after {
+    content: '✕';
+    color: #fff;
     font-size: 10px;
-    padding: 1px 6px;
-    border-radius: 10px;
-    text-transform: uppercase;
+    font-weight: 700;
+    line-height: 1;
+}
+
+.extraction-phase-active .extraction-phase-dot {
+    border-color: rgba(115, 87, 184, 0.25);
+    border-top-color: #7357b8;
+}
+
+.extraction-phase-timeline-live .extraction-phase-active .extraction-phase-dot {
+    animation: extraction-spin 0.8s linear infinite;
+}
+
+.extraction-phase-head {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    min-height: 20px;
+}
+
+.extraction-phase-label {
+    font-size: 14px;
+    font-weight: 600;
+    line-height: 1.25;
+    color: rgba(26, 39, 68, 0.5);
+}
+
+.extraction-phase-active .extraction-phase-label,
+.extraction-phase-done .extraction-phase-label {
+    color: #1a2744;
+}
+
+.extraction-phase-error .extraction-phase-label {
+    color: #b84d4d;
+}
+
+.extraction-phase-count {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 18px;
+    height: 18px;
+    padding: 0 5px;
+    border-radius: 9px;
+    background: rgba(115, 87, 184, 0.14);
+    color: #7357b8;
+    font-size: 11px;
     font-weight: 700;
 }
 
-.extraction-stage-timeline-status-ok {
-    background: rgba(63, 135, 109, 0.16);
-    color: #3f876d;
-}
-
-.extraction-stage-timeline-status-error {
-    background: rgba(220, 80, 80, 0.16);
-    color: #b84d4d;
-}
-
-.extraction-stage-timeline-status-skipped {
-    background: rgba(26, 39, 68, 0.08);
-    color: rgba(26, 39, 68, 0.58);
-}
-
-.extraction-stage-timeline-summary {
-    margin-top: 4px;
-    color: rgba(26, 39, 68, 0.72);
-}
-
-.extraction-stage-timeline-error {
-    margin-top: 4px;
-    color: #b84d4d;
+.extraction-phase-duration {
+    margin-left: auto;
+    font-variant-numeric: tabular-nums;
     font-size: 11px;
-    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-    white-space: pre-wrap;
+    color: rgba(26, 39, 68, 0.55);
 }
 
-.extraction-stage-timeline-details {
-    margin-top: 4px;
+.extraction-phase-meta {
+    margin: 3px 0 0;
+    font-size: 11px;
+    color: rgba(26, 39, 68, 0.5);
+    overflow-wrap: anywhere;
+}
+
+.extraction-phase-waiting {
+    margin: 4px 0 0;
+    font-size: 11px;
+    font-style: italic;
+    color: rgba(26, 39, 68, 0.45);
+}
+
+.extraction-phase-substeps {
+    margin: 6px 0 0;
+    padding: 0;
+    list-style: none;
+    display: grid;
+    gap: 4px;
+}
+
+.extraction-substep {
+    padding: 5px 9px;
+    border-radius: 6px;
+    background: rgba(115, 87, 184, 0.04);
+}
+
+.extraction-substep-ok {
+    background: rgba(63, 135, 109, 0.05);
+}
+
+.extraction-substep-error {
+    background: rgba(220, 80, 80, 0.06);
+}
+
+.extraction-substep-skipped {
+    opacity: 0.7;
+    background: rgba(26, 39, 68, 0.03);
+}
+
+.extraction-substep-head {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.extraction-substep-label {
+    flex: 1 1 auto;
+    min-width: 0;
+    overflow-wrap: anywhere;
+    font-size: 12px;
+    font-weight: 500;
+    color: #1a2744;
+}
+
+.extraction-substep-aside {
+    flex: 0 0 auto;
+    margin-left: auto;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.extraction-substep-model {
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 10px;
+    color: rgba(26, 39, 68, 0.6);
+}
+
+.extraction-substep-duration {
+    font-variant-numeric: tabular-nums;
+    font-size: 10px;
+    color: rgba(26, 39, 68, 0.6);
+}
+
+.extraction-substep-status {
+    flex: 0 0 auto;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 14px;
+    height: 14px;
+    box-sizing: border-box;
+    font-size: 12px;
+    line-height: 1;
+}
+
+.extraction-substep-ok .extraction-substep-status::after {
+    content: '✓';
+    color: #3f876d;
+    font-weight: 700;
+}
+
+.extraction-substep-error .extraction-substep-status::after {
+    content: '✕';
+    color: #b84d4d;
+    font-weight: 700;
+}
+
+.extraction-substep-skipped .extraction-substep-status::after {
+    content: '–';
+    color: rgba(26, 39, 68, 0.5);
+}
+
+.extraction-substep-running .extraction-substep-status {
+    border: 2px solid rgba(115, 87, 184, 0.25);
+    border-top-color: #7357b8;
+    border-radius: 50%;
+}
+
+.extraction-phase-timeline-live .extraction-substep-running .extraction-substep-status {
+    animation: extraction-spin 0.7s linear infinite;
+}
+
+.extraction-substep-summary {
+    margin: 3px 0 0;
+    font-size: 11px;
+    line-height: 1.45;
+    color: rgba(26, 39, 68, 0.7);
+    overflow-wrap: anywhere;
+}
+
+.extraction-substep-error-text {
+    margin: 3px 0 0;
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 11px;
+    line-height: 1.4;
+    color: #b84d4d;
+    white-space: pre-wrap;
+    overflow-wrap: anywhere;
+}
+
+.extraction-substep-details {
+    margin: 3px 0 0;
     font-size: 11px;
     color: rgba(26, 39, 68, 0.58);
 
@@ -1039,17 +1073,46 @@
     }
 }
 
-.extraction-stage-timeline-preview {
-    margin: 4px 0 0;
+.extraction-substep-preview {
+    margin: 3px 0 0;
     padding: 6px 8px;
     background: rgba(26, 39, 68, 0.04);
     border-radius: 4px;
-    max-height: 220px;
+    max-height: 240px;
     overflow-y: auto;
-    white-space: pre-wrap;
+    overflow-wrap: anywhere;
     font-size: 11px;
-    line-height: 1.4;
+    line-height: 1.5;
+    color: rgba(26, 39, 68, 0.78);
 }
+
+.extraction-substep-output-details {
+    margin: 4px 0 0;
+    font-size: 11px;
+
+    summary {
+        cursor: pointer;
+        user-select: none;
+        color: rgba(26, 39, 68, 0.58);
+    }
+}
+
+.extraction-substep-output {
+    margin: 4px 0 0;
+    padding: 6px 9px;
+    max-height: 260px;
+    overflow-y: auto;
+    border-left: 2px solid rgba(115, 87, 184, 0.34);
+    border-radius: 0 4px 4px 0;
+    background: rgba(115, 87, 184, 0.06);
+    color: rgba(26, 39, 68, 0.82);
+    font-size: 11px;
+    line-height: 1.5;
+    overflow-wrap: anywhere;
+}
+
+// Markdown element styles (.lixpi-markdown / .lixpi-md-*) are global — see
+// src/sass/_markdown.scss and documentation/coding-style-guides/MARKDOWN-RENDERING.md.
 
 .extraction-tab-reasoning-toggle {
     margin: 6px 0 0;

--- a/services/web-ui/src/infographics/workspace/media-library-panel.scss
+++ b/services/web-ui/src/infographics/workspace/media-library-panel.scss
@@ -1112,7 +1112,7 @@
 }
 
 // Markdown element styles (.lixpi-markdown / .lixpi-md-*) are global — see
-// src/sass/_markdown.scss and documentation/coding-style-guides/MARKDOWN-RENDERING.md.
+// src/sass/_markdown.scss and documentation/features/MARKDOWN-RENDERING.md.
 
 .extraction-tab-reasoning-toggle {
     margin: 6px 0 0;

--- a/services/web-ui/src/infographics/workspace/mediaLibraryPanel.test.ts
+++ b/services/web-ui/src/infographics/workspace/mediaLibraryPanel.test.ts
@@ -19,7 +19,8 @@ describe('Media Library panel contract', () => {
     })
 
     it('does not truncate feature instructions or tags', () => {
-        expect(panelSource).toContain('${feature.instructions}')
+        // Instructions render through the unified markdown stream renderer, untruncated.
+        expect(panelSource).toContain('renderMarkdownStatic(feature.instructions')
         expect(panelSource).toContain('for (const tag of feature.tags ?? [])')
         expect(panelSource).not.toContain('feature.instructions.slice')
         expect(panelSource).not.toContain('feature.tags?.slice')

--- a/services/web-ui/src/infographics/workspace/mediaLibraryPanel.ts
+++ b/services/web-ui/src/infographics/workspace/mediaLibraryPanel.ts
@@ -1,6 +1,7 @@
 'use strict'
 
 import { html } from '$src/utils/domTemplates.ts'
+import { renderMarkdownStatic } from '$src/utils/markdownStreamRenderer.ts'
 import {
     NATS_SUBJECTS,
     MEDIA_LIBRARY_BROWSE_ALL,
@@ -420,10 +421,12 @@ export function createMediaLibraryPanel(options: MediaLibraryPanelOptions) {
 
     function buildInstructionsPreview(feature: Feature): HTMLElement | null {
         if (!feature.instructions?.trim()) return null
-        return html`<div className="feature-library-instructions">
+        // Render instructions through the unified markdown renderer, not as raw text.
+        const wrapEl = html`<div className="feature-library-instructions">
             <div className="feature-library-instructions-title">Application notes</div>
-            <div className="feature-library-instructions-body">${feature.instructions}</div>
         </div>` as HTMLElement
+        wrapEl.appendChild(renderMarkdownStatic(feature.instructions, `feature:${feature.featureId}`, 'feature-library-instructions-body lixpi-markdown'))
+        return wrapEl
     }
 
     function buildSampleGallery(feature: FeatureMeta, details: FeatureDetailsState | undefined): HTMLElement {

--- a/services/web-ui/src/sass/_markdown.scss
+++ b/services/web-ui/src/sass/_markdown.scss
@@ -1,0 +1,70 @@
+// Global styles for markdown rendered by the unified MarkdownStreamRenderer
+// (src/utils/markdownStreamRenderer.ts). These are intentionally global so any
+// non-editable surface that renders markdown through the parser is styled
+// consistently. See documentation/coding-style-guides/MARKDOWN-RENDERING.md.
+
+.lixpi-markdown {
+    overflow-wrap: anywhere;
+}
+
+.lixpi-md-paragraph {
+    margin: 0 0 6px;
+
+    &:last-child {
+        margin-bottom: 0;
+    }
+}
+
+.lixpi-md-heading {
+    margin: 8px 0 4px;
+    font-weight: 700;
+    line-height: 1.3;
+    color: #1a2744;
+
+    &:first-child {
+        margin-top: 0;
+    }
+}
+
+.lixpi-md-h1 {
+    font-size: 15px;
+}
+
+.lixpi-md-h2 {
+    font-size: 14px;
+}
+
+.lixpi-md-h3 {
+    font-size: 13px;
+}
+
+.lixpi-md-h4,
+.lixpi-md-h5,
+.lixpi-md-h6 {
+    font-size: 12px;
+}
+
+.lixpi-md-pre {
+    margin: 6px 0;
+    padding: 8px 10px;
+    border-radius: 4px;
+    background: rgba(26, 39, 68, 0.06);
+    overflow-x: auto;
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 11px;
+    line-height: 1.45;
+
+    code {
+        font: inherit;
+        background: none;
+        padding: 0;
+    }
+}
+
+.lixpi-md-code-inline {
+    padding: 1px 4px;
+    border-radius: 3px;
+    background: rgba(26, 39, 68, 0.08);
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 0.92em;
+}

--- a/services/web-ui/src/sass/_markdown.scss
+++ b/services/web-ui/src/sass/_markdown.scss
@@ -1,7 +1,7 @@
 // Global styles for markdown rendered by the unified MarkdownStreamRenderer
 // (src/utils/markdownStreamRenderer.ts). These are intentionally global so any
 // non-editable surface that renders markdown through the parser is styled
-// consistently. See documentation/coding-style-guides/MARKDOWN-RENDERING.md.
+// consistently. See documentation/features/MARKDOWN-RENDERING.md.
 
 .lixpi-markdown {
     overflow-wrap: anywhere;

--- a/services/web-ui/src/sass/styles.scss
+++ b/services/web-ui/src/sass/styles.scss
@@ -8,6 +8,7 @@
 
 
 @import '_typography';
+@import '_markdown';
 
 @import 'components/animations';
 

--- a/services/web-ui/src/utils/markdownStreamRenderer.ts
+++ b/services/web-ui/src/utils/markdownStreamRenderer.ts
@@ -1,0 +1,120 @@
+'use strict'
+
+import { MarkdownStreamParser } from '@lixpi/markdown-stream-parser'
+import { html } from './domTemplates.ts'
+
+// Unified, framework-agnostic renderer that turns a markdown token stream into plain DOM
+// using the app's @lixpi/markdown-stream-parser.
+//
+// RULE: this is the ONLY way non-editable markdown may be rendered in the web UI. Editable
+// markdown in ProseMirror is handled by the aiChatThreadPlugin (StreamingInserter); every
+// other place that shows markdown — extraction tab, Media Library, future surfaces — MUST
+// use this class (or renderMarkdownStatic). Never hand-roll markdown→HTML and never render
+// raw markdown as plain text. See documentation/coding-style-guides/MARKDOWN-RENDERING.md.
+//
+// Each emitted segment is { status, segment: { segment, styles[], type, level, isBlockDefining } }
+// where type ∈ 'paragraph' | 'header' | 'code' and styles ⊆ 'bold' | 'italic' | 'strikethrough' | 'code'.
+
+type ParsedSegment = {
+    status: 'STREAMING' | 'END_STREAM'
+    segment?: {
+        segment?: string
+        styles?: string[]
+        type?: string
+        level?: number
+        isBlockDefining?: boolean
+    }
+}
+
+function wrapInline(child: Node, style: string): Node {
+    if (style === 'bold') { const el = html`<strong></strong>` as HTMLElement; el.appendChild(child); return el }
+    if (style === 'italic') { const el = html`<em></em>` as HTMLElement; el.appendChild(child); return el }
+    if (style === 'strikethrough') { const el = html`<del></del>` as HTMLElement; el.appendChild(child); return el }
+    if (style === 'code') { const el = html`<code className="lixpi-md-code-inline"></code>` as HTMLElement; el.appendChild(child); return el }
+    return child
+}
+
+// Wraps the text node from inner to outer so the outermost element is bold.
+function styledTextNode(text: string, styles: string[], blockType: string): Node {
+    if (blockType === 'code') return document.createTextNode(text)
+    let node: Node = document.createTextNode(text)
+    if (styles.includes('code')) node = wrapInline(node, 'code')
+    if (styles.includes('strikethrough')) node = wrapInline(node, 'strikethrough')
+    if (styles.includes('italic')) node = wrapInline(node, 'italic')
+    if (styles.includes('bold')) node = wrapInline(node, 'bold')
+    return node
+}
+
+function createBlock(type: string, level: number | undefined): HTMLElement {
+    if (type === 'header') {
+        const lvl = Math.min(Math.max(level ?? 3, 1), 6)
+        return html`<div className=${`lixpi-md-heading lixpi-md-h${lvl}`}></div>` as HTMLElement
+    }
+    if (type === 'code') return html`<pre className="lixpi-md-pre"><code></code></pre>` as HTMLElement
+    return html`<p className="lixpi-md-paragraph"></p>` as HTMLElement
+}
+
+export class MarkdownStreamRenderer {
+    readonly contentEl: HTMLElement
+    private readonly instanceId: string
+    private parser: ReturnType<typeof MarkdownStreamParser.getInstance>
+    private unsubscribe: (() => void) | null = null
+    private currentBlock: HTMLElement | null = null
+    private currentType: string | null = null
+
+    constructor(instanceId: string, className = 'lixpi-markdown') {
+        this.instanceId = instanceId
+        this.contentEl = html`<div className=${className}></div>` as HTMLElement
+        this.parser = MarkdownStreamParser.getInstance(instanceId)
+        this.unsubscribe = this.parser.subscribeToTokenParse((parsed: ParsedSegment) => this.handleSegment(parsed))
+        this.parser.startParsing()
+    }
+
+    push(text: string): void {
+        if (!text) return
+        this.parser.parseToken(text)
+    }
+
+    // Flushes any buffered block and tears down the parser. The END_STREAM segment from
+    // stopParsing triggers cleanup() so the final block renders whether the parser emits
+    // synchronously or asynchronously.
+    finalize(): void {
+        try { this.parser.stopParsing() } catch {}
+    }
+
+    private cleanup(): void {
+        this.unsubscribe?.()
+        this.unsubscribe = null
+        try { MarkdownStreamParser.removeInstance(this.instanceId) } catch {}
+    }
+
+    private handleSegment(parsed: ParsedSegment): void {
+        if (!parsed) return
+        if (parsed.status === 'END_STREAM') { this.cleanup(); return }
+        const seg = parsed.segment
+        if (!seg) return
+        const type = seg.type ?? 'paragraph'
+        const text = seg.segment ?? ''
+        const styles = seg.styles ?? []
+        if (seg.isBlockDefining || !this.currentBlock || type !== this.currentType) {
+            this.currentBlock = createBlock(type, seg.level)
+            this.currentType = type
+            this.contentEl.appendChild(this.currentBlock)
+        }
+        if (!text) return
+        const target = type === 'code'
+            ? (this.currentBlock.querySelector('code') ?? this.currentBlock)
+            : this.currentBlock
+        target.appendChild(styledTextNode(text, styles, type))
+    }
+}
+
+let staticRenderCounter = 0
+
+// One-shot render of a complete markdown string into a fresh element.
+export function renderMarkdownStatic(text: string, idBase: string, className = 'lixpi-markdown'): HTMLElement {
+    const renderer = new MarkdownStreamRenderer(`${idBase}:static:${staticRenderCounter++}`, className)
+    renderer.push(text)
+    renderer.finalize()
+    return renderer.contentEl
+}

--- a/services/web-ui/src/utils/markdownStreamRenderer.ts
+++ b/services/web-ui/src/utils/markdownStreamRenderer.ts
@@ -15,6 +15,9 @@ import { html } from './domTemplates.ts'
 //
 // The emitted token shape (MarkdownStreamToken) lives in @lixpi/constants — type ∈
 // 'paragraph' | 'header' | 'code' and styles ⊆ 'bold' | 'italic' | 'strikethrough' | 'code'.
+// NOTE: it is centralized in @lixpi/constants only because the published parser version does
+// not export its segment types. A newer @lixpi/markdown-stream-parser that exports proper types
+// is in development — once it ships, import the token type from the package instead.
 
 function wrapInline(child: Node, style: string): Node {
     if (style === 'bold') { const el = html`<strong></strong>` as HTMLElement; el.appendChild(child); return el }

--- a/services/web-ui/src/utils/markdownStreamRenderer.ts
+++ b/services/web-ui/src/utils/markdownStreamRenderer.ts
@@ -10,7 +10,7 @@ import { html } from './domTemplates.ts'
 // markdown in ProseMirror is handled by the aiChatThreadPlugin (StreamingInserter); every
 // other place that shows markdown — extraction tab, Media Library, future surfaces — MUST
 // use this class (or renderMarkdownStatic). Never hand-roll markdown→HTML and never render
-// raw markdown as plain text. See documentation/coding-style-guides/MARKDOWN-RENDERING.md.
+// raw markdown as plain text. See documentation/features/MARKDOWN-RENDERING.md.
 //
 // Each emitted segment is { status, segment: { segment, styles[], type, level, isBlockDefining } }
 // where type ∈ 'paragraph' | 'header' | 'code' and styles ⊆ 'bold' | 'italic' | 'strikethrough' | 'code'.

--- a/services/web-ui/src/utils/markdownStreamRenderer.ts
+++ b/services/web-ui/src/utils/markdownStreamRenderer.ts
@@ -1,6 +1,7 @@
 'use strict'
 
 import { MarkdownStreamParser } from '@lixpi/markdown-stream-parser'
+import type { MarkdownStreamToken } from '@lixpi/constants'
 import { html } from './domTemplates.ts'
 
 // Unified, framework-agnostic renderer that turns a markdown token stream into plain DOM
@@ -12,19 +13,8 @@ import { html } from './domTemplates.ts'
 // use this class (or renderMarkdownStatic). Never hand-roll markdown→HTML and never render
 // raw markdown as plain text. See documentation/features/MARKDOWN-RENDERING.md.
 //
-// Each emitted segment is { status, segment: { segment, styles[], type, level, isBlockDefining } }
-// where type ∈ 'paragraph' | 'header' | 'code' and styles ⊆ 'bold' | 'italic' | 'strikethrough' | 'code'.
-
-type ParsedSegment = {
-    status: 'STREAMING' | 'END_STREAM'
-    segment?: {
-        segment?: string
-        styles?: string[]
-        type?: string
-        level?: number
-        isBlockDefining?: boolean
-    }
-}
+// The emitted token shape (MarkdownStreamToken) lives in @lixpi/constants — type ∈
+// 'paragraph' | 'header' | 'code' and styles ⊆ 'bold' | 'italic' | 'strikethrough' | 'code'.
 
 function wrapInline(child: Node, style: string): Node {
     if (style === 'bold') { const el = html`<strong></strong>` as HTMLElement; el.appendChild(child); return el }
@@ -66,7 +56,7 @@ export class MarkdownStreamRenderer {
         this.instanceId = instanceId
         this.contentEl = html`<div className=${className}></div>` as HTMLElement
         this.parser = MarkdownStreamParser.getInstance(instanceId)
-        this.unsubscribe = this.parser.subscribeToTokenParse((parsed: ParsedSegment) => this.handleSegment(parsed))
+        this.unsubscribe = this.parser.subscribeToTokenParse((parsed: MarkdownStreamToken) => this.handleSegment(parsed))
         this.parser.startParsing()
     }
 
@@ -88,7 +78,7 @@ export class MarkdownStreamRenderer {
         try { MarkdownStreamParser.removeInstance(this.instanceId) } catch {}
     }
 
-    private handleSegment(parsed: ParsedSegment): void {
+    private handleSegment(parsed: MarkdownStreamToken): void {
         if (!parsed) return
         if (parsed.status === 'END_STREAM') { this.cleanup(); return }
         const seg = parsed.segment


### PR DESCRIPTION
## Summary

Redesigns the feature-extraction tab and hardens the extraction pipeline.

**UI** — replaces the flat `StageTraceEvent` dump with a grouped **4-phase progress timeline** (Analyze input → Extract feature → Generate samples → Save to library). Each phase shows its backend stages as **async substeps**; pure-CSS progress circles + connector rail with live spinners; the skeleton renders upfront and lights up as events stream in. **Nothing is silenced** — every event keeps its model, duration, status, output/input summary, error text, and an expandable prompt preview. The reducer is a pure, unit-tested module (`extractionTimelineModel.ts`).

**Markdown** — all non-editable markdown now renders through a single reusable `MarkdownStreamRenderer` (`utils/markdownStreamRenderer.ts`) driving `@lixpi/markdown-stream-parser`: prompt previews, streamed model output, and Media Library feature instructions (previously raw text). Element styles are global (`sass/_markdown.scss`, `.lixpi-md-*`). The rule — all markdown goes through the parser; editable → ProseMirror plugin, non-editable → `MarkdownStreamRenderer` — is documented in `coding-style-guides/MARKDOWN-RENDERING.md`.

**Reliability**
- VLM errors are logged with the real cause (status / retry-after / cause chain) and transient errors retry with jittered backoff; extractor concurrency is capped (`FEATURE_EXTRACTOR_CONCURRENCY`, default 4) to stop the connection-flood failures.
- The saved feature card is delivered as **structured content** (was truncated by the token stream's tail buffering → "could not be rendered").
- `ExtractionRun.appendTrace` strips `undefined` before persisting (fixes the DynamoDB marshaller errors).

## Tests

- New unit + contract tests in `extractionTab.test.ts` (timeline reducer, markdown wiring, structured feature card); Media Library + stream-publisher suites updated and passing.
- All changed/new web-ui files are clean under `svelte-check`.

## Notes

- Backend changes hot-reload via nodemon; the `@lixpi/constants` change is type-only (no rebuild needed).
- A markdown render and the connection fix couldn't be visually verified from the dev environment — worth a quick manual extraction run before merge.

Closes #187
