### PR TITLE
LIX-195 # Update main README for 0.2 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,96 +1,26 @@
 # Lixpi
 
-**A visual, node-based AI workspace for building image and video generation pipelines.**
-
-Lixpi sits at the intersection of an infinite spatial canvas (like Miro) and a visual logic execution pipeline (like n8n). Instead of writing workflow DSLs or using linear chat prompts, you map out ideas spatially — the arrangement of documents, images, and AI chat threads on the canvas directly dictates context, dependencies, and execution.
+**A visual, node-based AI workspace for image and video generation pipelines.**
 
 [Watch the demo →](https://youtu.be/Eee2Ku-Tl_8)
 
 ![UI screenshot](./documentation/assets/ui-screenshot.jpeg)
 
-## What Problem Does It Solve?
+Lixpi looks like an AI concept board where an artist runs their entire creative workflow on an infinite canvas. Technically, it's a visual, node-based workflow engine for AI image and video pipelines — the spatial arrangement of nodes *is* the workflow.
 
-Traditional AI tools suffer from **context collapse** — each conversation is isolated, and maintaining consistency across multiple generations (especially images) requires fragile prompt engineering.
+A few things make it unusual:
 
-Lixpi solves this through **artifact piping**: every AI-generated image becomes a concrete node on the canvas. You draw connections from that node into other AI threads, mechanically guaranteeing that downstream models receive the exact same reference. This makes complex scene creation and strict character consistency reliable — no copy-pasting prompts, no hoping the model "remembers."
-
-**Key capabilities:**
-- **Infinite canvas** with document nodes, image nodes, and AI chat thread nodes
-- **Directional edges** between nodes define context flow — connect a reference image to multiple threads to reuse it
-- **Multi-model support** — switch between OpenAI, Anthropic, and Google models mid-conversation
-- **Progressive image streaming** — see partial previews as images generate in real-time
-- **Multi-turn image editing** — refine generated images across branching threads
-
-See the [Product Overview](documentation/PRODUCT-OVERVIEW.md) for full details on capabilities and canvas primitives.
+- **Topology is the workflow.** Images, documents, and AI chat threads are nodes; directional edges between them define what feeds into what. Rearranging the canvas rearranges the pipeline.
+- **Feature extraction.** A "feature" is any reusable abstraction pulled from one or more reference inputs — a texture, drawing style, stroke pattern, lighting setup, time period, genre, or something abstract like mood or atmosphere. Each feature is stored as a small set of graphic artifacts together with a written skill that tells the model what they encode and how to apply them. Reference them in plain language (`/use loose-watercolor`) inside any prompt and mix freely. Stacking features is what gives character-consistent generation across many scenes — the hard problem text prompts alone cannot solve.
+- **Prompt enhancement.** Image and video generation isn't a one-shot call. The prompt first runs through a reasoning model that expands your input into a detailed brief; that brief is what the media model actually receives.
 
 ---
 
-## Model Chaining
+## Quick Start
 
-Image generation models are bad at understanding language. They struggle with attribute binding ("a red book and a yellow vase" vs "a yellow book and a red vase"), spatial reasoning ("a panda making latte art" vs "latte art of a panda"), negation, counting, and complex multi-part descriptions. This is a well-documented limitation — it's the reason OpenAI built DALL-E 3 natively on ChatGPT, with the LLM automatically rewriting user prompts before they reach the image model. Their own docs confirm it: the mainline text model "will automatically revise your prompt for improved performance."
+### 1. Clone with submodules
 
-Lixpi takes this same principle and makes it user-controlled and cross-provider.
-
-Users select a **text model** and an **image model** independently. When a user asks for an image, the text model analyzes the full conversation — including reference images piped in through canvas edges — reasons about what the user actually wants, and writes a detailed image prompt via a `generate_image` tool call. The system intercepts that call, extracts the crafted prompt along with any reference images, and routes everything to the selected image model through the ImageRouter.
-
-![AI Chat - Enhancing prompt through model chaining](./documentation/assets/ai-chat-enhancing-prompt-through-model-chaining.jpeg)
-
-The text model has deep language understanding — it resolves ambiguity, maintains context from the conversation, and sees the reference images the user connected. The image model has visual generation capability but shallow language comprehension. Chaining them means the user gets the reasoning of a frontier LLM driving the output of a specialized image generator, without needing to learn prompt engineering for each image model's quirks.
-
-The two models can be from **different providers** — Claude writing prompts for gpt-image-1, GPT-5 for Nano Banana — because the ImageRouter normalizes everything into a standard multimodal format before invoking the image model's own LangGraph workflow.
-
-### Why Different Combinations Produce Different Styles
-
-Each image model learns a different visual distribution — a unique internal representation of what images should look like — shaped by its architecture, training data, and how it interprets text.
-
-![AI Chat - Why different model combinations produce different styles](./documentation/assets/ai-chat-why-different-model-combinations-produce-different-styes.jpeg)
-
-**Architecture matters.** Stable Diffusion 1–2 uses a U-Net backbone; Stable Diffusion 3 switched to a Rectified Flow Transformer. DALL-E evolved from an autoregressive Transformer to diffusion conditioned on CLIP embeddings. These structural differences change how the model denoises random noise into an image — affecting texture handling, composition patterns, and the overall character of the output.
-
-**Training data defines aesthetics.** Stable Diffusion trained on LAION-5B — 5 billion web-scraped image-text pairs, filtered to 600 million images scoring ≥5/10 on an aesthetic predictor, sourced from Pinterest, DeviantArt, Flickr, and similar sites. DALL-E and Midjourney use proprietary curated datasets. Midjourney's separate "Niji" model, fine-tuned specifically on anime, is direct proof that training data composition determines visual style. A model can only generate what it has learned to see.
-
-**Text encoding shapes interpretation.** Before generation begins, the text prompt gets converted into vectors by a text encoder — CLIP for Stable Diffusion 1–2, T5 for Stable Diffusion 3 and Google Imagen. These encoders represent the same words in different vector spaces with different semantic emphasis, so the same prompt steers different models through different regions of their latent space.
-
-The text model compounds all of this. Claude, GPT-5, and Gemini write image prompts differently — different compositional emphasis, different descriptive vocabulary, different structural choices. How a scene is described determines which parts of the image model's learned distribution get activated.
-
-The result: pairing Claude with gpt-image-1 produces a genuinely different aesthetic than pairing GPT-5 with Nano Banana. Every component — the text model's prompt style, the text encoder's vector representation, the model architecture, the training data distribution — compounds into a distinct visual signature. This makes model pairing a creative decision, not just a technical one. [More info... →](documentation/knowledge/WHY-DIFFERENT-MODEL-COMBINATIONS-PRODUCE-DIFFERENT-STYLES.md)
-
----
-
-## Architecture: How It Works
-
-![High-Level System Overview](./documentation/assets/services-architecture-diagram.jpeg)
-
-- **Everything talks through NATS** — browser clients and the API service communicate via the same message bus
-- **Web UI connects directly to NATS** via WebSocket, enabling real-time streaming without HTTP polling
-- **API Service** handles authentication, CRUD, database operations, AND the in-process LangGraph LLM workflow that streams AI responses directly to clients
-
-### AI Chat Data Flow
-
-#### Request Path — From Canvas to AI
-
-![AI Chat Flow — Request Path](./documentation/assets/ai-chat-data-flow-diagram.jpeg)
-
-1. **Context extraction** (browser): When you hit Send, the web-ui traverses canvas edges — pulling text from connected Document nodes, `nats-obj://` image references from Image nodes, and conversation history from upstream AI Thread nodes — then assembles everything into a multimodal payload.
-2. **Publish to NATS**: The browser publishes the payload via WebSocket.
-3. **API service** (`lixpi-api`): The NATS handler fetches AI model metadata from DynamoDB, then invokes the LLM module (`services/api/src/llm/`) in-process. The module runs a LangGraph workflow that resolves `nats-obj://` references, streams from the AI provider, and — if image generation is needed — routes to the appropriate image model.
-4. **Render**: Tokens stream directly to the browser via NATS (`ai.interaction.chat.receiveMessage.{ws}.{thread}`) and render in ProseMirror.
-
-#### Streaming Response — From AI to Canvas
-
-![AI Chat Flow — Streaming Response](./documentation/assets/ai-streaming-response-diagram.jpeg)
-
-1. **Text streaming**: The LangGraph workflow streams the text response from the AI provider. If the model invokes the `generate_image` tool, image generation is triggered; otherwise, tokens stream directly to the browser.
-2. **Image generation path**: The ImageRouter creates a transient image-model provider (OpenAI gpt-image-*, Google Gemini, Stability), streams partial previews (blurry → clear), and uploads the final image to JetStream Object Store via the in-process `storeWorkspaceImage` helper.
-3. **Delivery**: Text-only responses arrive via `END_STREAM` and render in ProseMirror. Generated images arrive via `IMAGE_COMPLETE` and appear as image nodes on the canvas.
-
-For the full architecture deep-dive, see [Architecture](documentation/ARCHITECTURE.md).
-
----
-
-## Clone this repository
-
-Third-party sources under `packages-vendor/` are **Git submodules** ([shadcn-svelte](https://github.com/huntabyte/shadcn-svelte), [xyflow](https://github.com/xyflow/xyflow)). Clone with submodules so those checkouts exist:
+Third-party sources under `packages-vendor/` are Git submodules ([shadcn-svelte](https://github.com/huntabyte/shadcn-svelte), [xyflow](https://github.com/xyflow/xyflow)):
 
 ```bash
 git clone --recurse-submodules <repository-url>
@@ -102,11 +32,7 @@ If you already cloned without submodules, initialize them once from the repo roo
 git submodule update --init --recursive
 ```
 
----
-
-## Quick Start
-
-### 1. Environment Setup
+### 2. Environment setup
 
 ```bash
 # macOS / Linux
@@ -118,7 +44,7 @@ init-config.bat
 
 For CI/automation, see [`infrastructure/init-script/README.md`](infrastructure/init-script/README.md).
 
-### 2. Initialize Infrastructure
+### 3. Initialize infrastructure
 
 First-time setup for TLS certificates and DynamoDB tables:
 
@@ -130,7 +56,7 @@ First-time setup for TLS certificates and DynamoDB tables:
 init-infrastructure.bat
 ```
 
-### 3. Start
+### 4. Start
 
 ```bash
 # macOS / Linux
@@ -142,17 +68,78 @@ start.bat
 
 ---
 
+## Key Features
+
+### Feature Extraction & Library
+
+Features are first-class library entries that capture the essence of any visual abstraction — painting style, color palette, mood, lighting setup, stroke pattern, character design — extracted from one or more reference inputs (images, documents, threads, or mixes of all three).
+
+Extraction runs as a multi-stage pipeline: scene assessment and routing → parallel per-axis extractors (palette, lighting, character design, line quality, medium signature, composition, mood, texture, etc.) → deterministic source-pixel crops → dominance-weighted synthesis → sample generation → persistence. The result is a reusable entry with structured parameters, a written instruction body, and content-free sample artifacts that preserve the medium without leaking the source subject. Features apply via `/use <name>` in any prompt; the server resolves the reference at send time and injects the instructions and samples as system context — the original reference content is never forwarded to the downstream model.
+
+See [Feature Extraction & Library](documentation/features/FEATURE-EXTRACTION-AND-LIBRARY.md).
+
+### Media Library
+
+A canvas-owned panel for media a user has explicitly chosen to keep. Saved images are independent copies — not bookmarks to a canvas node — so users can reorganize or delete the original canvas image without losing what they saved for reuse. Items are scoped per-workspace, per-user, per-organization, or public; the same panel hosts the extracted Features library.
+
+See [Media Library](documentation/features/MEDIA-LIBRARY.md).
+
+### Image Branch Lineage
+
+Every AI-generated image is a first-class canvas artifact with explicit parentage, branch identity, visual summaries, and resolver audit metadata. When you say "draw a goat in the style of that landscape painting," a structured VLM resolver inspects the labeled candidate images on the canvas and decides which are the subject reference, which are style references, and which are unrelated — without parsing strings or guessing from recency. Pixels make the decision, not regex.
+
+See [Image Branch Lineage](documentation/features/IMAGE-BRANCH-LINEAGE.md).
+
+### Artifact Piping & Character Consistency
+
+Every AI-generated image becomes a concrete canvas node. Draw an edge from that node into other AI threads and downstream models receive the exact same reference — mechanically. No copy-pasting prompts, no hoping the model "remembers." This is what makes strict character and object consistency reliable across many scenes.
+
+### Multi-Model with Prompt Enhancement
+
+Each thread carries independent text-model and image-model selectors. The two can be from **different providers** — Claude writing prompts for gpt-image-1, GPT-5 driving Nano Banana — because the chain runs through an in-process `ImageRouter` that normalizes everything to a standard multimodal format before invoking the image model. Each pairing produces a distinct visual signature: the text model's prompt style, the image model's text encoder, architecture, and training data all compound, which makes model pairing a creative decision rather than a technical one.
+
+See [Model chaining and why different combinations produce different styles](documentation/knowledge/WHY-DIFFERENT-MODEL-COMBINATIONS-PRODUCE-DIFFERENT-STYLES.md).
+
+### Progressive Streaming & Multi-Turn Editing
+
+An animated placeholder appears immediately when generation starts; up to three progressively sharper previews update the canvas node in real time before the final image replaces them. "Edit in New Thread" creates a fresh AI thread pre-linked to the image, carrying provider continuity IDs so the model can make targeted modifications without regenerating from scratch — and the same image can be branched in multiple edit directions simultaneously.
+
+---
+
+## Tech Stack
+
+- **LangGraph** — AI workflow orchestration
+- **NATS / NATS JetStream** — messaging backbone for the entire system (end-to-end communication and object storage)
+- **PIXI.js, @xyflow/system, D3, Svelte** — infinite canvas UI
+- **ProseMirror, CodeMirror** — rich-text editors for AI chat and prompt input
+- **DynamoDB** — persistence
+- **Pulumi, AWS** — cloud deployment (largely cloud-agnostic today; the plan is to go fully cloud-agnostic by swapping DynamoDB for Cassandra)
+- **LLM / media APIs** — OpenAI, Anthropic, Google, Stable Diffusion, Seedance
+- **TypeScript** — main language across the project
+
+---
+
+## Architecture: How It Works
+
+![High-Level System Overview](./documentation/assets/services-architecture-diagram.jpeg)
+
+- **Everything talks through NATS** — browser clients and backend services share the same message bus.
+- **Web UI connects directly to NATS** via WebSocket, enabling real-time streaming without HTTP polling.
+- **Main API** handles authentication, CRUD, DynamoDB persistence, and **all LLM orchestration in-process** as a TypeScript LangGraph module — validation, token streaming, image generation, feature extraction, branch resolution, and usage tracking. (Earlier releases ran a separate Python `llm-api` service; that has been absorbed into the main API.)
+- **AI tokens stream directly** through per-thread NATS subjects to the browser, so token delivery is not gated by any extra service hop.
+
+For the full architecture deep-dive — including AI chat request/response flow, streaming, scalability via NATS queue groups, and authentication — see [Architecture](documentation/ARCHITECTURE.md). For image generation specifics, see [Image Generation](documentation/features/IMAGE-GENERATION.md).
+
+---
+
 ## Documentation
 
 - [Product Overview](documentation/PRODUCT-OVERVIEW.md) — capabilities, canvas primitives, artifact piping, image generation
 - [Architecture](documentation/ARCHITECTURE.md) — system design, NATS messaging, AI chat flow, scalability
 - [Development Guide](documentation/DEVELOPMENT.md) — building services, local auth, Pulumi
+- [Feature Extraction & Library](documentation/features/FEATURE-EXTRACTION-AND-LIBRARY.md)
+- [Media Library](documentation/features/MEDIA-LIBRARY.md)
+- [Image Branch Lineage](documentation/features/IMAGE-BRANCH-LINEAGE.md)
 - [Canvas Engine](documentation/features/CANVAS-ENGINE.md) — rendering, pan/zoom, node interactions
 - [Image Generation](documentation/features/IMAGE-GENERATION.md) — streaming, placement, multi-turn editing
-
----
-
-## Built With
-
-[ProseMirror](https://prosemirror.net) · [CodeMirror](https://codemirror.net) · [NATS](https://nats.io) · [D3](https://d3js.org) · [Svelte](https://svelte.dev) · [LangGraph](https://www.langchain.com/langgraph) · [shadcn-svelte](https://www.shadcn-svelte.com) · [@xyflow/system](https://github.com/xyflow/xyflow) (low-level pan/zoom/coordinate math only — not React Flow or Svelte Flow) · [CSS Loaders](https://cssloaders.github.io/)
-
+- [Why Different Model Combinations Produce Different Styles](documentation/knowledge/WHY-DIFFERENT-MODEL-COMBINATIONS-PRODUCE-DIFFERENT-STYLES.md)


### PR DESCRIPTION
## Summary

The main README has been rewritten for the 0.2 release. The previous version was outdated — still pitching the system around "context collapse," still pointing at the standalone Python `llm-api` service, missing every major 0.2 feature, and burying Quick Start at the bottom.

What changed:

- **Tighter intro** modeled on the proposal-style concept-board framing; dropped the "Problem It Solves" section.
- **Quick Start moved up** — now the second section.
- **Key Features** rewritten with sections for Feature Extraction & Library, Media Library, Image Branch Lineage, Artifact Piping, Multi-Model with Prompt Enhancement, and Progressive Streaming.
- **Model Chaining / Why Different Combinations** shortened to a paragraph with a link to [`documentation/knowledge/WHY-DIFFERENT-MODEL-COMBINATIONS-PRODUCE-DIFFERENT-STYLES.md`](documentation/knowledge/WHY-DIFFERENT-MODEL-COMBINATIONS-PRODUCE-DIFFERENT-STYLES.md). Inline screenshots removed.
- **AI Chat Data Flow and Streaming Response** sections removed from the README and replaced with pointers to [`ARCHITECTURE.md`](documentation/ARCHITECTURE.md) and [`features/IMAGE-GENERATION.md`](documentation/features/IMAGE-GENERATION.md).
- **Architecture: How It Works** updated to reflect that the main API now owns all LLM orchestration in-process (the Python `llm-api` is gone — #137). The existing `services-architecture-diagram.jpeg` is kept.
- **Tech Stack** section added per the proposal: LangGraph, NATS/JetStream, PIXI.js + @xyflow/system + D3 + Svelte, ProseMirror/CodeMirror, DynamoDB, Pulumi/AWS, OpenAI/Anthropic/Google/Stable Diffusion/Seedance, TypeScript.
- **Documentation** section expanded with links to the new feature docs.

Resolves #195. Part of the 0.2 release tracked in #152.

## Notes

- `documentation/PRODUCT-OVERVIEW.md` and `documentation/ARCHITECTURE.md` still describe the old Python `llm-api` as a separate service. Those weren't in scope for this PR but should probably get a follow-up pass.
- `services-architecture-diagram.jpeg` still shows the old two-service split — the README text now contradicts the diagram. The image will be updated separately.

## Test plan

- [ ] Render the README on GitHub and visually confirm the layout
- [ ] Click every link in the Documentation section and confirm each target exists
- [ ] Confirm the existing `services-architecture-diagram.jpeg` displays correctly under "Architecture: How It Works"