### PR TITLE
LIX-201 # Remove canvas generated image center spinner

### DIFF
--- a/documentation/features/CANVAS-ENGINE.md
+++ b/documentation/features/CANVAS-ENGINE.md
@@ -123,7 +123,7 @@ flowchart TB
 
 The PIXI image canvas sits **above** the DOM viewport; the PIXI context-region canvas sits **below** it. Generated-image provider badges, info buttons, and full-width provenance panels sit in `.workspace-image-chrome-viewport`, a separate CSS-transformed DOM overlay above the PIXI media canvas. Provenance panels use the exact image-node width and expand to their full content height, so long prompts and reference metadata are not cropped. Image-node DOM shells are kept as `<div data-node-id>` elements for two reasons:
 
-1. They host core interaction chrome — drag overlay, resize handles, and generation spinner.
+1. They host core interaction chrome — drag overlay and resize handles.
 2. They provide stable DOM geometry for selection, drag, resize, and bubble-menu integration.
 
 Canvas image nodes create no DOM `<img>` element. Stored, external, data-URL, and generated partial image sources all go through the PIXI media layer, so there is no duplicate hidden loader or fallback pixel surface. Generated-image partial pixels and the traveling in-progress outline are rendered by PIXI, not by a DOM/SVG overlay.

--- a/documentation/features/WORKSPACE-FEATURE.md
+++ b/documentation/features/WORKSPACE-FEATURE.md
@@ -1086,9 +1086,9 @@ Multi-turn editing is supported: users can continue refining an image within the
 1. User enables "Image Generation" mode in an AI chat thread's settings
 2. User types a prompt like "Create a logo for a coffee shop"
 3. The request goes to `llm-api` which calls OpenAI with the `image_generation` tool
-4. As soon as OpenAI fires `response.output_item.added` (before any pixel data), `provider.py` publishes an early `IMAGE_PARTIAL` with an empty `imageUrl`. This triggers the canvas to create a placeholder image node with a PIXI-rendered traveling progress border and a three-dot bounce spinner
-5. OpenAI streams back partial images (up to 3) as the generation progresses. The first real partial removes the spinner; subsequent partials update the image progressively
-6. On completion, `IMAGE_COMPLETE` removes the animated border and spinner, finalizes the canvas node with full metadata, and updates the edge with `sourceMessageId` so the connector points back to the producing AI response.
+4. As soon as OpenAI fires `response.output_item.added` (before any pixel data), `provider.py` publishes an early `IMAGE_PARTIAL` with an empty `imageUrl`. This triggers the canvas to create a placeholder image node with a PIXI-rendered traveling progress border
+5. OpenAI streams back partial images (up to 3) as the generation progresses. Each partial updates the image progressively while the border remains active
+6. On completion, `IMAGE_COMPLETE` removes the animated border, finalizes the canvas node with full metadata, and updates the edge with `sourceMessageId` so the connector points back to the producing AI response.
 7. The revised prompt text appears inside the AI response message in the chat thread
 8. Multiple generated images stack using the spacing configured in `settings.imageBranchLineage`.
 
@@ -1126,12 +1126,12 @@ sequenceDiagram
     %% PHASE 2: EARLY PLACEHOLDER → CANVAS
     %% ═══════════════════════════════════════════════════════════════
     rect rgb(195, 222, 221)
-        Note over User, Storage: PHASE 2 - EARLY PLACEHOLDER — Animated border + spinner before pixels arrive
+        Note over User, Storage: PHASE 2 - EARLY PLACEHOLDER — Animated border before pixels arrive
         OpenAI->>LLM: response.output_item.added (image_generation_call)
         LLM->>AIS: IMAGE_PARTIAL { imageUrl: "", partialIndex: 0 }
         AIS->>Thread: Plugin routes to canvas callback
         Thread->>Canvas: onImagePartialToCanvas({ imageUrl: "" })
-        Canvas->>Canvas: Create ImageCanvasNode (transparent 1×1 PNG) + PIXI traveling progress border + 3-dot spinner
+        Canvas->>Canvas: Create ImageCanvasNode (transparent 1×1 PNG) + PIXI traveling progress border
     end
 
     %% ═══════════════════════════════════════════════════════════════
@@ -1144,7 +1144,7 @@ sequenceDiagram
             LLM->>AIS: IMAGE_PARTIAL { partialIndex, imageUrl, fileId }
             AIS->>Thread: Plugin routes to canvas callback
             Thread->>Canvas: onImagePartialToCanvas(...)
-            Canvas->>Canvas: Remove spinner on first real partial, update image
+            Canvas->>Canvas: Update image; keep PIXI progress border active
         end
     end
 
@@ -1198,9 +1198,9 @@ Multi-turn image editing uses a **provider-agnostic approach** by leveraging can
 
 When the AI generates an image:
 
-1. An early `IMAGE_PARTIAL` with an empty `imageUrl` creates the `ImageCanvasNode` placeholder on the canvas (transparent 1×1 PNG, PIXI traveling progress border, bounce spinner). Subsequent `IMAGE_PARTIAL` events with real image data update the existing node in place.
+1. An early `IMAGE_PARTIAL` with an empty `imageUrl` creates the `ImageCanvasNode` placeholder on the canvas (transparent 1×1 PNG and PIXI traveling progress border). Subsequent `IMAGE_PARTIAL` events with real image data update the existing node in place.
 2. The `partialImageTracker` Map records the pending partial SYNCHRONOUSLY before any async work to prevent race conditions with `IMAGE_COMPLETE`
-3. Progressive partial previews update the same canvas image node in real-time; `pixiMediaLayer.ts` renders the changing image pixels and synchronizes its progress bounds into `PixiTravelingOutlineRenderer`. The first real partial removes the bounce spinner.
+3. Progressive partial previews update the same canvas image node in real-time; `pixiMediaLayer.ts` renders the changing image pixels and synchronizes its progress bounds into `PixiTravelingOutlineRenderer` until the final image arrives.
 4. `IMAGE_COMPLETE` clears the active-generation tracker so PIXI removes the animated border only after the final image is received, then finalizes the canvas node with full `generatedBy` metadata: `{ aiChatThreadId, responseId, aiModel, revisedPrompt }`
 5. A `WorkspaceEdge` connects the thread to the image with `sourceMessageId` identifying the specific `aiResponseMessage` (the response node gets a unique `id` when created by `handleStreamStart`)
 6. Multiple images from the same thread stack vertically using spacing from `settings.imageBranchLineage`

--- a/services/web-ui/src/infographics/workspace/README.md
+++ b/services/web-ui/src/infographics/workspace/README.md
@@ -207,7 +207,6 @@ Image nodes have a simpler structure:
 ┌─────────────────────────────────────────┐
 │  .image-drag-overlay                    │
 │   (covers entire image for dragging)    │
-│  .image-generating-spinner (during gen) │
 └─────────────────────────────────────────┘
   ↖ resize     resize ↗
   handle       handle
@@ -244,9 +243,8 @@ When an AI-generated image is being created, the canvas provides visual feedback
 2. **VLM branch resolution** — The API emits `IMAGE_BRANCH_RESOLVED` before image partials. `WorkspaceCanvas.ts` stores that result and uses it for generated-image placement, parent edge selection, and `generatedBy` lineage metadata. When the API identifies an existing generated candidate as the target/identity reference, placement follows that generated node and preserves its branch id even if the requested color palette or medium changes. `IMAGE_BRANCH_RESOLUTION_ERROR` clears pending placement and stops the generation path visibly.
 3. **Early placeholder** — The backend emits an `IMAGE_PARTIAL` with an empty `imageUrl` as soon as OpenAI's `response.output_item.added` event fires (before any pixel data arrives). `buildImageSrc` converts the empty URL to a transparent 1×1 PNG data URI for the generated canvas node.
 4. **Animated progress border** — `pixiMediaLayer.ts` feeds active generated-image bounds to the shared `PixiTravelingOutlineRenderer`, which draws a PIXI `Graphics` track with a colored snake segment traveling around the rounded image perimeter while the image remains in `partialImageTracker`. Motion follows the loop-safe `Easing.travelingOutlineTransition()` curve; track, snake palette, length, width, and lap duration are configured through `settings.imageNode.generationBorder`.
-5. **Bounce spinner** — A three-dot bounce animation (`.image-generating-spinner`) appears centered over the image while waiting for the first real partial. The spinner uses inline styles and an injected `@keyframes img-dot-bounce` so it works without external SCSS.
-6. **First real partial** — When `onImagePartialToCanvas` receives a non-empty `imageUrl`, it commits the updated canvas image node for PIXI to render, removes the spinner, and continues replacing that node for later partials.
-7. **Completion** — `onImageCompleteToCanvas` clears the tracker only after the final image arrives, which removes the PIXI progress outline and the DOM spinner.
+5. **First real partial** — When `onImagePartialToCanvas` receives a non-empty `imageUrl`, it commits the updated canvas image node for PIXI to render and continues replacing that node for later partials.
+6. **Completion** — `onImageCompleteToCanvas` clears the tracker only after the final image arrives, which removes the PIXI progress outline.
 
 ### Image Lifecycle
 
@@ -460,7 +458,6 @@ Menu items are defined in `canvasBubbleMenuItems.ts`. The core `BubbleMenu` clas
 | `.workspace-image-node-context-region-child` | Image node contained by a context region, with the region-only off-white frame |
 | `.workspace-thread-rail` | Vertical rail outer container spanning thread + gap + floating input (drag handle, connection proxy) |
 | `.workspace-thread-rail-line` | Inner visual line child limited to thread node height; hosts `::before` gradient line |
-| `.image-generating-spinner` | Three-dot bounce spinner shown before first partial image arrives |
 | `.workspace-generated-image-chrome` | Per-generated-image chrome container positioned below the image node at the exact image-node width |
 | `.image-model-badge` | Large circular image-provider icon badge for generated images |
 | `.image-info-button` | Large circular icon button that expands the generated-image metadata block and uses `$steelBlue` when active |

--- a/services/web-ui/src/infographics/workspace/WorkspaceCanvas.ts
+++ b/services/web-ui/src/infographics/workspace/WorkspaceCanvas.ts
@@ -2933,8 +2933,6 @@ export function createWorkspaceCanvas(options: WorkspaceCanvasOptions) {
             // Show error placeholder on the node so the user sees what failed,
             // then remove it from the canvas state (and DOM) after a short delay.
             const nodeEl = viewportEl?.querySelector(`[data-node-id="${existing.nodeId}"]`) as HTMLElement | null
-            const spinnerEl = nodeEl?.querySelector('.image-generating-spinner')
-            if (spinnerEl) spinnerEl.remove()
             if (nodeEl) showImageErrorPlaceholder(nodeEl)
 
             const errorNodeId = existing.nodeId
@@ -2972,9 +2970,6 @@ export function createWorkspaceCanvas(options: WorkspaceCanvasOptions) {
                     })
 
                     commitCanvasStatePreservingEditors({ ...currentCanvasState, nodes: updatedNodes })
-
-                    const spinnerEl = viewportEl?.querySelector(`[data-node-id="${existing.nodeId}"] .image-generating-spinner`)
-                    if (spinnerEl) spinnerEl.remove()
                 }
 
                 partialImageTracker.set(threadId, { ...existing, fileId: fileId || existing.fileId })
@@ -3075,8 +3070,6 @@ export function createWorkspaceCanvas(options: WorkspaceCanvasOptions) {
                 pendingGeneratedImagePlacements.delete(threadId)
 
                 // PIXI removes the progress border when the tracker is cleared and this state commits.
-                const spinnerEl = viewportEl?.querySelector(`[data-node-id="${partial.nodeId}"] .image-generating-spinner`)
-                if (spinnerEl) spinnerEl.remove()
                 const collisionExclusions = new Set<string>()
                 for (const child of nodes) {
                     if (child.parentId) collisionExclusions.add(`${child.parentId}-${child.nodeId}`)
@@ -4385,45 +4378,6 @@ export function createWorkspaceCanvas(options: WorkspaceCanvasOptions) {
         )
         syncContextRegionImageFrame(nodeEl, node)
         dragOverlay.className = 'image-drag-overlay nopan'
-
-        // Check if this image is currently generating
-        const isGenerating = Array.from(partialImageTracker.values()).some(p => p.nodeId === node.nodeId)
-
-        if (isGenerating) {
-            // Add loading spinner — three bouncing dots matching AI response message style
-            const spinnerContainerStyle = {
-                position: 'absolute' as const,
-                top: '0',
-                left: '0',
-                width: '100%',
-                height: '100%',
-                display: 'flex',
-                alignItems: 'center',
-                justifyContent: 'center',
-                zIndex: '5',
-                pointerEvents: 'none' as const,
-            }
-            const spinnerContainer = html`<div className="image-generating-spinner" style=${spinnerContainerStyle}></div>` as HTMLDivElement
-
-            const dotsWrapperStyle = { display: 'flex', gap: '8px', alignItems: 'center' }
-            const dotsWrapper = html`<div style=${dotsWrapperStyle}></div>` as HTMLDivElement
-
-            for (let i = 0; i < 3; i++) {
-                const dotStyle = { width: '8px', height: '8px', borderRadius: '50%', background: '#b0b0b0', animation: `img-dot-bounce 1s ${i * 0.15}s infinite ease-in-out` }
-                const dot = html`<div style=${dotStyle}></div>` as HTMLDivElement
-                dotsWrapper.appendChild(dot)
-            }
-
-            // Inject keyframes if not already present
-            if (!document.getElementById('img-dot-bounce-keyframes')) {
-                const style = html`<style id="img-dot-bounce-keyframes" innerHTML=${'@keyframes img-dot-bounce { 0%,80%,100%{transform:scale(1);opacity:.4} 40%{transform:scale(1.3);opacity:1} }'}></style>` as HTMLStyleElement
-                document.head.appendChild(style)
-            }
-
-            spinnerContainer.appendChild(dotsWrapper)
-            nodeEl.appendChild(spinnerContainer)
-
-        }
 
         return nodeEl
     }

--- a/services/web-ui/src/infographics/workspace/workspace-canvas.scss
+++ b/services/web-ui/src/infographics/workspace/workspace-canvas.scss
@@ -884,8 +884,8 @@
     }
 
     // The PIXI media layer owns all image pixels and the generating-image border.
-    // The DOM node still owns interaction chrome: drag overlay, resize handles,
-    // and spinner. The node shadow/frame may sit behind the PIXI sprite.
+    // The DOM node still owns interaction chrome: drag overlay and resize handles.
+    // The node shadow/frame may sit behind the PIXI sprite.
 
     &.is-selected,
     &.workspace-image-node-context-region-child.is-selected {

--- a/services/web-ui/src/infographics/workspace/workspace-canvas.test.ts
+++ b/services/web-ui/src/infographics/workspace/workspace-canvas.test.ts
@@ -320,6 +320,8 @@ describe('Workspace canvas — generated image preview rendering', () => {
 		expectSourceToContain(settingsTs, 'animationDurationMs: 3200')
 		expectSourceNotToContain(ts, 'SvgGradientRenderer')
 		expectSourceNotToContain(ts, 'image-generating-border')
+		expectSourceNotToContain(ts, 'image-generating-spinner')
+		expectSourceNotToContain(ts, 'img-dot-bounce')
 		expectSourceNotToContain(scss, '.workspace-image-progress-viewport')
 		expectExcerptNotToContain(partialHandler, 'partialImageTracker.delete', 'partial image handler')
 		expectExcerptToContain(completeHandler, 'partialImageTracker.delete(threadId)')
@@ -1869,6 +1871,8 @@ describe('Image loading — PIXI ownership and URL resolution strategy', () => {
 		expectExcerptNotToContain(fnBody, 'image-node-img', 'createImageNode')
 		expectExcerptNotToContain(fnBody, '<img', 'createImageNode')
 		expectExcerptNotToContain(fnBody, 'imgEl', 'createImageNode')
+		expectExcerptNotToContain(fnBody, 'image-generating-spinner', 'createImageNode')
+		expectExcerptNotToContain(fnBody, 'img-dot-bounce', 'createImageNode')
 		expectSourceNotToContain(pixiLayerTs, 'workspace-image-node-pixi-owned')
 	})
 


### PR DESCRIPTION
## Summary

- Remove the centered three-dot DOM spinner from in-progress generated-image nodes on the workspace canvas.
- Keep the PIXI traveling snake outline as the sole canvas generation indicator, with its existing lifecycle through partial previews until final completion or error cleanup.
- Remove obsolete spinner cleanup/keyframe code and update documentation and regression guards accordingly.

## Scope

This is a focused follow-up to the already merged generated-image preview work in #199 / #200. It does not change partial image delivery or PIXI image rendering: streamed partial pixels continue to update the same PIXI-backed image node.

### Changed

- `WorkspaceCanvas.ts` no longer creates `.image-generating-spinner` or injects `img-dot-bounce` keyframes for generated canvas image nodes.
- Partial, complete, and error handlers no longer carry unreachable spinner-removal branches.
- Canvas source-shape tests assert that no generated-image DOM spinner/keyframe path is reintroduced.
- Canvas/workspace documentation now describes the PIXI outline as the only canvas generation progress indicator.

### Unchanged

- PIXI partial preview rendering.
- `partialImageTracker` ownership and final/error outline removal.
- Chat-panel loading/progress indicators.

## Verification

- `docker exec lixpi-web-ui pnpm test:run` - 36 test files passed, 782 tests passed.
- `git diff --check origin/main...HEAD` - no whitespace errors.

## Base Branch Note

The repository workflow document defaults to `develop`, but GitHub currently exposes no `develop` branch for `Lixpi/lixpi`; the repository default and live integration branch is `main`. This branch was created from merged `main` at `5a0f965`, so this PR contains only the six-file follow-up delta.

Closes #201