### PR TITLE
LIX-214 # Restore video bubble menu media actions

### DIFF
--- a/documentation/features/VIDEO-GENERATION.md
+++ b/documentation/features/VIDEO-GENERATION.md
@@ -311,7 +311,7 @@ Video reuses the workspace bucket and the same content-hash dedup as images.
 
 **Self-healing dedup (durability).** In line with the NATS Object Store durability work (PR #208 / LIX-207, see [WORKSPACE-EXPORT.md](WORKSPACE-EXPORT.md)), the hash-dedup short-circuit only returns "duplicate" after confirming the bytes are actually present (`getObjectInfo`). If a hash is registered in `workspace.files` but its bytes are missing, `storeWorkspaceVideo` re-stores them so the dangling reference self-heals instead of returning a URL to lost bytes. Object-store reads/deletes are open-only and never auto-create a bucket.
 
-**HTTP route** — `GET /api/videos/:workspaceId/:fileId` (`services/api/src/routes/video-routes.ts`) streams the MP4 with **HTTP Range support** (206 Partial Content) so the HTML `<video>` element can seek and scrub; it returns 404 when the object or bucket is missing. Authentication mirrors the image route (Bearer or `?token=`). The poster reuses `GET /api/images/...`.
+**HTTP routes** — `GET /api/videos/:workspaceId/:fileId` (`services/api/src/routes/video-routes.ts`) streams the MP4 with **HTTP Range support** (206 Partial Content) so the HTML `<video>` element can seek and scrub; it returns 404 when the object or bucket is missing. `POST /api/videos/:workspaceId` accepts a replacement/user-supplied video, stores it through the same workspace-video path, and best-effort extracts a poster as a normal workspace image. Authentication mirrors the image route (Bearer or `?token=`). The poster reuses `GET /api/images/...`.
 
 **Deletion** — `workspace.video.delete` (`video-subjects.ts`) removes the MP4 from the Object Store and its `workspace.files` entry. On the canvas, `canvasVideoLifecycle.ts` tracks `VideoCanvasNode`s across state commits and, when one disappears, fires `deleteVideo(fileId, workspaceId, posterFileId)` — the MP4 via the video subject and the poster via the image-delete subject (the poster is a normal image). Workspace deletion cleans up video Media Library items by branching on `item.kind`.
 
@@ -452,7 +452,7 @@ services/api/src/
 ├── services/
 │   ├── video-storage.ts              # storeWorkspaceVideo (self-healing dedup) + extractPosterFrame (ffmpeg)
 │   └── media-library-storage.ts      # copy/materialize/scope video helpers
-├── routes/video-routes.ts            # GET /api/videos/:ws/:fileId (Range)
+├── routes/video-routes.ts            # POST /api/videos/:ws + GET /api/videos/:ws/:fileId (Range)
 ├── NATS/subscriptions/
 │   ├── video-subjects.ts             # workspace.video.delete
 │   ├── ai-interaction-subjects.ts    # resolve videoModelMetaInfo + forward video params

--- a/documentation/features/WORKSPACE-FEATURE.md
+++ b/documentation/features/WORKSPACE-FEATURE.md
@@ -588,13 +588,14 @@ AI chat threads belonging to the current workspace.
 | `WORKSPACE.MEDIA_LIBRARY.CHANGE_SCOPE` | Copy a library object to a new scope and update metadata |
 | `WORKSPACE.MEDIA_LIBRARY.DELETE` | Delete a saved library item and its stored object(s) |
 
-### Image HTTP Endpoints
+### Media HTTP Endpoints
 
 | Endpoint | Method | Purpose |
 |----------|--------|---------|
 | `/api/images/:workspaceId` | POST | Upload image (multipart/form-data) |
 | `/api/images/:workspaceId/import-url` | POST | Fetch a public image URL into workspace Object Store before canvas insertion |
 | `/api/images/:workspaceId/:fileId` | GET | Serve image with auth token |
+| `/api/videos/:workspaceId` | POST | Upload replacement or user-supplied video, store its MP4, and best-effort extract a poster |
 | `/api/videos/:workspaceId/:fileId` | GET | Serve video with auth token and HTTP Range support |
 | `/api/media-library/items/:itemId/content` | GET | Serve an ACL-checked saved Media Library image preview or Range-capable video preview |
 | `/api/media-library/items/:itemId/poster` | GET | Serve an ACL-checked saved Media Library video poster |

--- a/services/api/src/routes/video-routes.test.ts
+++ b/services/api/src/routes/video-routes.test.ts
@@ -1,0 +1,112 @@
+'use strict'
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+    verify: vi.fn(),
+    getWorkspace: vi.fn(),
+    getObject: vi.fn(),
+    storeWorkspaceVideo: vi.fn(),
+    extractPosterFrame: vi.fn(),
+    storeWorkspaceImage: vi.fn(),
+}))
+
+vi.mock('@lixpi/debug-tools', () => ({ err: vi.fn() }))
+vi.mock('@lixpi/nats-service', () => ({
+    default: { getInstance: () => ({ getObject: mocks.getObject }) },
+}))
+vi.mock('../helpers/auth.ts', () => ({
+    jwtVerifier: { verify: mocks.verify },
+}))
+vi.mock('../models/workspace.ts', () => ({
+    default: { getWorkspace: mocks.getWorkspace },
+}))
+vi.mock('../services/video-storage.ts', () => ({
+    storeWorkspaceVideo: mocks.storeWorkspaceVideo,
+    extractPosterFrame: mocks.extractPosterFrame,
+}))
+vi.mock('../services/image-storage.ts', () => ({
+    storeWorkspaceImage: mocks.storeWorkspaceImage,
+}))
+
+import videoRoutes from './video-routes.ts'
+
+const findRoute = (path: string, method: string) => {
+    return (videoRoutes as any).stack
+        .find((layer: any) => layer.route?.path === path && layer.route?.methods?.[method])
+        .route
+}
+
+const createResponse = () => ({
+    status: vi.fn().mockReturnThis(),
+    json: vi.fn().mockReturnThis(),
+    setHeader: vi.fn(),
+    send: vi.fn().mockReturnThis(),
+    end: vi.fn().mockReturnThis(),
+})
+
+// =============================================================================
+// VIDEO UPLOAD ROUTE
+// =============================================================================
+
+describe('Video upload route', () => {
+    beforeEach(() => {
+        vi.clearAllMocks()
+        mocks.verify.mockResolvedValue({ decoded: { sub: 'user-1' } })
+        mocks.getWorkspace.mockResolvedValue({ workspaceId: 'workspace-1', files: [] })
+        mocks.storeWorkspaceVideo.mockResolvedValue({
+            fileId: 'video-file',
+            url: '/api/videos/workspace-1/video-file',
+            isDuplicate: false,
+            size: 12,
+            mimeType: 'video/mp4',
+        })
+        mocks.extractPosterFrame.mockResolvedValue(Buffer.from('poster'))
+        mocks.storeWorkspaceImage.mockResolvedValue({
+            fileId: 'poster-file',
+            url: '/api/images/workspace-1/poster-file',
+            isDuplicate: false,
+            size: 6,
+            mimeType: 'image/png',
+        })
+    })
+
+    it('stores uploaded video bytes and returns the generated poster reference', async () => {
+        const route = findRoute('/:workspaceId', 'post')
+        const handler = route.stack.at(-1).handle
+        const req: any = {
+            params: { workspaceId: 'workspace-1' },
+            file: {
+                buffer: Buffer.from('video-bytes'),
+                originalname: 'clip.mp4',
+                mimetype: 'video/mp4',
+            },
+        }
+        const res = createResponse()
+
+        await handler(req, res)
+
+        expect(mocks.storeWorkspaceVideo).toHaveBeenCalledWith({
+            workspaceId: 'workspace-1',
+            buffer: req.file.buffer,
+            originalName: 'clip.mp4',
+            mimeType: 'video/mp4',
+        })
+        expect(mocks.extractPosterFrame).toHaveBeenCalledWith(req.file.buffer)
+        expect(mocks.storeWorkspaceImage).toHaveBeenCalledWith({
+            workspaceId: 'workspace-1',
+            buffer: Buffer.from('poster'),
+            originalName: 'clip.mp4-poster.png',
+            mimeType: 'image/png',
+        })
+        expect(res.json).toHaveBeenCalledWith({
+            fileId: 'video-file',
+            url: '/api/videos/workspace-1/video-file',
+            isDuplicate: false,
+            size: 12,
+            mimeType: 'video/mp4',
+            posterFileId: 'poster-file',
+            posterUrl: '/api/images/workspace-1/poster-file',
+        })
+    })
+})

--- a/services/api/src/routes/video-routes.ts
+++ b/services/api/src/routes/video-routes.ts
@@ -1,6 +1,7 @@
 'use strict'
 
 import { Router } from 'express'
+import multer from 'multer'
 
 import NATS_Service from '@lixpi/nats-service'
 import { type DocumentFile } from '@lixpi/constants'
@@ -8,14 +9,12 @@ import { err } from '@lixpi/debug-tools'
 
 import { jwtVerifier } from '../helpers/auth.ts'
 import Workspace from '../models/workspace.ts'
+import { storeWorkspaceImage } from '../services/image-storage.ts'
+import { extractPosterFrame, storeWorkspaceVideo } from '../services/video-storage.ts'
 
-// Mirrors routes/image-routes.ts but for generated VEO videos. Two important
-// differences from the image route:
-//   1. Videos live in the same workspace Object Store bucket but are served
-//      with HTTP Range support so HTML5 <video> + PIXI VideoSource can seek
-//      without fetching the whole MP4 up front.
-//   2. There is no upload route — videos are produced server-side by the VEO
-//      provider and stored via services/video-storage.ts.
+// Mirrors routes/image-routes.ts for workspace videos. Videos live in the same
+// Object Store bucket as images, but are served with HTTP Range support so HTML5
+// <video> can seek without fetching the whole MP4 up front.
 //
 // Authentication mirrors the image route exactly so a tokenized URL passed to
 // a <video src=...> or PIXI VideoSource works the same way it does for <img>.
@@ -23,6 +22,22 @@ import Workspace from '../models/workspace.ts'
 const router = Router()
 
 const getWorkspaceBucketName = (workspaceId: string) => `workspace-${workspaceId}-files`
+const MAX_VIDEO_FILE_SIZE = 1024 * 1024 * 1024
+const ALLOWED_VIDEO_MIME_TYPES = ['video/mp4']
+
+const upload = multer({
+    storage: multer.memoryStorage(),
+    limits: {
+        fileSize: MAX_VIDEO_FILE_SIZE,
+    },
+    fileFilter: (_req, file, cb) => {
+        if (ALLOWED_VIDEO_MIME_TYPES.includes(file.mimetype)) {
+            cb(null, true)
+        } else {
+            cb(new Error(`Invalid content type. Allowed: ${ALLOWED_VIDEO_MIME_TYPES.join(', ')}`))
+        }
+    },
+})
 
 const authenticateRequest = async (req: any, res: any, next: any) => {
     const authHeader = req.headers.authorization
@@ -77,6 +92,57 @@ const validateWorkspaceAccess = async (req: any, res: any, next: any) => {
         return res.status(500).json({ error: 'Failed to validate workspace access' })
     }
 }
+
+// POST /api/videos/:workspaceId - Upload a replacement/user-supplied video.
+router.post(
+    '/:workspaceId',
+    authenticateRequest,
+    validateWorkspaceAccess,
+    upload.single('file'),
+    async (req: any, res: any) => {
+        const { workspaceId } = req.params
+        const file = req.file
+
+        if (!file) {
+            return res.status(400).json({ error: 'No file provided' })
+        }
+
+        try {
+            const video = await storeWorkspaceVideo({
+                workspaceId,
+                buffer: file.buffer,
+                originalName: file.originalname,
+                mimeType: file.mimetype,
+            })
+
+            let poster: { fileId: string; url: string } | null = null
+            const posterBuffer = await extractPosterFrame(file.buffer)
+            if (posterBuffer) {
+                poster = await storeWorkspaceImage({
+                    workspaceId,
+                    buffer: posterBuffer,
+                    originalName: `${file.originalname}-poster.png`,
+                    mimeType: 'image/png',
+                })
+            }
+
+            return res.json({
+                ...video,
+                posterFileId: poster?.fileId ?? '',
+                posterUrl: poster?.url ?? '',
+            })
+        } catch (e: any) {
+            err(`Video upload failed for workspace ${workspaceId}:`, e)
+            if (e?.message?.startsWith('Workspace not found')) {
+                return res.status(404).json({ error: 'Workspace not found' })
+            }
+            if (e?.message?.includes('NATS service unavailable')) {
+                return res.status(503).json({ error: 'Storage service unavailable' })
+            }
+            return res.status(500).json({ error: 'Failed to upload video' })
+        }
+    }
+)
 
 // GET /api/videos/:workspaceId/:fileId
 //

--- a/services/api/src/server.ts
+++ b/services/api/src/server.ts
@@ -184,7 +184,7 @@ app.use(cookieParser())
 // Image upload/download routes
 app.use('/api/images', imageRoutes)
 
-// Video download route (Range-capable for HTML5 <video> + PIXI VideoSource)
+// Video upload/download route (Range-capable for HTML5 <video> + PIXI VideoSource)
 app.use('/api/videos', videoRoutes)
 
 // Workspace export routes

--- a/services/web-ui/src/infographics/workspace/README.md
+++ b/services/web-ui/src/infographics/workspace/README.md
@@ -424,6 +424,8 @@ When an image node, video node, or edge is selected on the canvas, a bubble menu
 - **Delete** — removes the node and its associated edges from canvas state
 
 ### Video Node Actions
+- **Replace** — uploads a new video through `/api/videos/:workspaceId`, swaps the MP4/poster IDs on the existing node, and keeps the node in place
+- **Download** — downloads the stored MP4 through the Range-capable video route with `download=true`
 - **Add to Media Library** — saves a completed stored video and poster as independent library copies
 - **Connect to node** — starts the same menu-driven graph connection flow as images
 - **Extend video in new thread** — creates a new AI chat thread seeded with the selected video as VEO extension input

--- a/services/web-ui/src/infographics/workspace/WorkspaceCanvas.ts
+++ b/services/web-ui/src/infographics/workspace/WorkspaceCanvas.ts
@@ -447,18 +447,19 @@ export function createWorkspaceCanvas(options: WorkspaceCanvasOptions) {
                 selectNode(null)
                 commitCanvasState({ ...currentCanvasState, nodes: updatedNodes, edges: updatedEdges })
             },
-            onDownloadImage: (nodeId) => {
+            onDownloadMedia: (nodeId) => {
                 const node = currentCanvasState?.nodes.find((candidate: CanvasNode) => candidate.nodeId === nodeId)
-                if (!node || node.type !== 'image') return
+                if (!node || (node.type !== 'image' && node.type !== 'video')) return
 
                 void (async () => {
                     const API_BASE_URL = import.meta.env.VITE_API_URL || ''
                     const token = await AuthService.getTokenSilently()
                     const strippedSrc = node.src.replace(/[?&]token=[^&]+/, '')
-                    const isStoredImage = strippedSrc.startsWith('/api/') || (strippedSrc.startsWith('http') && strippedSrc.includes('/api/images/'))
-                    const resolvedSrc = isStoredImage ? `/api/images/${workspaceId}/${node.fileId}` : strippedSrc
-                    const imageSrc = buildImageSrc(resolvedSrc, API_BASE_URL, token || false)
-                    await downloadImage(imageSrc, {
+                    const route = node.type === 'video' ? 'videos' : 'images'
+                    const isStoredMedia = strippedSrc.startsWith('/api/') || (strippedSrc.startsWith('http') && strippedSrc.includes(`/api/${route}/`))
+                    const resolvedSrc = isStoredMedia ? `/api/${route}/${workspaceId}/${node.fileId}` : strippedSrc
+                    const mediaSrc = buildImageSrc(resolvedSrc, API_BASE_URL, token || false)
+                    await downloadImage(mediaSrc, {
                         getAuthToken: async () => {
                             const freshToken = await AuthService.getTokenSilently()
                             return freshToken || ''
@@ -466,12 +467,17 @@ export function createWorkspaceCanvas(options: WorkspaceCanvasOptions) {
                     })
                 })()
             },
-            onReplaceImage: (nodeId) => {
-                const input = html`<input type="file" accept="image/*" style=${{ display: 'none' }}></input>` as HTMLInputElement
+            onReplaceMedia: (nodeId) => {
+                const node = currentCanvasState?.nodes.find((candidate: CanvasNode) => candidate.nodeId === nodeId)
+                if (!node || (node.type !== 'image' && node.type !== 'video')) return
+
+                const accept = node.type === 'video' ? 'video/mp4' : 'image/*'
+                const expectedMimePrefix = node.type === 'video' ? 'video/' : 'image/'
+                const input = html`<input type="file" accept=${accept} style=${{ display: 'none' }}></input>` as HTMLInputElement
                 input.addEventListener('change', async () => {
                     const file = input.files?.[0]
                     input.remove()
-                    if (!file || !file.type.startsWith('image/')) return
+                    if (!file || !file.type.startsWith(expectedMimePrefix)) return
 
                     const API_BASE_URL = import.meta.env.VITE_API_URL || ''
                     const token = await AuthService.getTokenSilently()
@@ -480,7 +486,8 @@ export function createWorkspaceCanvas(options: WorkspaceCanvasOptions) {
                     const formData = new FormData()
                     formData.append('file', file)
 
-                    const response = await fetch(`${API_BASE_URL}/api/images/${workspaceId}`, {
+                    const route = node.type === 'video' ? 'videos' : 'images'
+                    const response = await fetch(`${API_BASE_URL}/api/${route}/${workspaceId}`, {
                         method: 'POST',
                         headers: { 'Authorization': `Bearer ${token}` },
                         body: formData
@@ -488,16 +495,43 @@ export function createWorkspaceCanvas(options: WorkspaceCanvasOptions) {
 
                     if (!response.ok) return
 
-                    const data = await response.json()
+                    const data = await response.json() as {
+                        fileId?: string
+                        url?: string
+                        posterFileId?: string
+                        posterUrl?: string
+                    }
+                    if (!data.fileId || !data.url) return
+
                     const newSrc = `${API_BASE_URL}${data.url}?token=${encodeURIComponent(token)}`
+                    const newPosterSrc = data.posterUrl
+                        ? `${API_BASE_URL}${data.posterUrl}?token=${encodeURIComponent(token)}`
+                        : ''
 
                     // Update canvas state; the PIXI sprite replaces its texture.
                     if (!currentCanvasState) return
                     const updatedNodes = currentCanvasState.nodes.map((n: CanvasNode) => {
-                        if (n.nodeId !== nodeId || n.type !== 'image') return n
-                        return { ...n, fileId: data.fileId, src: newSrc } as ImageCanvasNode
+                        if (n.nodeId !== nodeId) return n
+                        if (n.type === 'image' && node.type === 'image') {
+                            return { ...n, fileId: data.fileId, src: newSrc } as ImageCanvasNode
+                        }
+                        if (n.type === 'video' && node.type === 'video') {
+                            return {
+                                ...n,
+                                fileId: data.fileId,
+                                posterFileId: data.posterFileId ?? '',
+                                frameFileId: undefined,
+                                src: newSrc,
+                                posterSrc: newPosterSrc,
+                                descriptor: data.posterFileId ? buildAnalyzingDescriptor() : n.descriptor,
+                            } as VideoCanvasNode
+                        }
+                        return n
                     })
                     commitCanvasState({ ...currentCanvasState, nodes: updatedNodes })
+                    if (node.type === 'video' && data.posterFileId) {
+                        void analyzeUploadedMedia(nodeId, data.posterFileId)
+                    }
                 })
                 document.body.appendChild(input)
                 input.click()

--- a/services/web-ui/src/infographics/workspace/canvasBubbleMenuItems.test.ts
+++ b/services/web-ui/src/infographics/workspace/canvasBubbleMenuItems.test.ts
@@ -11,11 +11,12 @@ function createCallbacks() {
         onDeleteEdge: vi.fn(),
         onChangeConnectorCurve: vi.fn(),
         onAskAi: vi.fn(),
-        onDownloadImage: vi.fn(),
-        onReplaceImage: vi.fn(),
+        onDownloadMedia: vi.fn(),
+        onReplaceMedia: vi.fn(),
         onAddToMediaLibrary: vi.fn(),
         canAddToMediaLibrary: vi.fn(() => true),
         onTriggerConnection: vi.fn(),
+        onExtendVideoInNewThread: vi.fn(),
         onHide: vi.fn(),
     }
 }
@@ -59,6 +60,12 @@ describe('buildCanvasBubbleMenuItems — structure', () => {
         expect(items[3].context).toEqual([CANVAS_IMAGE_CONTEXT, CANVAS_VIDEO_CONTEXT])
     })
 
+    it('the Replace and Download buttons are shared between image and video contexts', () => {
+        const { items } = buildCanvasBubbleMenuItems(callbacks)
+        expect(items[1].context).toEqual([CANVAS_IMAGE_CONTEXT, CANVAS_VIDEO_CONTEXT])
+        expect(items[2].context).toEqual([CANVAS_IMAGE_CONTEXT, CANVAS_VIDEO_CONTEXT])
+    })
+
     it('the two video-only items follow the image items', () => {
         const { items } = buildCanvasBubbleMenuItems(callbacks)
         expect(items[6].context).toEqual([CANVAS_VIDEO_CONTEXT])
@@ -76,14 +83,14 @@ describe('buildCanvasBubbleMenuItems — structure', () => {
         expect(items[0].element.getAttribute('title')).toBe('Ask AI')
     })
 
-    it('second item is Replace image button', () => {
+    it('second item is Replace media button', () => {
         const { items } = buildCanvasBubbleMenuItems(callbacks)
-        expect(items[1].element.getAttribute('title')).toBe('Replace image')
+        expect(items[1].element.getAttribute('title')).toBe('Replace media')
     })
 
-    it('third item is Download button', () => {
+    it('third item is Download media button', () => {
         const { items } = buildCanvasBubbleMenuItems(callbacks)
-        expect(items[2].element.getAttribute('title')).toBe('Download image')
+        expect(items[2].element.getAttribute('title')).toBe('Download media')
     })
 
     it('fourth item is Add to Media Library button', () => {
@@ -183,14 +190,14 @@ describe('buildCanvasBubbleMenuItems — click behavior', () => {
         expect(callbacks.onHide).not.toHaveBeenCalled()
     })
 
-    it('Download fires onDownloadImage + onHide with active node', () => {
+    it('Download fires onDownloadMedia + onHide with active node', () => {
         const callbacks = createCallbacks()
         const { items, setActiveNodeId } = buildCanvasBubbleMenuItems(callbacks)
         setActiveNodeId('img-3')
 
         items[2].element.click()
 
-        expect(callbacks.onDownloadImage).toHaveBeenCalledWith('img-3')
+        expect(callbacks.onDownloadMedia).toHaveBeenCalledWith('img-3')
         expect(callbacks.onHide).toHaveBeenCalledOnce()
         expect(callbacks.onDeleteNode).not.toHaveBeenCalled()
     })
@@ -201,8 +208,29 @@ describe('buildCanvasBubbleMenuItems — click behavior', () => {
 
         items[2].element.click()
 
-        expect(callbacks.onDownloadImage).not.toHaveBeenCalled()
+        expect(callbacks.onDownloadMedia).not.toHaveBeenCalled()
         expect(callbacks.onHide).not.toHaveBeenCalled()
+    })
+
+    it('Replace fires onReplaceMedia + onHide with active node', () => {
+        const callbacks = createCallbacks()
+        const { items, setActiveNodeId } = buildCanvasBubbleMenuItems(callbacks)
+        setActiveNodeId('media-3')
+
+        items[1].element.click()
+
+        expect(callbacks.onReplaceMedia).toHaveBeenCalledWith('media-3')
+        expect(callbacks.onHide).toHaveBeenCalledOnce()
+    })
+
+    it('Video context keeps Replace and Download visible', () => {
+        const callbacks = createCallbacks()
+        const { items } = buildCanvasBubbleMenuItems(callbacks)
+        const videoItems = items.filter((item) => item.context.includes(CANVAS_VIDEO_CONTEXT))
+        const titles = videoItems.map((item) => item.element.getAttribute('title'))
+
+        expect(titles).toContain('Replace media')
+        expect(titles).toContain('Download media')
     })
 
     it('Connect fires onTriggerConnection + onHide on click with active node', () => {

--- a/services/web-ui/src/infographics/workspace/canvasBubbleMenuItems.ts
+++ b/services/web-ui/src/infographics/workspace/canvasBubbleMenuItems.ts
@@ -1,10 +1,10 @@
 // =============================================================================
 // CANVAS BUBBLE MENU ITEMS
 //
-// Menu items for the workspace canvas bubble menu. Supports image nodes
-// (Delete, Download, Ask AI, save, Connect), video nodes (Extend in new
-// thread, Connect, Delete), and edge connections (Delete). Framework-agnostic
-// — uses only DOM and callbacks. No ProseMirror imports.
+// Menu items for the workspace canvas bubble menu. Supports image nodes and
+// video nodes (Delete, Download, Replace, save, Connect), plus edge connections
+// (Delete). Framework-agnostic — uses only DOM and callbacks. No ProseMirror
+// imports.
 // =============================================================================
 
 import { createEl, applyStyle } from '$src/utils/domTemplates.ts'
@@ -29,8 +29,8 @@ type CanvasBubbleMenuCallbacks = {
     onDeleteEdge: (edgeId: string) => void
     onChangeConnectorCurve: (edgeId: string) => void
     onAskAi: (nodeId: string) => void
-    onDownloadImage: (nodeId: string) => void
-    onReplaceImage: (nodeId: string) => void
+    onDownloadMedia: (nodeId: string) => void
+    onReplaceMedia: (nodeId: string) => void
     onAddToMediaLibrary: (nodeId: string) => void
     canAddToMediaLibrary: (nodeId: string | null) => boolean
     onTriggerConnection: (nodeId: string) => void
@@ -92,11 +92,11 @@ export function buildCanvasBubbleMenuItems(callbacks: CanvasBubbleMenuCallbacks)
 
     const downloadButton = createCanvasButton({
         icon: downloadIcon,
-        title: 'Download image',
+        title: 'Download media',
         iconSize: 16,
         onClick: () => {
             if (activeNodeId) {
-                callbacks.onDownloadImage(activeNodeId)
+                callbacks.onDownloadMedia(activeNodeId)
                 callbacks.onHide()
             }
         },
@@ -104,11 +104,11 @@ export function buildCanvasBubbleMenuItems(callbacks: CanvasBubbleMenuCallbacks)
 
     const replaceButton = createCanvasButton({
         icon: downloadIcon,
-        title: 'Replace image',
+        title: 'Replace media',
         iconSize: 16,
         onClick: () => {
             if (activeNodeId) {
-                callbacks.onReplaceImage(activeNodeId)
+                callbacks.onReplaceMedia(activeNodeId)
                 callbacks.onHide()
             }
         },
@@ -209,8 +209,8 @@ export function buildCanvasBubbleMenuItems(callbacks: CanvasBubbleMenuCallbacks)
 
     const items: BubbleMenuItem[] = [
         { element: askAiButton, context: [CANVAS_IMAGE_CONTEXT] },
-        { element: replaceButton, context: [CANVAS_IMAGE_CONTEXT] },
-        { element: downloadButton, context: [CANVAS_IMAGE_CONTEXT] },
+        { element: replaceButton, context: [CANVAS_IMAGE_CONTEXT, CANVAS_VIDEO_CONTEXT] },
+        { element: downloadButton, context: [CANVAS_IMAGE_CONTEXT, CANVAS_VIDEO_CONTEXT] },
         {
             element: addToLibraryButton,
             context: [CANVAS_IMAGE_CONTEXT, CANVAS_VIDEO_CONTEXT],

--- a/services/web-ui/src/infographics/workspace/workspace-canvas.test.ts
+++ b/services/web-ui/src/infographics/workspace/workspace-canvas.test.ts
@@ -2390,15 +2390,19 @@ describe('video generation — canvas + plugin source shape', () => {
 		expectSourceNotToContain(ts, 'video-dot-bounce')
 	})
 
-	it('wires the bubble menu for video nodes (Extend + Connect + Delete)', () => {
-		// Phase 6: video nodes share Connect with image, but get a dedicated
-		// Extend-in-new-thread entry and a video-specific Delete.
+	it('wires the bubble menu for video nodes (Replace + Download + Extend + Connect + Delete)', () => {
+		// Video nodes share Replace, Download, Add to Media Library, and Connect
+		// with images, while keeping dedicated Extend and Delete entries.
 		const bubbleMenuTs = readSourceFile('canvasBubbleMenuItems.ts')
 		expectSourceToContain(ts, "import { buildCanvasBubbleMenuItems, CANVAS_IMAGE_CONTEXT, CANVAS_VIDEO_CONTEXT")
 		expectSourceToContain(ts, "node.type !== 'image' && node.type !== 'video'")
 		expectSourceToContain(ts, "node.type === 'video' ? CANVAS_VIDEO_CONTEXT : CANVAS_IMAGE_CONTEXT")
+		expectSourceToContain(ts, 'onDownloadMedia: (nodeId) => {')
+		expectSourceToContain(ts, 'onReplaceMedia: (nodeId) => {')
 		expectSourceToContain(ts, 'onExtendVideoInNewThread: async (nodeId) => {')
 		expectSourceToContain(bubbleMenuTs, "export const CANVAS_VIDEO_CONTEXT = 'canvasVideo'")
+		expectSourceToContain(bubbleMenuTs, "title: 'Replace media'")
+		expectSourceToContain(bubbleMenuTs, "title: 'Download media'")
 		expectSourceToContain(bubbleMenuTs, "title: 'Extend video in new thread'")
 		expectSourceToContain(bubbleMenuTs, "title: 'Delete video'")
 		expectSourceToContain(bubbleMenuTs, 'context: [CANVAS_IMAGE_CONTEXT, CANVAS_VIDEO_CONTEXT]')


### PR DESCRIPTION
## Summary

Restores the missing video canvas bubble menu media actions and keeps image/video behavior shared where the action is media-generic.

## What Changed

- Restored Replace and Download actions for video canvas nodes.
- Made video downloads resolve through `/api/videos/:workspaceId/:fileId` with the existing download utility.
- Added `POST /api/videos/:workspaceId` for MP4 replacement uploads with best-effort poster extraction.
- Swaps video MP4/poster IDs in canvas state after replacement and re-runs media analysis from the new poster.
- Added regression coverage for the video menu and upload route.
- Updated workspace/video generation docs for the restored behavior.

## Root Cause

The video bubble menu context only included video-specific actions and shared Add to Media Library / Connect. The media-generic Replace and Download buttons were still scoped to image nodes, so completed videos lost those actions.

## Verification

- `docker exec lixpi-web-ui pnpm test:run -- src/infographics/workspace/canvasBubbleMenuItems.test.ts src/infographics/workspace/workspace-canvas.test.ts`
- `docker exec lixpi-api pnpm test:run`

Closes #214