### PR TITLE
LIX-211 # Add shared video player controls

### DIFF
--- a/documentation/coding-style-guides/TYPESCRIPT.md
+++ b/documentation/coding-style-guides/TYPESCRIPT.md
@@ -30,6 +30,13 @@ interface UserProfile {
 }
 ```
 
+## Classes And State Ownership
+
+- Prefer classes when a module owns cohesive state, behavior, lifecycle cleanup, or a public imperative API.
+- Use plain functions for pure utilities, small adapters, simple callbacks, and glue code where a class would add ceremony without making ownership clearer.
+- Prefer composition over inheritance. Do not build inheritance chains deeper than 3 levels; inheritance deeper than 3 levels is a deal breaker and must be redesigned.
+- Keep config, event payloads, and other object shapes as `type` definitions, not `interface`.
+
 ## Comments
 
 - Always use `//` single-line comments. For multi-line explanations, use multiple `//` lines.

--- a/documentation/coding-style-guides/UI-COMPONENTS.md
+++ b/documentation/coding-style-guides/UI-COMPONENTS.md
@@ -1,0 +1,391 @@
+# UI Components Coding Style Guide
+
+## Scope
+
+Use this guide when building UI components in `services/web-ui` that are not pure PIXI renderers. This includes Svelte UI, ProseMirror node views, canvas chrome, SVG controls, menus, switches, sliders, toolbars, overlays, and small reusable primitives.
+
+This guide does not replace the PIXI rendering rules for canvas scene content. If the element is part of the canvas world and can be rendered naturally in PIXI, PIXI is the first choice. Use this guide for UI that sits outside PIXI or for canvas-adjacent controls that need DOM/SVG semantics.
+
+## Rendering Decision
+
+Choose the rendering approach by where the UI lives and what it does.
+
+| Situation | First choice | Use when |
+|-----------|--------------|----------|
+| Canvas scene content | PIXI | Nodes, images, videos, sprites, shapes, hit-tested scene objects, high-frequency transforms, zoomed world content |
+| Canvas-adjacent controls | D3 SVG | Menus, switches, sliders, playback controls, control bars, badges, handles, and similar UI that must track canvas geometry but needs precise interactive controls |
+| Normal app UI | Svelte | Panels, dialogs, forms, settings, inspectors, app navigation, persistent screens |
+| Non-Svelte TypeScript DOM UI | `html` tagged template | ProseMirror node views, plugins, and small DOM surfaces covered by [`TYPESCRIPT.md`](./TYPESCRIPT.md) |
+| Static icon or decorative SVG in DOM | Existing icon system | Import from [`svgIcons/index.ts`](../../services/web-ui/src/svgIcons/index.ts), then inject or parse according to the host renderer |
+
+Do not use D3 as a general replacement for Svelte. Do not use HTML templates for canvas chrome when the control is expected to live in an SVG overlay. Do not use PIXI for form-like UI, menus, segmented switches, media controls, or text-heavy widgets unless there is a concrete rendering reason.
+
+## Canvas Rule
+
+When UI is located on or around the canvas:
+
+1. Use PIXI first for actual canvas content.
+2. Use D3 SVG for specialized UI controls that PIXI is bad at: menus, switches, sliders, playback controls, popups, focusable hit targets, and controls that need accessible DOM/SVG semantics.
+3. Keep the D3/SVG layer thin. It should drive or annotate canvas state, not replace PIXI rendering for the scene.
+4. Keep ownership clear. PIXI owns pixels and scene objects. D3 owns the SVG control elements. The feature or host owns application state.
+
+The video player controls follow this split: PIXI renders video pixels, while D3 SVG renders the control bar and drives the `HTMLVideoElement`.
+
+## D3 Policy
+
+Use the latest stable D3 documentation and D3 packages. Do not pin coding guidance to a specific D3 minor version in docs because it becomes stale quickly.
+
+Relevant official docs:
+
+- [`d3-selection`](https://d3js.org/d3-selection)
+- [`Selecting elements`](https://d3js.org/d3-selection/selecting)
+- [`Modifying elements`](https://d3js.org/d3-selection/modifying)
+- [`Handling events`](https://d3js.org/d3-selection/events)
+- [`d3-transition`](https://d3js.org/d3-transition)
+- [`d3-transition timing`](https://d3js.org/d3-transition/timing)
+- [`d3-ease`](https://d3js.org/d3-ease)
+
+Use modular imports from the D3 packages the component actually needs:
+
+```typescript
+import { select } from 'd3-selection'
+import 'd3-transition'
+import { easeCubicOut } from 'd3-ease'
+```
+
+Import `d3-transition` for side effects before calling `.transition()` on selections.
+
+## D3 SVG Component Shape
+
+D3 SVG UI components should render into a caller-provided SVG selection and expose a small imperative API.
+
+```typescript
+export type ExampleControlConfig = {
+    id: string
+    x: number
+    y: number
+    width: number
+    height?: number
+    className?: string
+    onChange?: (value: string, id: string) => void
+}
+
+export type ExampleControlInstance = {
+    render: () => void
+    resize?: (x: number, y: number, width: number) => void
+    destroy: () => void
+}
+
+export function createExampleControl(parent: any, config: ExampleControlConfig): ExampleControlInstance {
+    const group = parent.append('g')
+        .attr('class', `example-control-group ${config.className ?? ''}`)
+        .attr('transform', `translate(${config.x}, ${config.y})`)
+        .attr('data-example-control-id', config.id)
+
+    const background = group.append('rect')
+        .attr('class', 'example-control-background')
+        .attr('x', 0)
+        .attr('y', 0)
+        .attr('width', config.width)
+        .attr('height', config.height ?? 24)
+
+    function render(): void {
+        background.attr('width', config.width)
+    }
+
+    return {
+        render,
+        destroy: () => group.remove(),
+    }
+}
+```
+
+The public API should usually be `createX(parent, config)`. It appends one top-level SVG `<g>`, returns an instance object, and does not leak internal selections.
+
+## Factory Or Class
+
+Follow [`TYPESCRIPT.md`](./TYPESCRIPT.md) for class usage.
+
+Use a class when the component owns cohesive state, many selections, layout, lifecycle cleanup, global listeners, or a public imperative API. Keep the factory as the public entry point:
+
+```typescript
+class ExampleControl implements ExampleControlInstance {
+    render = (): void => {}
+    destroy = (): void => {}
+}
+
+export function createExampleControl(parent: any, config: ExampleControlConfig): ExampleControlInstance {
+    return new ExampleControl(parent, config)
+}
+```
+
+A closure-backed factory is fine for small controls with limited state and simple cleanup.
+
+Do not build deep inheritance hierarchies. Prefer composition and helper functions. Inheritance deeper than 3 levels is not allowed.
+
+## SVG Rendering Rules
+
+For D3 SVG UI:
+
+- Render visuals with SVG elements: `g`, `rect`, `circle`, `text`, `path`, `line`, `polyline`, and similar.
+- Position with SVG attributes: `x`, `y`, `cx`, `cy`, `r`, `width`, `height`, `rx`, `ry`, `transform`.
+- Style with SVG attributes first: `fill`, `stroke`, `stroke-width`, `opacity`, `display`, `text-anchor`, `dominant-baseline`.
+- Use `.style(...)` only when there is no clean SVG attribute equivalent, such as `cursor`.
+- Use transparent SVG hit areas for pointer targets.
+- Do not use `foreignObject` unless the requirement truly needs HTML inside SVG and the tradeoff is documented.
+- Do not create ordinary HTML with D3.
+- Do not move basic SVG geometry, color, hover, or animation into a stylesheet. Keep reusable constants in TypeScript and write attributes through D3.
+
+Bad:
+
+```typescript
+const button = document.createElement('button')
+button.className = 'canvas-control'
+```
+
+Good:
+
+```typescript
+const button = group.append('g')
+    .attr('class', 'canvas-control-button')
+    .attr('role', 'button')
+    .attr('tabindex', 0)
+
+button.append('rect')
+    .attr('class', 'canvas-control-button-hit')
+    .attr('width', BUTTON_SIZE)
+    .attr('height', BUTTON_SIZE)
+    .attr('fill', 'transparent')
+```
+
+## Svelte And HTML Rules
+
+Use Svelte for ordinary application UI. Keep Svelte components declarative and let Svelte own DOM updates.
+
+Use the `html` tagged template from [`TYPESCRIPT.md`](./TYPESCRIPT.md) for non-Svelte `.ts` files that create normal DOM elements. This is mandatory for ProseMirror plugins, NodeViews, shared DOM utilities, and other TypeScript-built HTML.
+
+Do not mix approaches inside one component without a clear boundary:
+
+- A Svelte panel can host an `<svg>` and call a D3 SVG primitive.
+- A ProseMirror NodeView can create a DOM shell with `html` and mount an SVG control inside it.
+- A canvas chrome layer can position an SVG host and let D3 render inside it.
+- A D3 SVG primitive should not create random HTML siblings.
+
+## State Ownership
+
+Every UI component must have one clear source of truth.
+
+Patterns:
+
+- Internal state: the component owns the value and exposes setters/getters.
+- External state: the host owns the value and calls `render()` or setters when it changes.
+- DOM/media state: a DOM object is the source of truth, and the component listens to its events.
+- Store state: a Svelte store or app state object is the source of truth, and the component is a view/controller for it.
+
+Do not maintain parallel state copies without a sync plan. If the component writes to external state, callbacks should report the change. If a setter is programmatic, document whether it fires callbacks.
+
+## Config And Instance API
+
+Config types should use `type`, not `interface`.
+
+Common config fields:
+
+- `id`: stable identity for `data-*` attributes and callbacks.
+- Geometry: `x`, `y`, `width`, `height`, or `size`.
+- `className`: optional caller-specific class.
+- `disabled`, `selectedValue`, `checked`, or equivalent initial state.
+- `onChange`: callback for user-driven changes.
+- External source references only when intentional, such as `videoEl`.
+
+Instance APIs should be small:
+
+- `render()` to resync the UI.
+- `resize(...)` when geometry changes after mount.
+- `setValue(...)`, `setChecked(...)`, or similar setters.
+- `getValue()` or `getChecked()` only when callers need internal state.
+- `destroy()` for cleanup.
+
+Do not expose internal D3 selections, DOM nodes, or Svelte internals unless the host genuinely needs them.
+
+## Layout
+
+For D3 SVG components:
+
+- Compute geometry numerically, then write attributes.
+- Define constants for padding, gaps, fixed widths, radii, timings, and colors.
+- Use helper functions for repeated geometry.
+- Use `transform="translate(x, y)"` for top-level positioning.
+- Update numeric attributes directly instead of parsing strings.
+- Clamp pointer-derived values.
+- Hide unsupported controls with `display="none"` and remove or disable their hit areas.
+
+For Svelte/HTML components:
+
+- Use existing layout primitives and CSS rules from nearby code.
+- Keep app UI responsive through CSS, not D3 calculations.
+- Avoid canvas-specific coordinate math unless the UI is explicitly mounted over the canvas.
+
+## Events
+
+Rules for all UI components:
+
+- Stop propagation when the control sits on top of canvas, ProseMirror, or drag surfaces.
+- Use `preventDefault()` for keyboard, pointer drag, and button-like interactions where browser behavior can interfere.
+- Keep user-driven callbacks separate from programmatic setters.
+- Cleanly detach global listeners.
+
+D3 SVG controls should use `selection.on(...)` for SVG-owned elements:
+
+```typescript
+hitArea.on('click', (event: MouseEvent) => {
+    event.preventDefault()
+    event.stopPropagation()
+    applyValue(option.value, true)
+})
+```
+
+D3 event listeners receive the event argument directly. Do not use old `d3.event` patterns.
+
+Use arrow functions when handlers need lexical class `this`. Use `function () { select(this) ... }` only when the current DOM element is required.
+
+## Pointer Coordinates
+
+For SVG-local pointer coordinates, prefer `d3.pointer(event, target)` when the target's SVG coordinate system matters.
+
+For simple one-dimensional sliders in screen pixels, `getBoundingClientRect()` is acceptable. Clamp ratios:
+
+```typescript
+function ratioFromEvent(event: PointerEvent | MouseEvent, hit: SVGRectElement): number {
+    const rect = hit.getBoundingClientRect()
+    if (rect.width <= 0) return 0
+    return clamp((event.clientX - rect.left) / rect.width, 0, 1)
+}
+```
+
+## Transitions
+
+Use motion only when it clarifies state:
+
+- Switch toggles.
+- Slider handles.
+- Segmented indicators.
+- Menu open/close states.
+- Brief opacity or color transitions.
+
+Do not animate every render. Initial render and external sync renders should usually be immediate. User-driven state changes can animate.
+
+For D3 transitions:
+
+```typescript
+indicator
+    .transition()
+    .duration(200)
+    .ease(easeCubicOut)
+    .attr('x', targetX)
+```
+
+Keep durations short. Use easing intentionally. Avoid playful easing unless the product surface is intentionally playful.
+
+## Icons
+
+Use existing icons from [`svgIcons/index.ts`](../../services/web-ui/src/svgIcons/index.ts).
+
+For HTML/Svelte, inject icon markup through the existing DOM/template patterns.
+
+For D3 SVG controls, parse imported SVG markup and append paths into an SVG group:
+
+```typescript
+function setIconPaths(iconGroup: any, svgMarkup: string, fill: string): void {
+    iconGroup.selectAll('*').remove()
+    for (const pathData of extractPathData(svgMarkup)) {
+        iconGroup.append('path')
+            .attr('d', pathData)
+            .attr('fill', fill)
+    }
+}
+```
+
+Cache parsed path data if an icon is large or updated frequently.
+
+## Accessibility
+
+UI components must expose accessible behavior appropriate to their renderer.
+
+For D3 SVG controls:
+
+- Add `role="button"` to clickable groups.
+- Add `tabindex="0"` when keyboard focus is required.
+- Add `aria-label` and update it when state changes.
+- Add `aria-pressed` for toggle-like controls.
+- For keyboard-interactive sliders, add `role="slider"`, `aria-valuemin`, `aria-valuemax`, and `aria-valuenow`.
+- Support `Enter` and `Space` for buttons.
+- Support arrow keys for sliders, segmented controls, and menu movement when needed.
+
+For Svelte/HTML controls, use native controls when possible before recreating semantics manually.
+
+Do not rely on color alone. Text, icon state, geometry, and ARIA should reflect the current value.
+
+## Cleanup
+
+Every imperative UI instance must expose `destroy()`.
+
+`destroy()` must:
+
+- Remove the top-level mounted element or SVG group.
+- Remove external listeners added to `window`, `document`, media elements, stores, or other objects.
+- Cancel active pointer-drag cleanup.
+- Leave caller-owned containers and external data untouched.
+
+If a D3 component uses only `.on(...)` listeners on SVG elements that are removed with the group, `group.remove()` is enough for those internal listeners. Anything outside the group must be removed explicitly.
+
+## Tests
+
+Follow [`documentation/testing/TypeScript/web-ui/TESTING-GUIDE.md`](../testing/TypeScript/web-ui/TESTING-GUIDE.md).
+
+For D3 SVG UI:
+
+- Mount into a real SVG element created with `document.createElementNS`.
+- Use `select(svg)` to pass the host selection.
+- Assert expected SVG classes and attributes.
+- Dispatch `MouseEvent`, `KeyboardEvent`, or pointer-like events to hit areas.
+- Stub external state sources such as `HTMLVideoElement`.
+- Assert callbacks fire only when they should.
+- Assert public setters update rendered state.
+- Assert `destroy()` removes the group and external listeners.
+
+For Svelte/HTML UI, use the existing test approach near the component. Do not use browser screenshots or manual browser inspection for agent verification.
+
+## Documentation
+
+Component docs should describe:
+
+- Which renderer owns the UI: PIXI, D3 SVG, Svelte, or TypeScript `html`.
+- Where the component mounts.
+- Public config and instance API.
+- State ownership and callback behavior.
+- Geometry and resize behavior.
+- Animation behavior.
+- Cleanup expectations.
+- Known limitations.
+
+If adding Mermaid diagrams, follow [`MERMAID-DIAGRAMS-STYLE-GUIDE.md`](../documentation-style-guides/MERMAID-DIAGRAMS-STYLE-GUIDE.md). Keep Mermaid syntax GitHub-safe: single-line theme config, ASCII labels when in doubt, full-width `Note over First, Last` for sequence phase titles, and paired activations in sequence diagrams.
+
+## Review Checklist
+
+Before merging a UI component, check:
+
+- The renderer choice follows the decision table.
+- Canvas scene content uses PIXI unless there is a documented reason not to.
+- Canvas-adjacent controls use D3 SVG when they need menus, switches, sliders, control bars, or similar UI.
+- Normal app UI uses Svelte.
+- Non-Svelte TypeScript HTML uses the `html` tagged template.
+- State has one source of truth.
+- Public API is small and explicit.
+- Geometry and colors are centralized.
+- User interactions stop propagation where needed.
+- Keyboard and ARIA behavior are covered.
+- Pointer hit areas are large enough.
+- Transitions are short and meaningful.
+- `destroy()` removes mounted UI and external listeners.
+- Tests cover render, interaction, programmatic updates, and cleanup.
+- Component docs are updated when behavior or API changes.

--- a/services/web-ui/src/components/proseMirror/plugins/aiChatThreadPlugin/README.md
+++ b/services/web-ui/src/components/proseMirror/plugins/aiChatThreadPlugin/README.md
@@ -213,6 +213,12 @@ sequenceDiagram
 
 **`aiGeneratedImage`** - AI-generated images (from DALL-E, etc.)
 
+**`aiGeneratedVideo`** - AI-generated videos (from VEO, etc.)
+- Renders pending and error states inline in the AI response body
+- On completion, displays a controls-less `<video>` element with the shared SVG `components/videoControls` bar overlaid at the bottom
+- Uses the same authenticated URL resolution path as generated images for `/api/videos/...` and poster `/api/images/...` URLs
+- Emits canvas lifecycle callbacks for pending, generating, complete, error, branch-resolution, and trace events
+
 **`aiCollapsibleBlock`** - Collapsible disclosure block for image generation prompts
 - Content: `(paragraph | block)*`
 - Attributes: `title, isOpen, isStreaming, imageGenerationTrace, imageGenerationTraceId`

--- a/services/web-ui/src/components/proseMirror/plugins/aiChatThreadPlugin/aiGeneratedVideoNode.ts
+++ b/services/web-ui/src/components/proseMirror/plugins/aiChatThreadPlugin/aiGeneratedVideoNode.ts
@@ -3,13 +3,15 @@ import { html, applyStyle } from '$src/utils/domTemplates.ts'
 import AuthService from '$src/services/auth-service.ts'
 import { NodeSelection } from 'prosemirror-state'
 import type { ImageBranchVlmResolution, VideoGenerationTrace } from '@lixpi/constants'
+// @ts-ignore - runtime import
+import { select } from 'd3-selection'
+import { createVideoControls, type VideoControlsInstance } from '$src/components/videoControls/index.ts'
 
 // Sibling of aiGeneratedImageNode.ts. The in-chat representation of a generated
 // video. While VIDEO_PENDING is the active state, the node renders a placeholder
 // (matching the canvas placeholder style — no DOM spinner per PR #202). On
-// VIDEO_COMPLETE the node swaps to a poster + <video> element with controls;
-// because the workspace canvas owns inline playback, this in-chat player is
-// intentionally controls-based and small.
+// VIDEO_COMPLETE the node swaps to a poster + controls-less <video> element plus
+// the shared SVG videoControls bar used by the workspace canvas.
 
 export const aiGeneratedVideoNodeType = 'aiGeneratedVideo'
 
@@ -172,13 +174,28 @@ const buildAuthenticatedUrl = async (url: string): Promise<string> => {
 }
 
 export const aiGeneratedVideoNodeView = (node: any, view: any, getPos: () => number | undefined) => {
+    const containerStyle = {
+        position: 'relative' as const,
+        overflow: 'hidden' as const,
+    }
+    const controlsHostStyle = {
+        position: 'absolute' as const,
+        left: '10px',
+        right: '10px',
+        bottom: '10px',
+        height: '44px',
+        pointerEvents: 'auto' as const,
+        filter: 'drop-shadow(0 4px 14px rgba(0, 0, 0, 0.34))',
+        display: 'none',
+    }
     const wrapper = html`
         <div className="ai-generated-video-wrapper">
-            <div className="ai-generated-video-container">
+            <div className="ai-generated-video-container" style=${containerStyle}>
                 <div className="ai-generated-video-placeholder">
                     <span className="placeholder-text">Generating video…</span>
                 </div>
-                <video className="ai-generated-video-content" controls preload="metadata" playsinline crossorigin="anonymous"></video>
+                <video className="ai-generated-video-content" preload="metadata" playsinline crossorigin="anonymous"></video>
+                <div className="ai-generated-video-controls-host nopan" style=${controlsHostStyle}></div>
             </div>
         </div>
     `
@@ -187,12 +204,16 @@ export const aiGeneratedVideoNodeView = (node: any, view: any, getPos: () => num
     const placeholderElement = wrapper.querySelector('.ai-generated-video-placeholder') as HTMLElement
     const placeholderText = wrapper.querySelector('.ai-generated-video-placeholder .placeholder-text') as HTMLElement
     const videoElement = wrapper.querySelector('.ai-generated-video-content') as HTMLVideoElement
+    const controlsHost = wrapper.querySelector('.ai-generated-video-controls-host') as HTMLDivElement
+    let videoControls: VideoControlsInstance | null = null
+    let controlsSvg: any = null
+    let resizeObserver: ResizeObserver | null = null
 
     applyStyle(videoElement, { display: 'none' })
 
     const handleClick = (event: MouseEvent) => {
-        // Don't intercept clicks on the video controls themselves
-        if ((event.target as HTMLElement).tagName === 'VIDEO') return
+        const target = event.target as HTMLElement
+        if (target.closest('.ai-generated-video-controls-host') || target.tagName === 'VIDEO') return
 
         event.preventDefault()
         event.stopPropagation()
@@ -207,11 +228,66 @@ export const aiGeneratedVideoNodeView = (node: any, view: any, getPos: () => num
 
     wrapper.addEventListener('click', handleClick)
 
+    const getControlsWidth = (): number => {
+        const measuredWidth = controlsHost.getBoundingClientRect().width || controlsHost.clientWidth
+        return Math.max(240, measuredWidth || 520)
+    }
+
+    const syncControlsGeometry = (): void => {
+        if (!videoControls || !controlsSvg) return
+        const width = getControlsWidth()
+        controlsSvg
+            .attr('viewBox', `0 0 ${width} 44`)
+            .attr('width', '100%')
+            .attr('height', '44')
+        videoControls.resize(0, 0, width)
+    }
+
+    const destroyVideoControls = (): void => {
+        videoControls?.destroy()
+        videoControls = null
+        controlsSvg = null
+        controlsHost.replaceChildren()
+    }
+
+    const ensureVideoControls = (): void => {
+        if (videoControls) {
+            syncControlsGeometry()
+            return
+        }
+
+        const width = getControlsWidth()
+        controlsSvg = select(controlsHost)
+            .append('svg')
+            .attr('class', 'ai-generated-video-controls-svg')
+            .attr('width', '100%')
+            .attr('height', '44')
+            .attr('viewBox', `0 0 ${width} 44`)
+            .style('display', 'block')
+            .style('overflow', 'visible')
+
+        videoControls = createVideoControls(controlsSvg, {
+            id: String(node.attrs.responseId || node.attrs.fileId || 'chat-video'),
+            x: 0,
+            y: 0,
+            width,
+            videoEl: videoElement,
+            className: 'ai-generated-video-controls',
+        })
+
+        if (!resizeObserver && typeof ResizeObserver !== 'undefined') {
+            resizeObserver = new ResizeObserver(syncControlsGeometry)
+            resizeObserver.observe(controlsHost)
+        }
+    }
+
     const updateDisplay = async () => {
         const { videoUrl, posterUrl, isPending, errorMessage } = node.attrs
 
         if (errorMessage) {
             applyStyle(videoElement, { display: 'none' })
+            applyStyle(controlsHost, { display: 'none' })
+            destroyVideoControls()
             placeholderElement.classList.remove('is-active')
             if (!container.querySelector('.video-error-placeholder')) {
                 container.appendChild(html`
@@ -223,6 +299,8 @@ export const aiGeneratedVideoNodeView = (node: any, view: any, getPos: () => num
 
         if (isPending || !videoUrl) {
             applyStyle(videoElement, { display: 'none' })
+            applyStyle(controlsHost, { display: 'none' })
+            destroyVideoControls()
             placeholderElement.classList.add('is-active')
             placeholderText.textContent = 'Generating video…'
             return
@@ -230,6 +308,7 @@ export const aiGeneratedVideoNodeView = (node: any, view: any, getPos: () => num
 
         placeholderElement.classList.remove('is-active')
         applyStyle(videoElement, { display: 'block' })
+        applyStyle(controlsHost, { display: 'block' })
 
         const resolvedVideoSrc = await buildAuthenticatedUrl(videoUrl)
         const resolvedPosterSrc = posterUrl ? await buildAuthenticatedUrl(posterUrl) : ''
@@ -240,10 +319,13 @@ export const aiGeneratedVideoNodeView = (node: any, view: any, getPos: () => num
         if (resolvedPosterSrc && videoElement.poster !== resolvedPosterSrc) {
             videoElement.poster = resolvedPosterSrc
         }
+        ensureVideoControls()
     }
 
     videoElement.onerror = () => {
         applyStyle(videoElement, { display: 'none' })
+        applyStyle(controlsHost, { display: 'none' })
+        destroyVideoControls()
         if (!container.querySelector('.video-error-placeholder')) {
             container.appendChild(html`
                 <div className="video-error-placeholder"><span innerHTML=${brokenImageIcon}></span><span>Video unavailable</span></div>
@@ -266,6 +348,9 @@ export const aiGeneratedVideoNodeView = (node: any, view: any, getPos: () => num
         },
         destroy: () => {
             wrapper.removeEventListener('click', handleClick)
+            resizeObserver?.disconnect()
+            resizeObserver = null
+            destroyVideoControls()
             try {
                 videoElement.pause()
                 videoElement.removeAttribute('src')
@@ -274,8 +359,9 @@ export const aiGeneratedVideoNodeView = (node: any, view: any, getPos: () => num
                 // Pause/teardown is best-effort during ProseMirror destroy.
             }
         },
-        stopEvent: (_event: Event) => {
-            return false
+        stopEvent: (event: Event) => {
+            const target = event.target as HTMLElement | null
+            return Boolean(target?.closest('.ai-generated-video-controls-host') || target === videoElement)
         },
     }
 }

--- a/services/web-ui/src/components/videoControls/index.ts
+++ b/services/web-ui/src/components/videoControls/index.ts
@@ -1,0 +1,5 @@
+export {
+    createVideoControls,
+    type VideoControlsConfig,
+    type VideoControlsInstance,
+} from '$src/components/videoControls/videoControls.ts'

--- a/services/web-ui/src/components/videoControls/videoControls.test.ts
+++ b/services/web-ui/src/components/videoControls/videoControls.test.ts
@@ -1,0 +1,205 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { select } from 'd3-selection'
+import { createVideoControls } from '$src/components/videoControls/videoControls.ts'
+
+const SVG_NS = 'http://www.w3.org/2000/svg'
+
+type MockVideo = HTMLVideoElement & {
+    _setCurrentTime: (value: number) => void
+}
+
+function createMockVideo(): MockVideo {
+    const video = document.createElement('video') as MockVideo
+    let currentTime = 0
+    let duration = 120
+    let paused = true
+    let volume = 1
+    let muted = false
+    let playbackRate = 1
+
+    Object.defineProperty(video, 'currentTime', {
+        get: () => currentTime,
+        set: (value: number) => { currentTime = value },
+        configurable: true,
+    })
+    Object.defineProperty(video, 'duration', {
+        get: () => duration,
+        set: (value: number) => { duration = value },
+        configurable: true,
+    })
+    Object.defineProperty(video, 'paused', {
+        get: () => paused,
+        configurable: true,
+    })
+    Object.defineProperty(video, 'volume', {
+        get: () => volume,
+        set: (value: number) => { volume = value },
+        configurable: true,
+    })
+    Object.defineProperty(video, 'muted', {
+        get: () => muted,
+        set: (value: boolean) => { muted = value },
+        configurable: true,
+    })
+    Object.defineProperty(video, 'playbackRate', {
+        get: () => playbackRate,
+        set: (value: number) => { playbackRate = value },
+        configurable: true,
+    })
+    Object.defineProperty(video, 'buffered', {
+        get: () => ({
+            length: 1,
+            start: () => 0,
+            end: () => 60,
+        }),
+        configurable: true,
+    })
+
+    video.play = vi.fn(async () => {
+        paused = false
+        video.dispatchEvent(new Event('play'))
+    })
+    video.pause = vi.fn(() => {
+        paused = true
+        video.dispatchEvent(new Event('pause'))
+    })
+    video._setCurrentTime = (value: number) => { currentTime = value }
+
+    return video
+}
+
+function mount(width = 520) {
+    const svg = document.createElementNS(SVG_NS, 'svg') as unknown as SVGSVGElement
+    document.body.appendChild(svg)
+    const video = createMockVideo()
+    const controls = createVideoControls(select(svg), {
+        id: 'video-1',
+        x: 0,
+        y: 0,
+        width,
+        videoEl: video,
+    })
+
+    return { svg, video, controls }
+}
+
+function click(element: Element): void {
+    element.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }))
+}
+
+function pointerDown(element: Element, clientX: number): void {
+    element.dispatchEvent(new MouseEvent('pointerdown', { bubbles: true, cancelable: true, clientX }))
+}
+
+function mockRect(element: Element, width: number): void {
+    element.getBoundingClientRect = () => ({
+        x: 0,
+        y: 0,
+        left: 0,
+        top: 0,
+        right: width,
+        bottom: 44,
+        width,
+        height: 44,
+        toJSON: () => ({}),
+    })
+}
+
+describe('createVideoControls', () => {
+    beforeEach(() => {
+        document.body.innerHTML = ''
+    })
+
+    it('appends an SVG control group with core controls', () => {
+        const { svg } = mount()
+
+        expect(svg.querySelector('.video-controls-group')).not.toBeNull()
+        expect(svg.querySelector('.video-controls-play')).not.toBeNull()
+        expect(svg.querySelector('.video-controls-seek-hit')).not.toBeNull()
+        expect(svg.querySelector('.video-controls-speed')).not.toBeNull()
+        expect(svg.querySelector('.video-controls-volume-hit')).not.toBeNull()
+    })
+
+    it('toggles play and pause through the supplied video element', async () => {
+        const { svg, video } = mount()
+        const playButton = svg.querySelector('.video-controls-play')!
+
+        click(playButton)
+        await Promise.resolve()
+
+        expect(video.play).toHaveBeenCalledTimes(1)
+        expect(video.paused).toBe(false)
+
+        click(playButton)
+
+        expect(video.pause).toHaveBeenCalledTimes(1)
+        expect(video.paused).toBe(true)
+    })
+
+    it('skips relative to current time without leaving video bounds', () => {
+        const { svg, video } = mount()
+        video._setCurrentTime(20)
+
+        click(svg.querySelector('.video-controls-skip-forward')!)
+        expect(video.currentTime).toBe(30)
+
+        click(svg.querySelector('.video-controls-skip-back')!)
+        click(svg.querySelector('.video-controls-skip-back')!)
+        click(svg.querySelector('.video-controls-skip-back')!)
+        expect(video.currentTime).toBe(0)
+    })
+
+    it('scrubs the video by writing currentTime from pointer position', () => {
+        const { svg, video } = mount()
+        const seekHit = svg.querySelector('.video-controls-seek-hit')!
+        mockRect(seekHit, 100)
+
+        pointerDown(seekHit, 25)
+
+        expect(video.currentTime).toBe(30)
+    })
+
+    it('sets playback rate from the speed menu', () => {
+        const { svg, video } = mount()
+
+        click(svg.querySelector('.video-controls-speed')!)
+        click(svg.querySelector('.video-controls-rate-option-hit[data-rate="1.5"]')!)
+
+        expect(video.playbackRate).toBe(1.5)
+        expect(svg.querySelector('.video-controls-speed-text')?.textContent).toBe('1.5x')
+    })
+
+    it('writes volume and mute state from the volume slider and button', () => {
+        const { svg, video } = mount()
+        const volumeHit = svg.querySelector('.video-controls-volume-hit')!
+        mockRect(volumeHit, 100)
+
+        pointerDown(volumeHit, 45)
+        expect(video.volume).toBe(0.45)
+        expect(video.muted).toBe(false)
+
+        click(svg.querySelector('.video-controls-volume-button')!)
+        expect(video.muted).toBe(true)
+    })
+
+    it('removes media listeners and DOM on destroy', () => {
+        const video = createMockVideo()
+        const removeSpy = vi.spyOn(video, 'removeEventListener')
+        const svg = document.createElementNS(SVG_NS, 'svg') as unknown as SVGSVGElement
+        document.body.appendChild(svg)
+
+        const controls = createVideoControls(select(svg), {
+            id: 'video-1',
+            x: 0,
+            y: 0,
+            width: 520,
+            videoEl: video,
+        })
+
+        controls.destroy()
+
+        expect(svg.querySelector('.video-controls-group')).toBeNull()
+        expect(removeSpy).toHaveBeenCalledWith('timeupdate', expect.any(Function))
+        expect(removeSpy).toHaveBeenCalledWith('play', expect.any(Function))
+    })
+})

--- a/services/web-ui/src/components/videoControls/videoControls.ts
+++ b/services/web-ui/src/components/videoControls/videoControls.ts
@@ -1,0 +1,780 @@
+// SVG video control bar, built as a framework-agnostic d3 primitive like
+// slidingSwitch and toggleSwitch. The component renders controls only; the host
+// owns video pixels and supplies the HTMLVideoElement as the single source of truth.
+
+// @ts-ignore - runtime import
+import { select } from 'd3-selection'
+import {
+    videoFullscreenEnterGlyphIcon,
+    videoFullscreenExitGlyphIcon,
+    videoPauseGlyphIcon,
+    videoPictureInPictureGlyphIcon,
+    videoPlayGlyphIcon,
+    videoSkipBack10GlyphIcon,
+    videoSkipForward10GlyphIcon,
+    videoVolumeHighGlyphIcon,
+    videoVolumeMutedGlyphIcon,
+} from '$src/svgIcons/index.ts'
+
+export type VideoControlsConfig = {
+    id: string
+    x: number
+    y: number
+    width: number
+    height?: number
+    videoEl: HTMLVideoElement
+    skipSeconds?: number
+    playbackRates?: number[]
+    className?: string
+}
+
+export type VideoControlsInstance = {
+    render: () => void
+    resize: (x: number, y: number, width: number) => void
+    destroy: () => void
+}
+
+type ButtonControl = {
+    group: any
+    hit: any
+    icon: any
+}
+
+const DEFAULT_HEIGHT = 44
+const DEFAULT_SKIP_SECONDS = 10
+const DEFAULT_PLAYBACK_RATES = [0.5, 0.75, 1, 1.25, 1.5, 2]
+const PADDING = 6
+const GAP = 4
+const BUTTON_SIZE = 30
+const ICON_SIZE = 18
+const BAR_RADIUS = 10
+const SCRUBBER_HEIGHT = 5
+const SCRUBBER_HANDLE_RADIUS = 5
+const TIME_WIDTH = 42
+const SPEED_WIDTH = 44
+const VOLUME_SLIDER_WIDTH = 54
+
+const COLORS = {
+    background: 'rgba(14, 18, 24, 0.82)',
+    backgroundStroke: 'rgba(255, 255, 255, 0.14)',
+    buttonHover: 'rgba(255, 255, 255, 0.12)',
+    icon: 'rgba(255, 255, 255, 0.92)',
+    iconMuted: 'rgba(255, 255, 255, 0.58)',
+    text: 'rgba(255, 255, 255, 0.88)',
+    textSubtle: 'rgba(255, 255, 255, 0.62)',
+    rail: 'rgba(255, 255, 255, 0.22)',
+    buffered: 'rgba(255, 255, 255, 0.32)',
+    progress: '#ffffff',
+    popup: 'rgba(18, 23, 32, 0.96)',
+}
+
+const MEDIA_EVENTS = [
+    'loadedmetadata',
+    'durationchange',
+    'timeupdate',
+    'progress',
+    'play',
+    'pause',
+    'ended',
+    'ratechange',
+    'volumechange',
+    'seeking',
+    'seeked',
+] as const
+
+function clamp(value: number, min: number, max: number): number {
+    return Math.min(max, Math.max(min, value))
+}
+
+function isFiniteDuration(videoEl: HTMLVideoElement): boolean {
+    return Number.isFinite(videoEl.duration) && videoEl.duration > 0
+}
+
+function formatTime(seconds: number): string {
+    if (!Number.isFinite(seconds) || seconds <= 0) return '0:00'
+    const wholeSeconds = Math.floor(seconds)
+    const minutes = Math.floor(wholeSeconds / 60)
+    const remainingSeconds = wholeSeconds % 60
+    return `${minutes}:${String(remainingSeconds).padStart(2, '0')}`
+}
+
+function formatRate(rate: number): string {
+    return `${Number.isInteger(rate) ? String(rate) : String(rate).replace(/0$/, '')}x`
+}
+
+function extractPathData(svgMarkup: string): string[] {
+    const parser = new DOMParser()
+    const svgDoc = parser.parseFromString(svgMarkup, 'image/svg+xml')
+    return Array.from(svgDoc.querySelectorAll('path'))
+        .map((path) => path.getAttribute('d') || '')
+        .filter(Boolean)
+}
+
+function setIconPaths(iconGroup: any, svgMarkup: string, fill: string = COLORS.icon): void {
+    iconGroup.selectAll('*').remove()
+    for (const pathData of extractPathData(svgMarkup)) {
+        iconGroup.append('path')
+            .attr('d', pathData)
+            .attr('fill', fill)
+    }
+}
+
+function setButtonPosition(button: ButtonControl, x: number, y: number, visible = true): void {
+    button.group
+        .attr('transform', `translate(${x}, ${y})`)
+        .attr('display', visible ? null : 'none')
+}
+
+function bindButtonAction(button: ButtonControl, action: (event: Event) => void): void {
+    const run = (event: Event) => {
+        event.preventDefault()
+        event.stopPropagation()
+        action(event)
+    }
+
+    button.group
+        .on('click', run)
+        .on('keydown', (event: KeyboardEvent) => {
+            if (event.key !== 'Enter' && event.key !== ' ') return
+            run(event)
+        })
+        .on('mouseenter', () => button.hit.attr('fill', COLORS.buttonHover))
+        .on('mouseleave', () => button.hit.attr('fill', 'transparent'))
+}
+
+function bufferedEnd(videoEl: HTMLVideoElement): number {
+    if (!isFiniteDuration(videoEl)) return 0
+    try {
+        if (!videoEl.buffered || videoEl.buffered.length === 0) return 0
+        return clamp(videoEl.buffered.end(videoEl.buffered.length - 1), 0, videoEl.duration)
+    } catch {
+        return 0
+    }
+}
+
+function supportsPictureInPicture(videoEl: HTMLVideoElement): boolean {
+    const doc = document as Document & {
+        pictureInPictureEnabled?: boolean
+    }
+    const videoWithPip = videoEl as HTMLVideoElement & {
+        requestPictureInPicture?: () => Promise<unknown>
+    }
+    return Boolean(doc.pictureInPictureEnabled && typeof videoWithPip.requestPictureInPicture === 'function')
+}
+
+function isPictureInPicture(videoEl: HTMLVideoElement): boolean {
+    const doc = document as Document & {
+        pictureInPictureElement?: Element | null
+    }
+    return doc.pictureInPictureElement === videoEl
+}
+
+function supportsFullscreen(videoEl: HTMLVideoElement): boolean {
+    return typeof videoEl.requestFullscreen === 'function' && typeof document.exitFullscreen === 'function'
+}
+
+function isFullscreen(videoEl: HTMLVideoElement): boolean {
+    return document.fullscreenElement === videoEl
+}
+
+class VideoControls implements VideoControlsInstance {
+    private readonly id: string
+    private readonly height: number
+    private readonly videoEl: HTMLVideoElement
+    private readonly skipSeconds: number
+    private readonly playbackRates: number[]
+    private readonly buttonY: number
+    private readonly scrubberY: number
+
+    private x: number
+    private y: number
+    private width: number
+    private seekX = PADDING
+    private seekWidth: number
+    private volumeWidth = VOLUME_SLIDER_WIDTH
+    private speedMenuOpen = false
+    private destroyed = false
+    private activePointerCleanup: (() => void) | null = null
+
+    private readonly group: any
+    private readonly background: any
+    private readonly playButton: ButtonControl
+    private readonly skipBackButton: ButtonControl
+    private readonly skipForwardButton: ButtonControl
+    private readonly volumeButton: ButtonControl
+    private readonly pipButton: ButtonControl
+    private readonly fullscreenButton: ButtonControl
+    private readonly currentTimeText: any
+    private readonly durationText: any
+    private readonly seekGroup: any
+    private readonly seekRail: any
+    private readonly seekBuffered: any
+    private readonly seekProgress: any
+    private readonly seekHandle: any
+    private readonly seekHit: any
+    private readonly speedButton: any
+    private readonly speedButtonBg: any
+    private readonly speedText: any
+    private readonly speedMenu: any
+    private readonly volumeGroup: any
+    private readonly volumeRail: any
+    private readonly volumeProgress: any
+    private readonly volumeHandle: any
+    private readonly volumeHit: any
+
+    constructor(parent: any, config: VideoControlsConfig) {
+        const {
+            id,
+            videoEl,
+            skipSeconds = DEFAULT_SKIP_SECONDS,
+            playbackRates = DEFAULT_PLAYBACK_RATES,
+            className = '',
+        } = config
+
+        this.id = id
+        this.videoEl = videoEl
+        this.skipSeconds = skipSeconds
+        this.playbackRates = playbackRates
+        this.x = config.x
+        this.y = config.y
+        this.width = config.width
+        this.height = config.height ?? DEFAULT_HEIGHT
+        this.buttonY = (this.height - BUTTON_SIZE) / 2
+        this.scrubberY = this.height / 2 - SCRUBBER_HEIGHT / 2
+        this.seekWidth = Math.max(1, this.width - PADDING * 2)
+
+        this.group = parent.append('g')
+            .attr('class', `video-controls-group ${className}`)
+            .attr('transform', `translate(${this.x}, ${this.y})`)
+            .attr('data-video-controls-id', this.id)
+            .style('cursor', 'default')
+
+        this.background = this.group.append('rect')
+            .attr('class', 'video-controls-background')
+            .attr('x', 0)
+            .attr('y', 0)
+            .attr('width', this.width)
+            .attr('height', this.height)
+            .attr('rx', BAR_RADIUS)
+            .attr('ry', BAR_RADIUS)
+            .attr('fill', COLORS.background)
+            .attr('stroke', COLORS.backgroundStroke)
+            .attr('stroke-width', 1)
+
+        this.playButton = this.createButton('video-controls-play', videoPlayGlyphIcon, 'Play video')
+        this.skipBackButton = this.createButton('video-controls-skip-back', videoSkipBack10GlyphIcon, `Skip back ${this.skipSeconds} seconds`)
+        this.skipForwardButton = this.createButton('video-controls-skip-forward', videoSkipForward10GlyphIcon, `Skip forward ${this.skipSeconds} seconds`)
+        this.volumeButton = this.createButton('video-controls-volume-button', videoVolumeHighGlyphIcon, 'Mute video')
+        this.pipButton = this.createButton('video-controls-pip', videoPictureInPictureGlyphIcon, 'Picture in picture')
+        this.fullscreenButton = this.createButton('video-controls-fullscreen', videoFullscreenEnterGlyphIcon, 'Enter fullscreen')
+
+        this.currentTimeText = this.group.append('text')
+            .attr('class', 'video-controls-current-time')
+            .attr('y', this.height / 2)
+            .attr('dominant-baseline', 'central')
+            .attr('font-size', 11)
+            .attr('font-weight', 600)
+            .attr('fill', COLORS.textSubtle)
+
+        this.durationText = this.group.append('text')
+            .attr('class', 'video-controls-duration')
+            .attr('y', this.height / 2)
+            .attr('dominant-baseline', 'central')
+            .attr('font-size', 11)
+            .attr('font-weight', 600)
+            .attr('fill', COLORS.textSubtle)
+
+        this.seekGroup = this.group.append('g')
+            .attr('class', 'video-controls-seek')
+            .style('cursor', 'pointer')
+
+        this.seekRail = this.seekGroup.append('rect')
+            .attr('class', 'video-controls-seek-rail')
+            .attr('y', this.scrubberY)
+            .attr('height', SCRUBBER_HEIGHT)
+            .attr('rx', SCRUBBER_HEIGHT / 2)
+            .attr('ry', SCRUBBER_HEIGHT / 2)
+            .attr('fill', COLORS.rail)
+
+        this.seekBuffered = this.seekGroup.append('rect')
+            .attr('class', 'video-controls-seek-buffered')
+            .attr('y', this.scrubberY)
+            .attr('height', SCRUBBER_HEIGHT)
+            .attr('rx', SCRUBBER_HEIGHT / 2)
+            .attr('ry', SCRUBBER_HEIGHT / 2)
+            .attr('fill', COLORS.buffered)
+
+        this.seekProgress = this.seekGroup.append('rect')
+            .attr('class', 'video-controls-seek-progress')
+            .attr('y', this.scrubberY)
+            .attr('height', SCRUBBER_HEIGHT)
+            .attr('rx', SCRUBBER_HEIGHT / 2)
+            .attr('ry', SCRUBBER_HEIGHT / 2)
+            .attr('fill', COLORS.progress)
+
+        this.seekHandle = this.seekGroup.append('circle')
+            .attr('class', 'video-controls-seek-handle')
+            .attr('cy', this.scrubberY + SCRUBBER_HEIGHT / 2)
+            .attr('r', SCRUBBER_HANDLE_RADIUS)
+            .attr('fill', COLORS.progress)
+
+        this.seekHit = this.seekGroup.append('rect')
+            .attr('class', 'video-controls-seek-hit')
+            .attr('y', 0)
+            .attr('height', this.height)
+            .attr('fill', 'transparent')
+
+        this.speedButton = this.group.append('g')
+            .attr('class', 'video-controls-speed')
+            .attr('role', 'button')
+            .attr('tabindex', 0)
+            .attr('aria-label', 'Playback speed')
+            .style('cursor', 'pointer')
+
+        this.speedButtonBg = this.speedButton.append('rect')
+            .attr('class', 'video-controls-speed-bg')
+            .attr('x', 0)
+            .attr('y', this.buttonY)
+            .attr('width', SPEED_WIDTH)
+            .attr('height', BUTTON_SIZE)
+            .attr('rx', 7)
+            .attr('ry', 7)
+            .attr('fill', 'transparent')
+
+        this.speedText = this.speedButton.append('text')
+            .attr('class', 'video-controls-speed-text')
+            .attr('x', SPEED_WIDTH / 2)
+            .attr('y', this.height / 2)
+            .attr('text-anchor', 'middle')
+            .attr('dominant-baseline', 'central')
+            .attr('font-size', 11)
+            .attr('font-weight', 650)
+            .attr('fill', COLORS.text)
+
+        this.speedMenu = this.group.append('g')
+            .attr('class', 'video-controls-speed-menu')
+            .attr('display', 'none')
+
+        this.volumeGroup = this.group.append('g')
+            .attr('class', 'video-controls-volume')
+            .style('cursor', 'pointer')
+
+        this.volumeRail = this.volumeGroup.append('rect')
+            .attr('class', 'video-controls-volume-rail')
+            .attr('y', this.scrubberY)
+            .attr('height', SCRUBBER_HEIGHT)
+            .attr('rx', SCRUBBER_HEIGHT / 2)
+            .attr('ry', SCRUBBER_HEIGHT / 2)
+            .attr('fill', COLORS.rail)
+
+        this.volumeProgress = this.volumeGroup.append('rect')
+            .attr('class', 'video-controls-volume-progress')
+            .attr('y', this.scrubberY)
+            .attr('height', SCRUBBER_HEIGHT)
+            .attr('rx', SCRUBBER_HEIGHT / 2)
+            .attr('ry', SCRUBBER_HEIGHT / 2)
+            .attr('fill', COLORS.progress)
+
+        this.volumeHandle = this.volumeGroup.append('circle')
+            .attr('class', 'video-controls-volume-handle')
+            .attr('cy', this.scrubberY + SCRUBBER_HEIGHT / 2)
+            .attr('r', 4)
+            .attr('fill', COLORS.progress)
+
+        this.volumeHit = this.volumeGroup.append('rect')
+            .attr('class', 'video-controls-volume-hit')
+            .attr('y', 0)
+            .attr('height', this.height)
+            .attr('fill', 'transparent')
+
+        this.bindButtonActions()
+        this.bindSpeedButton()
+        this.bindPointerDrag(this.seekHit, this.setVideoTimeFromEvent)
+        this.bindPointerDrag(this.volumeHit, this.setVolumeFromEvent)
+        this.addMediaListeners()
+        this.createSpeedMenu()
+        this.render()
+    }
+
+    render = (): void => {
+        if (this.destroyed) return
+        this.layout()
+
+        const duration = isFiniteDuration(this.videoEl) ? this.videoEl.duration : 0
+        const currentTime = duration > 0 ? clamp(this.videoEl.currentTime, 0, duration) : 0
+        const progressRatio = duration > 0 ? currentTime / duration : 0
+        const bufferedRatio = duration > 0 ? bufferedEnd(this.videoEl) / duration : 0
+        const volume = this.videoEl.muted ? 0 : clamp(this.videoEl.volume, 0, 1)
+
+        this.currentTimeText.text(formatTime(currentTime))
+        this.durationText.text(formatTime(duration))
+
+        this.seekBuffered.attr('width', this.seekWidth * bufferedRatio)
+        this.seekProgress.attr('width', this.seekWidth * progressRatio)
+        this.seekHandle.attr('cx', this.seekX + this.seekWidth * progressRatio)
+            .attr('opacity', duration > 0 ? 1 : 0.45)
+        this.seekGroup.attr('opacity', duration > 0 ? 1 : 0.45)
+
+        const playIcon = this.videoEl.paused ? videoPlayGlyphIcon : videoPauseGlyphIcon
+        setIconPaths(this.playButton.icon, playIcon)
+        this.playButton.group.attr('aria-label', this.videoEl.paused ? 'Play video' : 'Pause video')
+
+        const isMuted = this.videoEl.muted || this.videoEl.volume === 0
+        const volumeIcon = isMuted ? videoVolumeMutedGlyphIcon : videoVolumeHighGlyphIcon
+        setIconPaths(this.volumeButton.icon, volumeIcon, isMuted ? COLORS.iconMuted : COLORS.icon)
+        this.volumeButton.group.attr('aria-label', isMuted ? 'Unmute video' : 'Mute video')
+        this.volumeProgress.attr('width', this.volumeWidth * volume)
+        this.volumeHandle.attr('cx', this.volumeWidth * volume)
+
+        this.speedText.text(formatRate(this.videoEl.playbackRate || 1))
+        this.speedMenu.attr('display', this.speedMenuOpen ? null : 'none')
+
+        const fullscreenIcon = isFullscreen(this.videoEl) ? videoFullscreenExitGlyphIcon : videoFullscreenEnterGlyphIcon
+        setIconPaths(this.fullscreenButton.icon, fullscreenIcon)
+        this.fullscreenButton.group.attr('aria-label', isFullscreen(this.videoEl) ? 'Exit fullscreen' : 'Enter fullscreen')
+        this.pipButton.group.attr('aria-pressed', String(isPictureInPicture(this.videoEl)))
+    }
+
+    resize = (nextX: number, nextY: number, nextWidth: number): void => {
+        this.x = nextX
+        this.y = nextY
+        this.width = Math.max(120, nextWidth)
+        this.group.attr('transform', `translate(${this.x}, ${this.y})`)
+        this.render()
+    }
+
+    destroy = (): void => {
+        if (this.destroyed) return
+        this.destroyed = true
+        this.activePointerCleanup?.()
+        this.activePointerCleanup = null
+        for (const eventName of MEDIA_EVENTS) {
+            this.videoEl.removeEventListener(eventName, this.onMediaEvent)
+        }
+        document.removeEventListener('fullscreenchange', this.onMediaEvent)
+        this.videoEl.removeEventListener('enterpictureinpicture', this.onMediaEvent)
+        this.videoEl.removeEventListener('leavepictureinpicture', this.onMediaEvent)
+        window.removeEventListener('pointerdown', this.closeSpeedMenuOnOutsidePointer, true)
+        this.group.remove()
+    }
+
+    private createButton(className: string, iconMarkup: string, label: string): ButtonControl {
+        const buttonGroup = this.group.append('g')
+            .attr('class', className)
+            .attr('role', 'button')
+            .attr('tabindex', 0)
+            .attr('aria-label', label)
+            .style('cursor', 'pointer')
+
+        const hit = buttonGroup.append('rect')
+            .attr('class', `${className}-hit`)
+            .attr('x', 0)
+            .attr('y', 0)
+            .attr('width', BUTTON_SIZE)
+            .attr('height', BUTTON_SIZE)
+            .attr('rx', 7)
+            .attr('ry', 7)
+            .attr('fill', 'transparent')
+
+        const icon = buttonGroup.append('g')
+            .attr('class', `${className}-icon`)
+            .attr('transform', `translate(${(BUTTON_SIZE - ICON_SIZE) / 2}, ${(BUTTON_SIZE - ICON_SIZE) / 2}) scale(${ICON_SIZE / 24})`)
+
+        buttonGroup.append('text')
+            .attr('class', `${className}-label`)
+            .attr('x', BUTTON_SIZE / 2)
+            .attr('y', BUTTON_SIZE / 2)
+            .attr('text-anchor', 'middle')
+            .attr('dominant-baseline', 'central')
+            .attr('font-size', 11)
+            .attr('font-weight', 650)
+            .attr('fill', COLORS.text)
+            .attr('display', 'none')
+
+        setIconPaths(icon, iconMarkup)
+        return { group: buttonGroup, hit, icon }
+    }
+
+    private createSpeedMenu(): void {
+        this.speedMenu.selectAll('*').remove()
+        const optionHeight = 26
+        const menuWidth = SPEED_WIDTH
+        const menuHeight = optionHeight * this.playbackRates.length + 6
+
+        this.speedMenu.append('rect')
+            .attr('class', 'video-controls-speed-menu-bg')
+            .attr('x', 0)
+            .attr('y', 0)
+            .attr('width', menuWidth)
+            .attr('height', menuHeight)
+            .attr('rx', 8)
+            .attr('ry', 8)
+            .attr('fill', COLORS.popup)
+            .attr('stroke', COLORS.backgroundStroke)
+            .attr('stroke-width', 1)
+
+        for (const [index, rate] of this.playbackRates.entries()) {
+            const optionY = 3 + index * optionHeight
+            const optionGroup = this.speedMenu.append('g')
+                .attr('class', 'video-controls-rate-option')
+                .attr('transform', `translate(0, ${optionY})`)
+                .style('cursor', 'pointer')
+
+            optionGroup.append('rect')
+                .attr('class', 'video-controls-rate-option-hit')
+                .attr('x', 3)
+                .attr('y', 1)
+                .attr('width', menuWidth - 6)
+                .attr('height', optionHeight - 2)
+                .attr('rx', 5)
+                .attr('ry', 5)
+                .attr('fill', 'transparent')
+                .attr('data-rate', String(rate))
+                .on('mouseenter', function () { select(this).attr('fill', COLORS.buttonHover) })
+                .on('mouseleave', function () { select(this).attr('fill', 'transparent') })
+                .on('click', (event: MouseEvent) => {
+                    event.preventDefault()
+                    event.stopPropagation()
+                    this.videoEl.playbackRate = rate
+                    this.speedMenuOpen = false
+                    this.render()
+                })
+
+            optionGroup.append('text')
+                .attr('class', 'video-controls-rate-option-label')
+                .attr('x', menuWidth / 2)
+                .attr('y', optionHeight / 2)
+                .attr('text-anchor', 'middle')
+                .attr('dominant-baseline', 'central')
+                .attr('font-size', 11)
+                .attr('font-weight', 650)
+                .attr('fill', COLORS.text)
+                .text(formatRate(rate))
+        }
+    }
+
+    private layout(): void {
+        const showSkip = this.width >= 340
+        const showVolumeSlider = this.width >= 440
+        const showPip = supportsPictureInPicture(this.videoEl) && this.width >= 380
+        const showFullscreen = supportsFullscreen(this.videoEl) && this.width >= 320
+
+        this.background.attr('width', this.width).attr('height', this.height)
+
+        let left = PADDING
+        setButtonPosition(this.playButton, left, this.buttonY)
+        left += BUTTON_SIZE + GAP
+
+        setButtonPosition(this.skipBackButton, left, this.buttonY, showSkip)
+        if (showSkip) left += BUTTON_SIZE + GAP
+        setButtonPosition(this.skipForwardButton, left, this.buttonY, showSkip)
+        if (showSkip) left += BUTTON_SIZE + GAP
+
+        this.currentTimeText.attr('x', left + 2)
+        left += TIME_WIDTH
+
+        let right = this.width - PADDING
+
+        if (showFullscreen) {
+            right -= BUTTON_SIZE
+            setButtonPosition(this.fullscreenButton, right, this.buttonY, true)
+            right -= GAP
+        } else {
+            setButtonPosition(this.fullscreenButton, right, this.buttonY, false)
+        }
+
+        if (showPip) {
+            right -= BUTTON_SIZE
+            setButtonPosition(this.pipButton, right, this.buttonY, true)
+            right -= GAP
+        } else {
+            setButtonPosition(this.pipButton, right, this.buttonY, false)
+        }
+
+        if (showVolumeSlider) {
+            right -= VOLUME_SLIDER_WIDTH
+            this.volumeWidth = VOLUME_SLIDER_WIDTH
+            this.volumeGroup.attr('transform', `translate(${right}, 0)`).attr('display', null)
+            right -= GAP
+        } else {
+            this.volumeGroup.attr('display', 'none')
+        }
+
+        right -= BUTTON_SIZE
+        setButtonPosition(this.volumeButton, right, this.buttonY)
+        right -= GAP
+
+        right -= SPEED_WIDTH
+        this.speedButton.attr('transform', `translate(${right}, 0)`)
+        this.speedMenu.attr('transform', `translate(${right}, ${this.buttonY - this.playbackRates.length * 26 - 12})`)
+        right -= GAP
+
+        right -= TIME_WIDTH
+        this.durationText.attr('x', right + 4)
+        right -= GAP
+
+        this.seekX = left
+        this.seekWidth = Math.max(36, right - left)
+        this.seekRail.attr('x', this.seekX).attr('width', this.seekWidth)
+        this.seekBuffered.attr('x', this.seekX)
+        this.seekProgress.attr('x', this.seekX)
+        this.seekHit.attr('x', this.seekX).attr('width', this.seekWidth)
+        this.volumeRail.attr('x', 0).attr('width', this.volumeWidth)
+        this.volumeProgress.attr('x', 0)
+        this.volumeHit.attr('x', 0).attr('width', this.volumeWidth)
+    }
+
+    private seekRatioFromEvent(event: PointerEvent | MouseEvent): number {
+        const node = this.seekHit.node() as SVGRectElement | null
+        const rect = node?.getBoundingClientRect()
+        if (!rect || rect.width <= 0) return 0
+        return clamp((event.clientX - rect.left) / rect.width, 0, 1)
+    }
+
+    private volumeRatioFromEvent(event: PointerEvent | MouseEvent): number {
+        const node = this.volumeHit.node() as SVGRectElement | null
+        const rect = node?.getBoundingClientRect()
+        if (!rect || rect.width <= 0) return 0
+        return clamp((event.clientX - rect.left) / rect.width, 0, 1)
+    }
+
+    private readonly setVideoTimeFromEvent = (event: PointerEvent | MouseEvent): void => {
+        if (!isFiniteDuration(this.videoEl)) return
+        this.videoEl.currentTime = this.seekRatioFromEvent(event) * this.videoEl.duration
+        this.render()
+    }
+
+    private readonly setVolumeFromEvent = (event: PointerEvent | MouseEvent): void => {
+        this.videoEl.volume = this.volumeRatioFromEvent(event)
+        this.videoEl.muted = this.videoEl.volume === 0
+        this.render()
+    }
+
+    private bindPointerDrag(hit: any, applyValue: (event: PointerEvent) => void): void {
+        hit.on('pointerdown', (event: PointerEvent) => {
+            event.preventDefault()
+            event.stopPropagation()
+            this.activePointerCleanup?.()
+            applyValue(event)
+
+            const move = (moveEvent: PointerEvent) => applyValue(moveEvent)
+            const up = () => {
+                window.removeEventListener('pointermove', move)
+                window.removeEventListener('pointerup', up)
+                this.activePointerCleanup = null
+            }
+
+            window.addEventListener('pointermove', move)
+            window.addEventListener('pointerup', up)
+            this.activePointerCleanup = up
+        })
+    }
+
+    private readonly closeSpeedMenuOnOutsidePointer = (event: PointerEvent): void => {
+        if (!this.speedMenuOpen) return
+        const target = event.target as Node | null
+        const speedNode = this.speedButton.node() as Node | null
+        const menuNode = this.speedMenu.node() as Node | null
+        if ((speedNode && target && speedNode.contains(target)) || (menuNode && target && menuNode.contains(target))) return
+        this.speedMenuOpen = false
+        this.render()
+    }
+
+    private async togglePlay(): Promise<void> {
+        try {
+            if (this.videoEl.paused) await this.videoEl.play()
+            else this.videoEl.pause()
+        } catch (error) {
+            console.warn('[videoControls] play toggle failed', error)
+        }
+        this.render()
+    }
+
+    private async togglePictureInPicture(): Promise<void> {
+        if (!supportsPictureInPicture(this.videoEl)) return
+        const doc = document as Document & {
+            exitPictureInPicture?: () => Promise<void>
+        }
+        try {
+            if (isPictureInPicture(this.videoEl)) await doc.exitPictureInPicture?.()
+            else {
+                const videoWithPip = this.videoEl as HTMLVideoElement & {
+                    requestPictureInPicture?: () => Promise<unknown>
+                }
+                await videoWithPip.requestPictureInPicture?.()
+            }
+        } catch (error) {
+            console.warn('[videoControls] picture-in-picture failed', error)
+        }
+        this.render()
+    }
+
+    private async toggleFullscreen(): Promise<void> {
+        if (!supportsFullscreen(this.videoEl)) return
+        try {
+            if (isFullscreen(this.videoEl)) await document.exitFullscreen()
+            else await this.videoEl.requestFullscreen()
+        } catch (error) {
+            console.warn('[videoControls] fullscreen failed', error)
+        }
+        this.render()
+    }
+
+    private bindButtonActions(): void {
+        bindButtonAction(this.playButton, () => { void this.togglePlay() })
+        bindButtonAction(this.skipBackButton, () => {
+            if (!isFiniteDuration(this.videoEl)) return
+            this.videoEl.currentTime = clamp(this.videoEl.currentTime - this.skipSeconds, 0, this.videoEl.duration)
+            this.render()
+        })
+        bindButtonAction(this.skipForwardButton, () => {
+            if (!isFiniteDuration(this.videoEl)) return
+            this.videoEl.currentTime = clamp(this.videoEl.currentTime + this.skipSeconds, 0, this.videoEl.duration)
+            this.render()
+        })
+        bindButtonAction(this.volumeButton, () => {
+            this.videoEl.muted = !this.videoEl.muted
+            if (!this.videoEl.muted && this.videoEl.volume === 0) this.videoEl.volume = 0.5
+            this.render()
+        })
+        bindButtonAction(this.pipButton, () => { void this.togglePictureInPicture() })
+        bindButtonAction(this.fullscreenButton, () => { void this.toggleFullscreen() })
+    }
+
+    private bindSpeedButton(): void {
+        this.speedButton
+            .on('click', (event: MouseEvent) => {
+                event.preventDefault()
+                event.stopPropagation()
+                this.speedMenuOpen = !this.speedMenuOpen
+                this.render()
+            })
+            .on('keydown', (event: KeyboardEvent) => {
+                if (event.key !== 'Enter' && event.key !== ' ') return
+                event.preventDefault()
+                event.stopPropagation()
+                this.speedMenuOpen = !this.speedMenuOpen
+                this.render()
+            })
+            .on('mouseenter', () => this.speedButtonBg.attr('fill', COLORS.buttonHover))
+            .on('mouseleave', () => this.speedButtonBg.attr('fill', 'transparent'))
+    }
+
+    private addMediaListeners(): void {
+        for (const eventName of MEDIA_EVENTS) {
+            this.videoEl.addEventListener(eventName, this.onMediaEvent)
+        }
+        document.addEventListener('fullscreenchange', this.onMediaEvent)
+        this.videoEl.addEventListener('enterpictureinpicture', this.onMediaEvent)
+        this.videoEl.addEventListener('leavepictureinpicture', this.onMediaEvent)
+        window.addEventListener('pointerdown', this.closeSpeedMenuOnOutsidePointer, true)
+    }
+
+    private readonly onMediaEvent = (): void => {
+        this.render()
+    }
+}
+
+export function createVideoControls(parent: any, config: VideoControlsConfig): VideoControlsInstance {
+    return new VideoControls(parent, config)
+}

--- a/services/web-ui/src/infographics/workspace/README.md
+++ b/services/web-ui/src/infographics/workspace/README.md
@@ -53,6 +53,12 @@ All of this happens without the Svelte component knowing the details. It just pa
 - Automatically delete their workspace object when removed from canvas; explicitly saved Media Library copies are separate objects and remain available
 - Expose `Add to Media Library` in the bubble menu once their stored object is available; streaming generated-image placeholders hide the action until completion
 
+### Video Nodes
+- Display generated or media-library videos through the PIXI media layer, with a poster texture at rest and a live `Texture.from(videoElement)` source after playback or seeking starts
+- Keep the DOM node as an interaction shell only; video pixels are not rendered by a DOM `<video>` on the canvas
+- Use the shared SVG `components/videoControls` bar in the transformed image-chrome overlay, bound to the same hidden attached `HTMLVideoElement` that PIXI samples
+- Support play/pause, seek, skip, speed, volume, picture-in-picture, and fullscreen without persisting playback state into `canvasState`
+
 ### Media Library Panel
 - Implemented in `mediaLibraryPanel.ts` and `media-library-panel.scss` inside this canvas module; Svelte supplies the independent bottom-right launcher above the unchanged zoom badge and the style import.
 - Renders `Features` through the established Feature subjects; promoted Feature samples copy to durable storage before scope changes and legacy promoted samples migrate before origin-workspace deletion.

--- a/services/web-ui/src/infographics/workspace/WorkspaceCanvas.ts
+++ b/services/web-ui/src/infographics/workspace/WorkspaceCanvas.ts
@@ -38,7 +38,7 @@ import { getGeneratedImageTurnInfoFromThreadContent } from '$src/components/pros
 import { createAiResponseMessageShell, createAiUserMessageShell } from '$src/components/proseMirror/plugins/aiChatThreadPlugin/aiChatMessageShells.ts'
 import { createImageGenerationTraceDetails } from '$src/components/proseMirror/plugins/aiChatThreadPlugin/imageGenerationTraceDetails.ts'
 import AiInteractionService from '$src/services/ai-interaction-service.ts'
-import { imageResizeCornerIcon, aiChatThreadRailBoundaryCircle, brokenImageIcon, infoCircleIcon, trashBinIcon, xIcon, aiChatPanelToggleHistoryIcon, videoPlayGlyphIcon, videoPauseGlyphIcon } from '$src/svgIcons/index.ts'
+import { imageResizeCornerIcon, aiChatThreadRailBoundaryCircle, brokenImageIcon, infoCircleIcon, trashBinIcon, xIcon, aiChatPanelToggleHistoryIcon } from '$src/svgIcons/index.ts'
 import { type Document } from '$src/stores/documentStore.ts'
 import { createCanvasImageLifecycleTracker } from '$src/infographics/workspace/canvasImageLifecycle.ts'
 import { createCanvasVideoLifecycleTracker } from '$src/infographics/workspace/canvasVideoLifecycle.ts'
@@ -113,6 +113,7 @@ import {
 } from '$src/infographics/workspace/aiChatPanelState.ts'
 import { createSlidingSwitch } from '$src/components/slidingSwitch/index.ts'
 import { createToggleSwitch } from '$src/components/toggleSwitch/index.ts'
+import { createVideoControls, type VideoControlsInstance } from '$src/components/videoControls/index.ts'
 
 type ResizeCorner = 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right'
 type ResizeHandle = ResizeCorner | ContextRegionCloudResizeHandle
@@ -258,6 +259,7 @@ export function createWorkspaceCanvas(options: WorkspaceCanvasOptions) {
     let selectedNodeIds: Set<string> = new Set()
     let selectedEdgeId: string | null = null
     const expandedGeneratedImageInfoNodeIds: Set<string> = new Set()
+    const videoControlInstances: Map<string, VideoControlsInstance> = new Map()
     let resizingNodeId: string | null = null
     let draggingNodeId: string | null = null
     let selectionRectEl: HTMLDivElement | null = null
@@ -918,11 +920,10 @@ export function createWorkspaceCanvas(options: WorkspaceCanvasOptions) {
         })
     }
 
-    // The video play-button chrome spans the whole node so the button can center
-    // over the poster/video pixels (PIXI paints those above the DOM node shell, so
-    // a shell button would be hidden). The container is click-through; only the
-    // button captures pointer events.
-    function applyVideoPlayButtonGeometry(
+    // The video controls chrome spans the whole node so the SVG bar can sit over
+    // the PIXI-painted video pixels. The container is click-through; only the
+    // SVG host captures pointer events.
+    function applyVideoControlsGeometry(
         chromeEl: HTMLElement,
         position: { x: number; y: number },
         dimensions: { width: number; height: number }
@@ -933,6 +934,9 @@ export function createWorkspaceCanvas(options: WorkspaceCanvasOptions) {
             width: `${dimensions.width}px`,
             height: `${dimensions.height}px`,
         })
+
+        const controls = videoControlInstances.get(chromeEl.dataset.videoChromeNodeId || '')
+        controls?.resize(0, Math.max(0, dimensions.height - 54), dimensions.width)
     }
 
     function updateGeneratedImageChromeLiveTransform(
@@ -943,7 +947,7 @@ export function createWorkspaceCanvas(options: WorkspaceCanvasOptions) {
         const chromeEl = imageChromeViewportEl?.querySelector(`[data-image-chrome-node-id="${nodeId}"]`) as HTMLElement | null
         if (chromeEl) applyGeneratedImageChromeGeometry(chromeEl, position, dimensions)
         const videoChromeEl = imageChromeViewportEl?.querySelector(`[data-video-chrome-node-id="${nodeId}"]`) as HTMLElement | null
-        if (videoChromeEl) applyVideoPlayButtonGeometry(videoChromeEl, position, dimensions)
+        if (videoChromeEl) applyVideoControlsGeometry(videoChromeEl, position, dimensions)
     }
 
     function appendTextParagraph(host: HTMLElement, text: string, fallbackText: string): void {
@@ -1043,41 +1047,54 @@ export function createWorkspaceCanvas(options: WorkspaceCanvasOptions) {
         return chromeEl
     }
 
-    // Click-to-play button for a completed video node, rendered in the same
-    // transform-synced chrome layer (z-index 3) as image provenance chrome because
-    // PIXI paints the video pixels above the DOM node shell.
-    function createVideoPlayButtonChrome(node: VideoCanvasNode): HTMLElement {
-        const button = html`
-            <button type="button" className="workspace-video-play-button nopan" aria-label="Play video">
-                <span className="workspace-video-play-button-icon" innerHTML=${videoPlayGlyphIcon}></span>
-            </button>
-        ` as HTMLButtonElement
+    // Shared SVG control bar for completed video nodes. PIXI owns the pixels;
+    // this chrome only drives the same hidden HTMLVideoElement that videoNodeHandler
+    // samples as a texture.
+    function createVideoControlsChrome(node: VideoCanvasNode): HTMLElement | null {
+        const videoEl = videoNodeHandler?.getVideoElement(node.nodeId)
+        if (!videoEl) return null
 
-        const syncIcon = () => {
-            const playing = videoNodeHandler?.isPlaying(node.nodeId) ?? false
-            button.classList.toggle('is-playing', playing)
-            const iconEl = button.querySelector('.workspace-video-play-button-icon') as HTMLElement | null
-            if (iconEl) iconEl.innerHTML = playing ? videoPauseGlyphIcon : videoPlayGlyphIcon
-            button.setAttribute('aria-label', playing ? 'Pause video' : 'Play video')
+        const controlsHostStyle = {
+            position: 'absolute' as const,
+            left: '0',
+            bottom: '10px',
+            width: '100%',
+            height: '44px',
+            pointerEvents: 'auto' as const,
         }
-
-        button.addEventListener('click', async (event: MouseEvent) => {
-            event.preventDefault()
-            event.stopPropagation()
-            if (!videoNodeHandler?.hasEntry(node.nodeId)) return
-            await videoNodeHandler.toggle(node.nodeId).catch(() => {})
-            syncIcon()
-        })
-
         const chromeEl = html`
             <div className="workspace-video-chrome" data=${{ videoChromeNodeId: node.nodeId }}>
-                ${button}
+                <div className="workspace-video-controls-host nopan" style=${controlsHostStyle}></div>
             </div>
         ` as HTMLElement
+        const host = chromeEl.querySelector('.workspace-video-controls-host') as HTMLDivElement
+        const svg = select(host)
+            .append('svg')
+            .attr('class', 'workspace-video-controls-svg')
+            .attr('width', '100%')
+            .attr('height', '44')
+            .attr('viewBox', `0 0 ${node.dimensions.width} 44`)
+            .style('display', 'block')
+            .style('overflow', 'visible')
 
-        applyVideoPlayButtonGeometry(chromeEl, getNodeWorldPosition(node), node.dimensions)
-        syncIcon()
+        const controls = createVideoControls(svg, {
+            id: node.nodeId,
+            x: 0,
+            y: 0,
+            width: node.dimensions.width,
+            videoEl,
+            className: 'workspace-video-controls',
+        })
+        videoControlInstances.set(node.nodeId, controls)
+        applyVideoControlsGeometry(chromeEl, getNodeWorldPosition(node), node.dimensions)
         return chromeEl
+    }
+
+    function destroyVideoControlInstances(): void {
+        for (const controls of videoControlInstances.values()) {
+            controls.destroy()
+        }
+        videoControlInstances.clear()
     }
 
     function syncGeneratedImageChrome(canvasState: CanvasState | null = currentCanvasState): void {
@@ -1090,14 +1107,19 @@ export function createWorkspaceCanvas(options: WorkspaceCanvasOptions) {
             if (!generatedNodeIds.has(expandedNodeId)) expandedGeneratedImageInfoNodeIds.delete(expandedNodeId)
         }
 
-        // Completed video nodes (those with a stored MP4 src) get a centered
-        // play/pause button in the same chrome layer.
+        destroyVideoControlInstances()
+
+        // Completed video nodes (those with a stored MP4 src) get the shared SVG
+        // control bar in the same chrome layer.
         const playableVideoNodes = (canvasState?.nodes ?? [])
             .filter((node: CanvasNode): node is VideoCanvasNode => node.type === 'video' && Boolean((node as VideoCanvasNode).src))
+        const videoChromeEls = playableVideoNodes
+            .map(createVideoControlsChrome)
+            .filter((el): el is HTMLElement => Boolean(el))
 
         imageChromeViewportEl.replaceChildren(
             ...generatedImageNodes.map(createGeneratedImageChrome),
-            ...playableVideoNodes.map(createVideoPlayButtonChrome),
+            ...videoChromeEls,
         )
     }
 
@@ -5961,6 +5983,7 @@ export function createWorkspaceCanvas(options: WorkspaceCanvasOptions) {
             connectionManager?.destroy()
             connectionManager = null
             viewportBridge = null
+            destroyVideoControlInstances()
             imageChromeViewportEl?.remove()
             imageChromeViewportEl = null
             expandedGeneratedImageInfoNodeIds.clear()

--- a/services/web-ui/src/infographics/workspace/WorkspaceCanvas.ts
+++ b/services/web-ui/src/infographics/workspace/WorkspaceCanvas.ts
@@ -264,6 +264,7 @@ export function createWorkspaceCanvas(options: WorkspaceCanvasOptions) {
     let selectedEdgeId: string | null = null
     const expandedGeneratedImageInfoNodeIds: Set<string> = new Set()
     const videoControlInstances: Map<string, VideoControlsInstance> = new Map()
+    const videoControlsHideTimers: Map<string, number> = new Map()
     let resizingNodeId: string | null = null
     let draggingNodeId: string | null = null
     let selectionRectEl: HTMLDivElement | null = null
@@ -1117,9 +1118,14 @@ export function createWorkspaceCanvas(options: WorkspaceCanvasOptions) {
         return chromeEl
     }
 
-    // Shared SVG control bar for completed video nodes. PIXI owns the pixels;
-    // this chrome only drives the same hidden HTMLVideoElement that videoNodeHandler
-    // samples as a texture.
+    // Video chrome for completed video nodes: the actual <video> shown on the node
+    // PLUS the SVG control bar, both in the transform-synced chrome layer (above
+    // the PIXI poster). The element MUST be visibly composited — the browser
+    // throttles frame production for a <video> it isn't rendering, so sampling a
+    // hidden element into a PIXI texture renders blank on play (it only decodes
+    // when made visible, e.g. fullscreen). Showing the real element is what makes
+    // playback, PiP and fullscreen work; the opaque surface covers the redundant
+    // PIXI sprite behind it.
     function createVideoControlsChrome(node: VideoCanvasNode): HTMLElement | null {
         const videoEl = videoNodeHandler?.getVideoElement(node.nodeId)
         if (!videoEl) return null
@@ -1130,14 +1136,25 @@ export function createWorkspaceCanvas(options: WorkspaceCanvasOptions) {
             bottom: '10px',
             width: '100%',
             height: '44px',
-            pointerEvents: 'auto' as const,
         }
         const chromeEl = html`
             <div className="workspace-video-chrome" data=${{ videoChromeNodeId: node.nodeId }}>
+                <div className="workspace-video-surface"></div>
                 <div className="workspace-video-controls-host nopan" style=${controlsHostStyle}></div>
             </div>
         ` as HTMLElement
+
+        // Move the handler's <video> out of its off-screen host and onto the node
+        // so it actually renders (and plays).
+        const surface = chromeEl.querySelector('.workspace-video-surface') as HTMLDivElement
+        surface.appendChild(videoEl)
+
+        // Controls auto-hide: revealed on hover of the node body (the drag overlay,
+        // which lives in the DOM node shell) or of the bar itself.
         const host = chromeEl.querySelector('.workspace-video-controls-host') as HTMLDivElement
+        host.addEventListener('mouseenter', () => showVideoControls(node.nodeId))
+        host.addEventListener('mouseleave', () => hideVideoControls(node.nodeId))
+
         const svg = select(host)
             .append('svg')
             .attr('class', 'workspace-video-controls-svg')
@@ -1161,10 +1178,38 @@ export function createWorkspaceCanvas(options: WorkspaceCanvasOptions) {
     }
 
     function destroyVideoControlInstances(): void {
+        for (const timer of videoControlsHideTimers.values()) clearTimeout(timer)
+        videoControlsHideTimers.clear()
         for (const controls of videoControlInstances.values()) {
             controls.destroy()
         }
         videoControlInstances.clear()
+    }
+
+    // Show/hide the auto-hiding control bar for a video node. The hide is debounced
+    // so moving the pointer between the node body (drag overlay) and the bar — which
+    // live in different layers — doesn't flicker the controls off.
+    function showVideoControls(nodeId: string): void {
+        const pending = videoControlsHideTimers.get(nodeId)
+        if (pending !== undefined) {
+            clearTimeout(pending)
+            videoControlsHideTimers.delete(nodeId)
+        }
+        imageChromeViewportEl
+            ?.querySelector(`[data-video-chrome-node-id="${nodeId}"] .workspace-video-controls-host`)
+            ?.classList.add('is-visible')
+    }
+
+    function hideVideoControls(nodeId: string): void {
+        const pending = videoControlsHideTimers.get(nodeId)
+        if (pending !== undefined) clearTimeout(pending)
+        const timer = window.setTimeout(() => {
+            videoControlsHideTimers.delete(nodeId)
+            imageChromeViewportEl
+                ?.querySelector(`[data-video-chrome-node-id="${nodeId}"] .workspace-video-controls-host`)
+                ?.classList.remove('is-visible')
+        }, 140)
+        videoControlsHideTimers.set(nodeId, timer)
     }
 
     function syncGeneratedImageChrome(canvasState: CanvasState | null = currentCanvasState): void {
@@ -5581,6 +5626,11 @@ export function createWorkspaceCanvas(options: WorkspaceCanvasOptions) {
             { fileId: node.fileId }
         )
         dragOverlay.className = 'video-drag-overlay nopan'
+
+        // Reveal the (auto-hiding) control bar while the pointer is over the node.
+        // The bar lives in the chrome layer; this overlay covers the node body.
+        dragOverlay.addEventListener('mouseenter', () => showVideoControls(node.nodeId))
+        dragOverlay.addEventListener('mouseleave', () => hideVideoControls(node.nodeId))
 
         const togglePlayback = (event: Event) => {
             event.stopPropagation()

--- a/services/web-ui/src/infographics/workspace/WorkspaceCanvas.ts
+++ b/services/web-ui/src/infographics/workspace/WorkspaceCanvas.ts
@@ -939,8 +939,14 @@ export function createWorkspaceCanvas(options: WorkspaceCanvasOptions) {
             height: `${dimensions.height}px`,
         })
 
+        // The controls host is bottom-pinned (bottom:10px, height:44px) inside the
+        // node-sized chrome, and its SVG is 44px tall — so the bar sits at y=0 in
+        // that SVG, not pushed down the node. Keep the SVG viewBox width synced to
+        // the node so the bar spans the full width at any zoom/resize.
+        const svg = chromeEl.querySelector('.workspace-video-controls-svg') as SVGSVGElement | null
+        svg?.setAttribute('viewBox', `0 0 ${Math.max(1, dimensions.width)} 44`)
         const controls = videoControlInstances.get(chromeEl.dataset.videoChromeNodeId || '')
-        controls?.resize(0, Math.max(0, dimensions.height - 54), dimensions.width)
+        controls?.resize(0, 0, dimensions.width)
     }
 
     function updateGeneratedImageChromeLiveTransform(

--- a/services/web-ui/src/infographics/workspace/rendering/videoNodeHandler.test.ts
+++ b/services/web-ui/src/infographics/workspace/rendering/videoNodeHandler.test.ts
@@ -27,4 +27,12 @@ describe('videoNodeHandler — poster texture loading', () => {
 		// VideoSource — so the play path legitimately keeps that form.
 		expect(source).toContain('Texture.from(entry.videoElement')
 	})
+
+	it('exposes the attached video element and repaints when paused seeks complete', () => {
+		expect(source).toContain('getVideoElement: (nodeId: string) => entries.get(nodeId)?.videoElement ?? null')
+		expect(source).toContain('ensureHiddenVideoHost().appendChild(videoElement)')
+		expect(source).toContain("videoElement.addEventListener('seeking', handleSeeking)")
+		expect(source).toContain("videoElement.addEventListener('seeked', handleSeeked)")
+		expect(source).toContain('videoSource?.update?.()')
+	})
 })

--- a/services/web-ui/src/infographics/workspace/rendering/videoNodeHandler.ts
+++ b/services/web-ui/src/infographics/workspace/rendering/videoNodeHandler.ts
@@ -5,6 +5,7 @@ import type { CanvasNode, CanvasState, VideoCanvasNode } from '@lixpi/constants'
 import AuthService from '$src/services/auth-service.ts'
 import { settings } from '$src/settings.ts'
 import { decodeImageInWorker } from '$src/infographics/workspace/pixiImageDecoder.ts'
+import { html, applyStyle } from '$src/utils/domTemplates.ts'
 
 import type { MediaNodeHandler } from '$src/infographics/workspace/rendering/mediaNodeRegistry.ts'
 import type { WorldPosition } from '$src/infographics/workspace/pixiMediaLayerLogic.ts'
@@ -33,6 +34,9 @@ type VideoEntry = {
     sourceKey: string
     worldRect: { x: number; y: number; width: number; height: number }
     isPlaying: boolean
+    isActive: boolean
+    frameLoopRunning: boolean
+    removeEventListeners: () => void
 }
 
 export type VideoNodeHandlerOptions = {
@@ -47,14 +51,34 @@ export type VideoNodeHandlerControl = MediaNodeHandler<VideoCanvasNode> & {
     toggle: (nodeId: string) => Promise<void>
     isPlaying: (nodeId: string) => boolean
     hasEntry: (nodeId: string) => boolean
+    getVideoElement: (nodeId: string) => HTMLVideoElement | null
 }
 
 export function createVideoNodeHandler(options: VideoNodeHandlerOptions): VideoNodeHandlerControl {
     const { videoLayer, onIntrinsicSize, onRender } = options
     const entries = new Map<string, VideoEntry>()
     let destroyed = false
+    let hiddenVideoHost: HTMLDivElement | null = null
 
     const canHandle = (node: CanvasNode): node is VideoCanvasNode => node.type === 'video'
+
+    const ensureHiddenVideoHost = (): HTMLDivElement => {
+        if (hiddenVideoHost?.isConnected) return hiddenVideoHost
+
+        const hiddenVideoHostStyle = {
+            position: 'fixed' as const,
+            left: '0',
+            top: '0',
+            width: '1px',
+            height: '1px',
+            overflow: 'hidden' as const,
+            pointerEvents: 'none' as const,
+            zIndex: '-1',
+        }
+        hiddenVideoHost = html`<div className="workspace-hidden-video-host" style=${hiddenVideoHostStyle}></div>` as HTMLDivElement
+        document.body.appendChild(hiddenVideoHost)
+        return hiddenVideoHost
+    }
 
     const buildAuthenticatedUrl = async (url: string): Promise<string> => {
         if (!url) return ''
@@ -89,11 +113,17 @@ export function createVideoNodeHandler(options: VideoNodeHandlerOptions): VideoN
     }
 
     const scheduleVideoFrameLoop = (entry: VideoEntry): void => {
+        if (entry.frameLoopRunning) return
+        entry.frameLoopRunning = true
         const videoEl = entry.videoElement as HTMLVideoElement & {
             requestVideoFrameCallback?: (cb: () => void) => number
         }
         const tick = () => {
-            if (!entry.isPlaying || destroyed) return
+            if (!entry.isPlaying || destroyed) {
+                entry.frameLoopRunning = false
+                return
+            }
+            updateVideoTextureSource(entry)
             onRender?.()
             if (typeof videoEl.requestVideoFrameCallback === 'function') {
                 videoEl.requestVideoFrameCallback(tick)
@@ -106,6 +136,41 @@ export function createVideoNodeHandler(options: VideoNodeHandlerOptions): VideoN
         } else {
             requestAnimationFrame(tick)
         }
+    }
+
+    const updateVideoTextureSource = (entry: VideoEntry): void => {
+        const videoSource = entry.videoTexture?.source as { update?: () => void } | undefined
+        videoSource?.update?.()
+    }
+
+    const repaintVideoFrame = (entry: VideoEntry): void => {
+        if (!entry.videoTexture) return
+        updateVideoTextureSource(entry)
+        onRender?.()
+
+        const videoEl = entry.videoElement as HTMLVideoElement & {
+            requestVideoFrameCallback?: (cb: () => void) => number
+        }
+        if (typeof videoEl.requestVideoFrameCallback === 'function') {
+            videoEl.requestVideoFrameCallback(() => {
+                updateVideoTextureSource(entry)
+                onRender?.()
+            })
+        } else {
+            requestAnimationFrame(() => {
+                updateVideoTextureSource(entry)
+                onRender?.()
+            })
+        }
+    }
+
+    const activateVideoTexture = (entry: VideoEntry): void => {
+        if (!entry.videoTexture) {
+            entry.videoTexture = Texture.from(entry.videoElement as unknown as HTMLVideoElement)
+        }
+        entry.sprite.texture = entry.videoTexture
+        entry.isActive = true
+        repaintVideoFrame(entry)
     }
 
     const updateMediaSources = async (entry: VideoEntry, node: VideoCanvasNode): Promise<void> => {
@@ -178,19 +243,53 @@ export function createVideoNodeHandler(options: VideoNodeHandlerOptions): VideoN
             videoLayer.addChild(spriteMask)
             videoLayer.addChild(sprite)
 
-            const videoElement = document.createElement('video')
+            const videoElement = html`<video preload="metadata" playsinline crossorigin="anonymous"></video>` as HTMLVideoElement
+            const videoElementStyle = {
+                width: '100%',
+                height: '100%',
+                display: 'block',
+                objectFit: 'contain',
+            }
+            applyStyle(videoElement, videoElementStyle)
             videoElement.muted = true
             videoElement.playsInline = true
             videoElement.preload = 'metadata'
             videoElement.loop = true
             videoElement.crossOrigin = 'anonymous'
-            videoElement.addEventListener('loadedmetadata', () => {
+            ensureHiddenVideoHost().appendChild(videoElement)
+
+            let entryRef: VideoEntry
+            const handleLoadedMetadata = () => {
                 const vw = videoElement.videoWidth
                 const vh = videoElement.videoHeight
                 if (vw > 0 && vh > 0) {
                     onIntrinsicSize?.({ nodeId: node.nodeId, width: vw, height: vh })
                 }
-            })
+            }
+            const handlePlay = () => {
+                activateVideoTexture(entryRef)
+                entryRef.isPlaying = true
+                scheduleVideoFrameLoop(entryRef)
+            }
+            const handlePause = () => {
+                entryRef.isPlaying = false
+                repaintVideoFrame(entryRef)
+            }
+            const handleSeeking = () => {
+                activateVideoTexture(entryRef)
+                repaintVideoFrame(entryRef)
+            }
+            const handleSeeked = () => {
+                activateVideoTexture(entryRef)
+                repaintVideoFrame(entryRef)
+            }
+
+            videoElement.addEventListener('loadedmetadata', handleLoadedMetadata)
+            videoElement.addEventListener('play', handlePlay)
+            videoElement.addEventListener('pause', handlePause)
+            videoElement.addEventListener('ended', handlePause)
+            videoElement.addEventListener('seeking', handleSeeking)
+            videoElement.addEventListener('seeked', handleSeeked)
 
             entry = {
                 sprite,
@@ -202,7 +301,18 @@ export function createVideoNodeHandler(options: VideoNodeHandlerOptions): VideoN
                 sourceKey: '',
                 worldRect: { x, y, width: w, height: h },
                 isPlaying: false,
+                isActive: false,
+                frameLoopRunning: false,
+                removeEventListeners: () => {
+                    videoElement.removeEventListener('loadedmetadata', handleLoadedMetadata)
+                    videoElement.removeEventListener('play', handlePlay)
+                    videoElement.removeEventListener('pause', handlePause)
+                    videoElement.removeEventListener('ended', handlePause)
+                    videoElement.removeEventListener('seeking', handleSeeking)
+                    videoElement.removeEventListener('seeked', handleSeeked)
+                },
             }
+            entryRef = entry
             entries.set(node.nodeId, entry)
         }
 
@@ -247,6 +357,8 @@ export function createVideoNodeHandler(options: VideoNodeHandlerOptions): VideoN
         } catch {
             // Best-effort teardown.
         }
+        entry.removeEventListeners()
+        entry.videoElement.remove()
 
         videoLayer.removeChild(entry.sprite)
         videoLayer.removeChild(entry.spriteMask)
@@ -298,6 +410,8 @@ export function createVideoNodeHandler(options: VideoNodeHandlerOptions): VideoN
             remove(nodeId)
         }
         entries.clear()
+        hiddenVideoHost?.remove()
+        hiddenVideoHost = null
     }
 
     const play = async (nodeId: string): Promise<void> => {
@@ -307,11 +421,9 @@ export function createVideoNodeHandler(options: VideoNodeHandlerOptions): VideoN
 
         try {
             await entry.videoElement.play()
-            const videoTexture = Texture.from(entry.videoElement as unknown as HTMLVideoElement)
-            entry.videoTexture = videoTexture
-            entry.sprite.texture = videoTexture
-            entry.isPlaying = true
-            scheduleVideoFrameLoop(entry)
+            activateVideoTexture(entry)
+            entry.isPlaying = !entry.videoElement.paused
+            if (entry.isPlaying) scheduleVideoFrameLoop(entry)
         } catch (e) {
             console.warn('[videoNodeHandler] play failed', e)
         }
@@ -322,9 +434,7 @@ export function createVideoNodeHandler(options: VideoNodeHandlerOptions): VideoN
         if (!entry) return
         try { entry.videoElement.pause() } catch { /* noop */ }
         entry.isPlaying = false
-        if (entry.posterTexture) {
-            entry.sprite.texture = entry.posterTexture
-        }
+        if (entry.isActive) repaintVideoFrame(entry)
         onRender?.()
     }
 
@@ -346,5 +456,6 @@ export function createVideoNodeHandler(options: VideoNodeHandlerOptions): VideoN
         toggle,
         isPlaying: (nodeId: string) => entries.get(nodeId)?.isPlaying ?? false,
         hasEntry: (nodeId: string) => entries.has(nodeId),
+        getVideoElement: (nodeId: string) => entries.get(nodeId)?.videoElement ?? null,
     }
 }

--- a/services/web-ui/src/infographics/workspace/rendering/videoNodeHandler.ts
+++ b/services/web-ui/src/infographics/workspace/rendering/videoNodeHandler.ts
@@ -171,6 +171,12 @@ export function createVideoNodeHandler(options: VideoNodeHandlerOptions): VideoN
         if (node.posterSrc) {
             try {
                 const posterSrc = await buildAuthenticatedUrl(node.posterSrc)
+                // The element is shown directly on the canvas node (see
+                // createVideoControlsChrome) — a hidden element sampled only as a
+                // PIXI texture renders blank because the browser throttles frames
+                // for a video it isn't compositing. Give it a native poster so the
+                // at-rest frame shows before playback.
+                entry.videoElement.poster = posterSrc
                 // PIXI v8's Texture.from(urlString) does NOT fetch a remote URL — it
                 // only resolves already-loaded sources / cache aliases, so a poster
                 // URL renders as an empty texture (the dark colorRect shows through =

--- a/services/web-ui/src/infographics/workspace/rendering/videoNodeHandler.ts
+++ b/services/web-ui/src/infographics/workspace/rendering/videoNodeHandler.ts
@@ -115,9 +115,13 @@ export function createVideoNodeHandler(options: VideoNodeHandlerOptions): VideoN
     const scheduleVideoFrameLoop = (entry: VideoEntry): void => {
         if (entry.frameLoopRunning) return
         entry.frameLoopRunning = true
-        const videoEl = entry.videoElement as HTMLVideoElement & {
-            requestVideoFrameCallback?: (cb: () => void) => number
-        }
+        // Pump the texture from requestAnimationFrame, NOT requestVideoFrameCallback.
+        // The canvas <video> lives in an off-screen host, and the browser does not
+        // fire rVFC for a video it isn't compositing — so an rVFC-driven loop (and
+        // PIXI's own rVFC-based VideoSource auto-update) never pushes frames and the
+        // sprite stays stuck on its initial blank frame. rAF always fires; calling
+        // source.update() each tick re-uploads the current decoded frame while the
+        // muted clip plays.
         const tick = () => {
             if (!entry.isPlaying || destroyed) {
                 entry.frameLoopRunning = false
@@ -125,17 +129,9 @@ export function createVideoNodeHandler(options: VideoNodeHandlerOptions): VideoN
             }
             updateVideoTextureSource(entry)
             onRender?.()
-            if (typeof videoEl.requestVideoFrameCallback === 'function') {
-                videoEl.requestVideoFrameCallback(tick)
-            } else {
-                requestAnimationFrame(tick)
-            }
-        }
-        if (typeof videoEl.requestVideoFrameCallback === 'function') {
-            videoEl.requestVideoFrameCallback(tick)
-        } else {
             requestAnimationFrame(tick)
         }
+        requestAnimationFrame(tick)
     }
 
     const updateVideoTextureSource = (entry: VideoEntry): void => {
@@ -145,23 +141,19 @@ export function createVideoNodeHandler(options: VideoNodeHandlerOptions): VideoN
 
     const repaintVideoFrame = (entry: VideoEntry): void => {
         if (!entry.videoTexture) return
-        updateVideoTextureSource(entry)
-        onRender?.()
-
-        const videoEl = entry.videoElement as HTMLVideoElement & {
-            requestVideoFrameCallback?: (cb: () => void) => number
+        // Re-read the current frame now, then again across the next few animation
+        // frames. A seek/pause decodes asynchronously, and (as above) rVFC is
+        // unreliable for the off-screen element — so a short rAF burst guarantees
+        // the freshly-decoded frame reaches the texture even while paused.
+        let ticks = 0
+        const pump = () => {
+            if (destroyed || !entry.videoTexture) return
+            updateVideoTextureSource(entry)
+            onRender?.()
+            ticks += 1
+            if (ticks < 4) requestAnimationFrame(pump)
         }
-        if (typeof videoEl.requestVideoFrameCallback === 'function') {
-            videoEl.requestVideoFrameCallback(() => {
-                updateVideoTextureSource(entry)
-                onRender?.()
-            })
-        } else {
-            requestAnimationFrame(() => {
-                updateVideoTextureSource(entry)
-                onRender?.()
-            })
-        }
+        pump()
     }
 
     const activateVideoTexture = (entry: VideoEntry): void => {

--- a/services/web-ui/src/infographics/workspace/workspace-canvas.scss
+++ b/services/web-ui/src/infographics/workspace/workspace-canvas.scss
@@ -383,9 +383,32 @@
     pointer-events: none;
 }
 
+.workspace-video-surface {
+    position: absolute;
+    inset: 0;
+    overflow: hidden;
+    border-radius: var(--workspace-image-border-radius);
+    background: #1c1c1c;
+    pointer-events: none;
+
+    video {
+        width: 100%;
+        height: 100%;
+        display: block;
+        object-fit: contain;
+    }
+}
+
 .workspace-video-controls-host {
-    pointer-events: auto;
+    opacity: 0;
+    pointer-events: none;
     filter: drop-shadow(0 4px 14px rgba(0, 0, 0, 0.34));
+    transition: opacity 0.15s ease;
+
+    &.is-visible {
+        opacity: 1;
+        pointer-events: auto;
+    }
 }
 
 .workspace-video-controls-svg {

--- a/services/web-ui/src/infographics/workspace/workspace-canvas.scss
+++ b/services/web-ui/src/infographics/workspace/workspace-canvas.scss
@@ -378,59 +378,19 @@
     pointer-events: none;
 }
 
-// Centered click-to-play overlay for completed video nodes. The container spans
-// the node and is click-through; only the button takes pointer events.
 .workspace-video-chrome {
     position: absolute;
-    display: flex;
-    align-items: center;
-    justify-content: center;
     pointer-events: none;
 }
 
-.workspace-video-play-button {
+.workspace-video-controls-host {
     pointer-events: auto;
-    width: 68px;
-    height: 68px;
-    padding: 0;
-    border: none;
-    border-radius: 50%;
-    background: rgba(20, 22, 28, 0.55);
-    color: #fff;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    cursor: pointer;
-    backdrop-filter: blur(3px);
-    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.35);
-    transition: background 0.15s ease, opacity 0.2s ease, transform 0.15s ease;
+    filter: drop-shadow(0 4px 14px rgba(0, 0, 0, 0.34));
+}
 
-    .workspace-video-play-button-icon {
-        display: flex;
-        width: 34px;
-        height: 34px;
-
-        svg {
-            width: 100%;
-            height: 100%;
-            fill: currentColor;
-        }
-    }
-
-    &:hover {
-        background: rgba(20, 22, 28, 0.78);
-        transform: scale(1.05);
-    }
-
-    // While playing, fade the button so it doesn't cover the clip; hovering the
-    // center restores the pause control (an opacity-0 button still takes clicks).
-    &.is-playing {
-        opacity: 0;
-    }
-
-    &.is-playing:hover {
-        opacity: 1;
-    }
+.workspace-video-controls-svg {
+    display: block;
+    overflow: visible;
 }
 
 .workspace-generated-image-actions {

--- a/services/web-ui/src/infographics/workspace/workspace-canvas.test.ts
+++ b/services/web-ui/src/infographics/workspace/workspace-canvas.test.ts
@@ -387,16 +387,16 @@ describe('Workspace canvas — generated video canvas state', () => {
 		expectExcerptToContain(errorHandler, '...currentCanvasState', 'video error handler')
 	})
 
-	it('renders a click-to-play button for completed video nodes in the chrome layer', () => {
-		// The play button must live in the z-index-3 chrome layer (PIXI paints the
-		// video pixels above the DOM node shell) and be wired to the handler.
-		expectSourceToContain(ts, 'function createVideoPlayButtonChrome(node: VideoCanvasNode)')
-		expectSourceToContain(ts, 'className="workspace-video-play-button nopan"')
-		expectSourceToContain(ts, 'videoNodeHandler.toggle(node.nodeId)')
-		// Only completed videos (with a stored MP4 src) get the button.
+	it('renders shared SVG controls for completed video nodes in the chrome layer', () => {
+		// The controls must live in the z-index-3 chrome layer because PIXI paints
+		// the video pixels above the DOM node shell.
+		expectSourceToContain(ts, 'function createVideoControlsChrome(node: VideoCanvasNode)')
+		expectSourceToContain(ts, 'createVideoControls(svg, {')
+		expectSourceToContain(ts, 'videoNodeHandler?.getVideoElement(node.nodeId)')
+		// Only completed videos (with a stored MP4 src) get the controls.
 		expectSourceToContain(ts, "node.type === 'video' && Boolean((node as VideoCanvasNode).src)")
 		// The chrome geometry tracks the node during live drag/resize.
-		expectSourceToContain(ts, 'applyVideoPlayButtonGeometry(videoChromeEl, position, dimensions)')
+		expectSourceToContain(ts, 'applyVideoControlsGeometry(videoChromeEl, position, dimensions)')
 	})
 })
 

--- a/services/web-ui/src/svgIcons/index.ts
+++ b/services/web-ui/src/svgIcons/index.ts
@@ -94,6 +94,13 @@ export const pauseIcon = '<svg height="24" viewBox="0 0 24 24" width="24" xmlns=
 // circular background) for the canvas video node play/pause overlay.
 export const videoPlayGlyphIcon = '<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="M8 5v14l11-7z"/></svg>'
 export const videoPauseGlyphIcon = '<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="M6 5h4v14H6zm8 0h4v14h-4z"/></svg>'
+export const videoSkipBack10GlyphIcon = '<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="M11 7H7.8l2.1-2.1-1.4-1.4L4 8l4.5 4.5 1.4-1.4L7.8 9H11c2.8 0 5 2.2 5 5s-2.2 5-5 5a5 5 0 0 1-4.5-2.8l-1.8.9A7 7 0 1 0 11 7zm-1.7 5.1h1.4V17H9.3v-3.4l-.9.3-.3-1.1 1.2-.7zm2.4 2.4c0-1.6.8-2.5 2.1-2.5s2.1.9 2.1 2.5-.8 2.5-2.1 2.5-2.1-.9-2.1-2.5zm1.3 0c0 .9.3 1.4.8 1.4s.8-.5.8-1.4-.3-1.4-.8-1.4-.8.5-.8 1.4z"/></svg>'
+export const videoSkipForward10GlyphIcon = '<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="M13 7h3.2l-2.1-2.1 1.4-1.4L20 8l-4.5 4.5-1.4-1.4L16.2 9H13a5 5 0 1 0 4.5 7.2l1.8.9A7 7 0 1 1 13 7zm-4.7 5.1h1.4V17H8.3v-3.4l-.9.3-.3-1.1 1.2-.7zm2.4 2.4c0-1.6.8-2.5 2.1-2.5s2.1.9 2.1 2.5-.8 2.5-2.1 2.5-2.1-.9-2.1-2.5zm1.3 0c0 .9.3 1.4.8 1.4s.8-.5.8-1.4-.3-1.4-.8-1.4-.8.5-.8 1.4z"/></svg>'
+export const videoVolumeHighGlyphIcon = '<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="M4 9v6h4l5 4V5L8 9H4zm11.2-.6a5 5 0 0 1 0 7.2l1.4 1.4a7 7 0 0 0 0-10l-1.4 1.4zm2.8-2.8a9 9 0 0 1 0 12.8l1.4 1.4a11 11 0 0 0 0-15.6L18 5.6z"/></svg>'
+export const videoVolumeMutedGlyphIcon = '<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="M4 9v6h4l5 4V5L8 9H4zm12.6 1.4L15.2 12l1.4 1.6-1.4 1.4L13.8 13.4 12.4 15l-1.4-1.4 1.4-1.6-1.4-1.6L12.4 9l1.4 1.6L15.2 9l1.4 1.4z"/></svg>'
+export const videoPictureInPictureGlyphIcon = '<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="M3 5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2v9h-2V5H5v14h7v2H5a2 2 0 0 1-2-2V5zm11 10h7v6h-7v-6z"/></svg>'
+export const videoFullscreenEnterGlyphIcon = '<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="M5 5h6v2H7v4H5V5zm8 0h6v6h-2V7h-4V5zM5 13h2v4h4v2H5v-6zm12 0h2v6h-6v-2h4v-4z"/></svg>'
+export const videoFullscreenExitGlyphIcon = '<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="M9 9H5V7h6v6H9V9zm6 0v4h-2V7h6v2h-4zM5 15h4v-4h2v6H5v-2zm10-4v4h4v2h-6v-6h2z"/></svg>'
 
 // By MONO
 // https://www.flaticon.com/free-icon/file-share_18764184


### PR DESCRIPTION
## Summary

Adds a shared SVG video player controls component and wires it into generated-video playback in both workspace canvas video nodes and ProseMirror AI chat video nodes.

## Details

- Adds `services/web-ui/src/components/videoControls` with play/pause, skip, scrubber, playback speed, volume, picture-in-picture, fullscreen, resize, render, and destroy behavior.
- Replaces duplicated workspace overlay button behavior with shared controls backed by the supplied `HTMLVideoElement`.
- Adds AI generated video node controls and cleanup handling.
- Adds video control glyphs and targeted tests for the shared component plus workspace integration.
- Updates nearby README docs and the TypeScript style guide to prefer classes when they clarify cohesive state, behavior, lifecycle, or an imperative API.

Closes #211

## Validation

- `docker exec lixpi-web-ui ... pnpm test:run src/components/videoControls/videoControls.test.ts src/infographics/workspace/workspace-canvas.test.ts src/infographics/workspace/rendering/videoNodeHandler.test.ts`
- `git diff --check`