### PR TITLE
LIX-207 # Make NATS object-store media durable (R3) and stop silent data-loss masking

### DIFF
--- a/packages/lixpi/nats-service/ts/nats-service.ts
+++ b/packages/lixpi/nats-service/ts/nats-service.ts
@@ -4,7 +4,7 @@ import c from 'chalk'
 import { wsconnect } from '@nats-io/nats-core'
 import { connect } from "@nats-io/transport-node"
 import { fromSeed } from '@nats-io/nkeys'
-import { jetstream } from '@nats-io/jetstream'
+import { jetstream, jetstreamManager } from '@nats-io/jetstream'
 import { Objm } from '@nats-io/obj'
 
 import type {
@@ -13,8 +13,15 @@ import type {
     Subscription,
     ConnectionOptions
 } from '@nats-io/nats-core'
-import type { JetStreamClient } from '@nats-io/jetstream'
+import type { JetStreamClient, JetStreamManager } from '@nats-io/jetstream'
 import type { ObjectStore, ObjectStoreOptions, ObjectInfo } from '@nats-io/obj'
+
+// Default JetStream replication factor for all stores we create. The cluster
+// runs 3 nodes, so R3 keeps a quorum copy on every node: a single node lagging
+// or being briefly deemed unhealthy can no longer lose the only copy of data.
+// Never default to 1 in a cluster — an R1 asset has no redundancy and can be
+// silently lost when the meta-layer reassigns it during a health blip.
+const DEFAULT_STREAM_REPLICAS = 3
 
 import { log, info, infoStr, warn, err } from '@lixpi/debug-tools'
 
@@ -36,6 +43,7 @@ export type NatsServiceConfig = {
     subscriptions?: NatsSubjectSubscription[]
     middleware?: NatsMiddleware[]              // Middleware for all subscriptions
     replyMiddleware?: ReplyMiddleware[]        // Middleware specifically for replies
+    streamReplicas?: number                    // Replication factor for created stores (defaults to DEFAULT_STREAM_REPLICAS)
 }
 
 export type NatsSubjectSubscription<T = any> = {
@@ -141,8 +149,10 @@ export default class NatsService {
     private static instance: NatsService
     private nc: NatsConnection | null = null
     private js: JetStreamClient | null = null
+    private jsm: JetStreamManager | null = null
     private objm: Objm | null = null
     private config: NatsServiceConfig
+    private streamReplicas: number
     private isMonitoring = false
     private isConnecting = false
     private reconnectTimer: NodeJS.Timeout | null = null
@@ -162,6 +172,7 @@ export default class NatsService {
 
     private constructor(config: NatsServiceConfig) {
         this.config = config
+        this.streamReplicas = config.streamReplicas ?? DEFAULT_STREAM_REPLICAS
     }
 
     private scheduleReconnect(delay = 500) {
@@ -517,10 +528,44 @@ export default class NatsService {
         return this.objm
     }
 
+    private async getJetStreamManager(): Promise<JetStreamManager> {
+        if (!this.nc) {
+            throw new Error('NATS client is not connected.')
+        }
+        if (!this.jsm) {
+            this.jsm = await jetstreamManager(this.nc)
+        }
+        return this.jsm
+    }
+
+    // Distinguishes "the stream genuinely does not exist" (safe to create) from
+    // transient/cluster errors like "no responders" or request timeouts (which
+    // must NOT be treated as missing — creating a fresh empty bucket on a
+    // transient error is how data loss was previously masked).
+    private isStreamNotFoundError(e: any): boolean {
+        const msg = (e?.message ?? String(e ?? '')).toLowerCase()
+        const code = e?.code ?? e?.api_error?.err_code ?? e?.jsError?.code
+        if (msg.includes('no responders') || msg.includes('timeout') || msg.includes('503')) return false
+        return code === 404 || code === 10059 || msg.includes('stream not found') || msg.includes('no stream') || msg.includes('not found')
+    }
+
+    // Open a bucket read-only. Returns null when the bucket genuinely does not
+    // exist; rethrows on transient/cluster errors so callers never mistake an
+    // unreachable store for an empty one.
+    private async openObjectStoreOrNull(bucketName: string): Promise<ObjectStore | null> {
+        try {
+            return await this.getObjectStoreManager().open(bucketName)
+        } catch (e: any) {
+            if (this.isStreamNotFoundError(e)) return null
+            throw e
+        }
+    }
+
     async createObjectStore(bucketName: string, options?: Partial<ObjectStoreOptions>): Promise<ObjectStore> {
         const objm = this.getObjectStoreManager()
-        const os = await objm.create(bucketName, options)
-        info(`Object Store bucket created: ${bucketName}`)
+        // Default to the configured replication factor; callers may override.
+        const os = await objm.create(bucketName, { replicas: this.streamReplicas, ...options })
+        info(`Object Store bucket created: ${bucketName} (replicas=${(options?.replicas ?? this.streamReplicas)})`)
         return os
     }
 
@@ -529,15 +574,20 @@ export default class NatsService {
         return objm.open(bucketName)
     }
 
-    // Open a bucket, auto-creating it if it was wiped or never existed.
-    // All internal methods use this so operations survive a NATS storage reset.
+    // Open a bucket for WRITES, creating it only if it genuinely does not exist.
+    // A transient open failure is rethrown rather than masked by creating an
+    // empty replacement bucket. New buckets are created replicated (R3).
     async ensureObjectStore(bucketName: string): Promise<ObjectStore> {
         const objm = this.getObjectStoreManager()
         try {
             return await objm.open(bucketName)
-        } catch {
-            warn(`Object Store bucket missing, recreating: ${bucketName}`)
-            return await objm.create(bucketName, { replicas: 1 })
+        } catch (e: any) {
+            if (!this.isStreamNotFoundError(e)) {
+                err(`Object Store open failed for ${bucketName} (NOT auto-creating — transient/cluster error):`, e)
+                throw e
+            }
+            warn(`Object Store bucket does not exist, creating (replicas=${this.streamReplicas}): ${bucketName}`)
+            return await objm.create(bucketName, { replicas: this.streamReplicas })
         }
     }
 
@@ -546,6 +596,30 @@ export default class NatsService {
         const result = await objm.destroy(bucketName)
         info(`Object Store bucket deleted: ${bucketName}`)
         return result
+    }
+
+    // List all stream names visible to this connection's account.
+    async listStreamNames(): Promise<string[]> {
+        const jsm = await this.getJetStreamManager()
+        const names: string[] = []
+        for await (const si of jsm.streams.list()) {
+            names.push(si.config.name)
+        }
+        return names
+    }
+
+    // Scale a stream up to at least `replicas`. No-op when already at/above it.
+    // Used to migrate legacy R1 stores to replicated storage. NATS adds the new
+    // replicas and syncs them from the current leader (additive, non-destructive).
+    async ensureStreamReplicas(streamName: string, replicas: number = this.streamReplicas): Promise<{ name: string; from: number; to: number; changed: boolean }> {
+        const jsm = await this.getJetStreamManager()
+        const si = await jsm.streams.info(streamName)
+        const from = si.config.num_replicas ?? 1
+        if (from >= replicas) {
+            return { name: streamName, from, to: from, changed: false }
+        }
+        await jsm.streams.update(streamName, { num_replicas: replicas })
+        return { name: streamName, from, to: replicas, changed: true }
     }
 
     // Helper to convert Uint8Array to ReadableStream (required by @nats-io/obj)
@@ -574,7 +648,10 @@ export default class NatsService {
     }
 
     async getObject(bucketName: string, name: string): Promise<Uint8Array | null> {
-        const os = await this.ensureObjectStore(bucketName)
+        const os = await this.openObjectStoreOrNull(bucketName)
+        if (!os) {
+            return null
+        }
         const result = await os.get(name)
         if (!result) {
             return null
@@ -599,7 +676,10 @@ export default class NatsService {
     }
 
     async getObjectStream(bucketName: string, name: string): Promise<ReadableStream<Uint8Array> | null> {
-        const os = await this.ensureObjectStore(bucketName)
+        const os = await this.openObjectStoreOrNull(bucketName)
+        if (!os) {
+            return null
+        }
         const result = await os.get(name)
         if (!result) {
             return null
@@ -608,18 +688,28 @@ export default class NatsService {
     }
 
     async getObjectInfo(bucketName: string, name: string): Promise<ObjectInfo | null> {
-        const os = await this.ensureObjectStore(bucketName)
+        const os = await this.openObjectStoreOrNull(bucketName)
+        if (!os) {
+            return null
+        }
         return os.info(name)
     }
 
     async deleteObject(bucketName: string, name: string): Promise<void> {
-        const os = await this.ensureObjectStore(bucketName)
+        const os = await this.openObjectStoreOrNull(bucketName)
+        if (!os) {
+            warn(`Object Store bucket missing on delete, nothing to do: ${bucketName}/${name}`)
+            return
+        }
         await os.delete(name)
         info(`Object deleted: ${bucketName}/${name}`)
     }
 
     async listObjects(bucketName: string): Promise<ObjectInfo[]> {
-        const os = await this.ensureObjectStore(bucketName)
+        const os = await this.openObjectStoreOrNull(bucketName)
+        if (!os) {
+            return []
+        }
         const objects: ObjectInfo[] = []
         const list = await os.list()
         for await (const obj of list) {

--- a/services/api/src/NATS/subscriptions/workspace-subjects.ts
+++ b/services/api/src/NATS/subscriptions/workspace-subjects.ts
@@ -69,9 +69,9 @@ export const workspaceSubjects = [
                 }
 
                 try {
+                    // Replication factor is owned by NATS_Service (R3 by default).
                     await natsService.createObjectStore(bucketName, {
-                        description: `Files for workspace ${workspace.workspaceId}`,
-                        replicas: 1
+                        description: `Files for workspace ${workspace.workspaceId}`
                     })
                     info(`Created Object Store bucket: ${bucketName}`)
                 } catch (bucketError: any) {

--- a/services/api/src/models/workspace.ts
+++ b/services/api/src/models/workspace.ts
@@ -339,21 +339,22 @@ export default {
         const currentDate = new Date().getTime()
 
         try {
-            const workspace = await dynamoDBService.getItem({
-                tableName: getDynamoDbTableStageName('WORKSPACES', ORG_NAME, STAGE),
-                key: { workspaceId },
-                origin: 'model::Workspace->addFile()'
-            })
-
-            const currentFiles = workspace?.files || []
-            currentFiles.push(file)
-
+            // Atomic append. A read-modify-write here races when several images
+            // are stored concurrently (AI generation, extraction samples) and
+            // silently drops file registrations; list_append serializes per-item
+            // in DynamoDB so concurrent appends never clobber each other.
             await dynamoDBService.updateItem({
                 tableName: getDynamoDbTableStageName('WORKSPACES', ORG_NAME, STAGE),
                 key: { workspaceId },
-                updates: {
-                    files: currentFiles,
-                    updatedAt: currentDate
+                updateExpression: 'SET #files = list_append(if_not_exists(#files, :empty), :newFiles), #updatedAt = :now',
+                expressionAttributeNames: {
+                    '#files': 'files',
+                    '#updatedAt': 'updatedAt'
+                },
+                expressionAttributeValues: {
+                    ':empty': [],
+                    ':newFiles': [file],
+                    ':now': currentDate
                 },
                 origin: 'model::Workspace->addFile()'
             })

--- a/services/api/src/routes/workspace-export-routes.ts
+++ b/services/api/src/routes/workspace-export-routes.ts
@@ -168,6 +168,7 @@ router.get(
             // Export both to ensure imported workspaces have all referenced images.
             const files: DocumentFile[] = workspace.files || []
             const exportedFileIds = new Set<string>()
+            const missingFileIds = new Set<string>()
             const natsService = NATS_Service.getInstance()
             const bucketName = getWorkspaceBucketName(workspaceId)
 
@@ -180,9 +181,12 @@ router.get(
                             const ext = getFileExtension(file.mimeType, file.name)
                             archive.append(Buffer.from(data), { name: `images/${file.id}${ext}` })
                             exportedFileIds.add(file.id)
+                        } else {
+                            missingFileIds.add(file.id)
                         }
                     } catch (e: any) {
                         err(`Export: failed to retrieve file ${file.id}:`, e)
+                        missingFileIds.add(file.id)
                     }
                 }
 
@@ -197,15 +201,34 @@ router.get(
                         if (data) {
                             archive.append(Buffer.from(data), { name: `images/${fileId}.png` })
                             exportedFileIds.add(fileId)
+                        } else {
+                            missingFileIds.add(fileId)
                         }
                     } catch (e: any) {
                         err(`Export: failed to retrieve canvas-referenced file ${fileId}:`, e)
+                        missingFileIds.add(fileId)
                     }
                 }
             }
 
+            // Be loud about referenced images whose bytes are gone, and record them
+            // in the archive so a later import does not silently reproduce dangling
+            // nodes without any trace of what was lost.
+            if (missingFileIds.size > 0) {
+                const missing = [...missingFileIds]
+                err(`Workspace ${workspaceId} export: ${missing.length} referenced image(s) have NO bytes in storage and were omitted: ${missing.join(', ')}`)
+                archive.append(
+                    JSON.stringify({
+                        workspaceId,
+                        missingFileIds: missing,
+                        note: 'These fileIds are referenced by the workspace but their bytes were not found in storage at export time. The corresponding canvas image nodes will render broken until re-generated/re-uploaded.'
+                    }, null, 2),
+                    { name: 'missing-images.json' }
+                )
+            }
+
             await archive.finalize()
-            info(`Workspace ${workspaceId} exported successfully`)
+            info(`Workspace ${workspaceId} exported successfully (${exportedFileIds.size} images, ${missingFileIds.size} missing)`)
         } catch (e: any) {
             err('Workspace export failed:', e)
             if (!res.headersSent) {
@@ -352,7 +375,16 @@ router.post(
                 files
             })
 
-            info(`Workspace ${workspaceId} imported successfully (${manifest.documents.length} documents, ${manifest.aiChatThreads.length} threads, ${imageEntries.length} images)`)
+            // Be loud about canvas image nodes whose bytes were not present in the
+            // archive — these will render broken. Surface them instead of silently
+            // importing dangling references.
+            const importedImageIds = new Set(imageEntries.map((img) => img.fileId))
+            const danglingFileIds = collectCanvasImageFileIds(canvasState?.nodes || [], importedImageIds)
+            if (danglingFileIds.length > 0) {
+                err(`Workspace ${workspaceId} import: ${danglingFileIds.length} canvas image node(s) reference images not present in the archive and will render broken: ${danglingFileIds.join(', ')}`)
+            }
+
+            info(`Workspace ${workspaceId} imported successfully (${manifest.documents.length} documents, ${manifest.aiChatThreads.length} threads, ${imageEntries.length} images, ${danglingFileIds.length} dangling image refs)`)
 
             res.json({
                 success: true,
@@ -361,7 +393,8 @@ router.post(
                     documents: manifest.documents.length,
                     aiChatThreads: manifest.aiChatThreads.length,
                     images: imageEntries.length
-                }
+                },
+                ...(danglingFileIds.length > 0 ? { warnings: [{ type: 'missing_images', message: 'Some canvas image nodes reference images that were not in the archive and will render broken.', fileIds: danglingFileIds }] } : {})
             })
         } catch (e: any) {
             err('Workspace import failed:', e)

--- a/services/api/src/server.ts
+++ b/services/api/src/server.ts
@@ -124,6 +124,9 @@ await NATS_Service.init({
     name: 'api-server',
     user: 'regular_user',
     pass: env.NATS_REGULAR_USER_PASSWORD,
+    // Replication factor for JetStream stores/object-stores. Defaults to 3 (one
+    // copy per cluster node) so a single node hiccup can't lose the only copy.
+    ...(env.NATS_STREAM_REPLICAS ? { streamReplicas: Number(env.NATS_STREAM_REPLICAS) } : {}),
     middleware: [
         jwtAuthMiddleware, // global middleware, applies to all subscriptions
     ],

--- a/services/api/src/services/image-storage.ts
+++ b/services/api/src/services/image-storage.ts
@@ -5,7 +5,7 @@ import { createHash } from 'node:crypto'
 
 import NATS_Service from '@lixpi/nats-service'
 import { type DocumentFile } from '@lixpi/constants'
-import { info, err } from '@lixpi/debug-tools'
+import { info, warn, err } from '@lixpi/debug-tools'
 
 import Workspace from '../models/workspace.ts'
 
@@ -47,6 +47,13 @@ export const storeWorkspaceImage = async (input: StoreImageInput): Promise<Store
         throw new Error(`Workspace not found: ${workspaceId}`)
     }
 
+    const natsService = NATS_Service.getInstance()
+    if (!natsService) {
+        throw new Error('NATS service unavailable')
+    }
+
+    const bucketName = getWorkspaceBucketName(workspaceId)
+
     let fileId: string
     if (useContentHash) {
         const hash = createHash('sha256').update(buffer).digest('hex')
@@ -54,25 +61,26 @@ export const storeWorkspaceImage = async (input: StoreImageInput): Promise<Store
 
         const existing = workspace.files?.find((f: DocumentFile) => f.id === fileId)
         if (existing) {
-            info(`Duplicate image detected: ${fileId} (skipping upload)`)
-            return {
-                fileId,
-                url: `/api/images/${workspaceId}/${fileId}`,
-                isDuplicate: true,
-                size: existing.size,
-                mimeType: existing.mimeType,
+            // Only short-circuit as a duplicate if the bytes are ACTUALLY still
+            // in storage. If the object is gone (e.g. lost earlier), fall through
+            // and re-store it so the dangling reference self-heals instead of
+            // staying permanently broken.
+            const storedInfo = await natsService.getObjectInfo(bucketName, fileId).catch(() => null)
+            if (storedInfo && !storedInfo.deleted) {
+                info(`Duplicate image detected: ${fileId} (skipping upload)`)
+                return {
+                    fileId,
+                    url: `/api/images/${workspaceId}/${fileId}`,
+                    isDuplicate: true,
+                    size: existing.size,
+                    mimeType: existing.mimeType,
+                }
             }
+            warn(`Hash ${fileId} is registered in workspace ${workspaceId} but its bytes are missing from storage — re-storing`)
         }
     } else {
         fileId = uuid()
     }
-
-    const natsService = NATS_Service.getInstance()
-    if (!natsService) {
-        throw new Error('NATS service unavailable')
-    }
-
-    const bucketName = getWorkspaceBucketName(workspaceId)
 
     try {
         await natsService.putObject(bucketName, fileId, buffer, {


### PR DESCRIPTION
## Summary
Workspace media stored in NATS JetStream Object Store could vanish during normal operation (no restart required). Object stores were created **R1 (single, non-replicated copy)** on a 3-node cluster, so a single node lagging/being reassigned lost the only copy — and `ensureObjectStore` then silently recreated an **empty** bucket, hiding the loss behind gray-box image nodes.

## Changes
- **`@lixpi/nats-service`**
  - All object stores now created **R3** (one copy per node); replica count configurable via `NATS_STREAM_REPLICAS` (default 3).
  - `ensureObjectStore` (writes) auto-creates **only** on a genuine "stream not found"; transient/cluster errors are rethrown instead of masked with an empty bucket.
  - Reads/deletes are open-only and **never** auto-create a bucket.
  - Added JSM helpers (`listStreamNames`, `ensureStreamReplicas`) used to migrate existing R1 stores.
- **`workspace-subjects` / `server`** — dropped hardcoded `replicas: 1`; wired the configurable factor.
- **`image-storage`** — content-hash dedup re-stores when the bytes are actually missing (self-heals dangling refs).
- **`workspace.addFile`** — atomic `list_append` fixes a concurrent race that silently dropped `files[]` registrations.
- **`workspace-export-routes`** — export logs + records missing bytes (`missing-images.json`); import returns warnings for dangling refs.

## Operational
- Existing local buckets were migrated R1 → R3 (verified in-sync). **Production object stores need the same one-time migration after deploy** via `ensureStreamReplicas`.
- Already-lost bytes are unrecoverable from NATS.
- Not changed here: `nats-server.conf` `sync_interval` (120s) — R3 quorum is the primary protection; tightening it is a separate durability/throughput tradeoff.

Closes #207