### PR TITLE
LIX-213 # Add official Seedance 2.0 video generation support via BytePlus ModelArk

### DIFF
--- a/documentation/media-generation/VIDEO-GENERATION.md
+++ b/documentation/media-generation/VIDEO-GENERATION.md
@@ -110,7 +110,7 @@ The video fields mirror the image fields and use the same **"keep if undefined"*
 | `videoReferenceImages` | `string[]` | VLM-selected style/content references (≤3). |
 | `videoSourceForExtension` | `string` | `nats-obj://…` URI of a source MP4 to extend (multi-turn). |
 | `generatedVideos` | `string[]` | Resulting video URLs/ids. |
-| `videoUsage` | `VideoUsage` | `{ durationSeconds, resolution, aspectRatio }` for billing. |
+| `videoUsage` | `VideoUsage` | `{ durationSeconds, resolution, aspectRatio }` for billing, plus optional `completionTokens` / `totalTokens` for token-metered providers (Seedance). |
 
 ## The VEO Provider Path
 
@@ -130,6 +130,34 @@ The video fields mirror the image fields and use the same **"keep if undefined"*
 **Submit + poll.** `client.models.generateVideos(...)` returns an operation; the provider loops on `client.operations.getVideosOperation(...)` every `VEO_POLL_INTERVAL_MS`, publishing a `VIDEO_GENERATING` keepalive each tick and honoring the abort signal, until `operation.done`.
 
 **Download.** `fetchVideoBytes` uses inline `videoBytes` (base64) when present, otherwise `client.files.download(...)` to a temp file. `VideoPublisher.complete` validates the MP4 (`ftyp` box) before storing; non-MP4 bytes throw.
+
+## Seedance 2.0 via BytePlus ModelArk
+
+`BytePlusProvider` ([`byteplus-provider.ts`](../../services/api/src/llm/providers/byteplus-provider.ts)) is a first-party peer of `GoogleProvider` that produces video through **BytePlus ModelArk's** official Seedance 2.0 API. It is **video-only** — text streaming throws a capability error — and runs **only** when `enableVideoGeneration && /seedance/i.test(modelVersion)`. Everything else is reused unchanged: the same `generate_video` tool, post-stream router, VLM resolver, video NATS lifecycle, workspace storage, ffmpeg posters, and `VideoCanvasNode`. The router selects it exactly like VEO (`createTransient(instanceKey, 'BytePlus')`).
+
+**Official route** (overridable via `BYTEPLUS_ARK_BASE_URL`):
+
+- Create: `POST https://ark.ap-southeast.bytepluses.com/api/v3/contents/generations/tasks`
+- Retrieve: `GET …/contents/generations/tasks/{id}`
+- Auth: `Authorization: Bearer $ARK_API_KEY` (or `BYTEPLUS_ARK_API_KEY`)
+- Model ids: `dreamina-seedance-2-0-260128`, `dreamina-seedance-2-0-fast-260128` (China/Volcengine Ark uses `doubao-*` ids instead).
+
+The typed REST client lives in [`byteplus-video-types.ts`](../../services/api/src/llm/providers/byteplus-video-types.ts) (`createVideoGenerationTask` / `retrieveVideoGenerationTask` / `downloadVideo` over `fetch` + `AbortSignal`, preserving ModelArk `error.code`), with pure `buildSeedanceContent` and an injectable `pollVideoGenerationTask`.
+
+**Input precedence.** `content[]` is text-first, then ONE input family — first-frame and reference are mutually exclusive in Seedance, matching VEO:
+
+| Priority | Input (state field) | ModelArk `content[]` item | Notes |
+|----------|--------------------|---------------------------|-------|
+| 1 | Extension (`videoSourceForExtension`) | — | **Rejected** with a capability error — no provider-fetchable asset handoff yet. Use VEO for extension. |
+| 2 | First frame (`videoFirstFrameImage`) | `image_url` `role: first_frame` | Image-to-video. |
+| 3 | Reference images (`videoReferenceImages`, ≤9) | `image_url` `role: reference_image` | Already capped to the provider budget by the router. |
+| 4 | Text-to-video | — | None of the above set. |
+
+Inputs are base64 data URLs (the resolver already supplies them); private `nats-obj://` URIs are refused before submit so they never reach ModelArk.
+
+**Submit + poll + store.** Publish `VIDEO_PENDING` on accept; poll `GET …/tasks/{id}` every `BYTEPLUS_VIDEO_POLL_INTERVAL_MS` (default = `VEO_POLL_INTERVAL_MS`, 10s), publishing a `VIDEO_GENERATING` keepalive on each non-terminal poll, until `succeeded`/`failed`/`cancelled`/`expired`. On success, **download `content.video_url` immediately** — ModelArk output URLs are cleaned after 24 hours — then `VideoPublisher.complete` validates the MP4 (`ftyp`), extracts a poster + mid-frame, stores, and publishes `VIDEO_COMPLETE`. Vendor token usage (`usage.total_tokens`) flows into `videoUsage` for billing.
+
+**Prompt phrasing.** The shared final-prompt wrapper (`buildVideoModelPrompt`) selects a per-provider profile: Seedance uses positive/affirmative phrasing and **omits VEO's inline `Negative prompt:` line** (negative tokens backfire on Seedance — the model renders them). VEO's emitted prompt is byte-identical. The shared wrapper + profiles are covered in [AI Generation Pipeline](../platform/AI-GENERATION-PIPELINE.md).
 
 ## VLM Reference Mapping
 
@@ -228,12 +256,14 @@ Completed playback is **browser-composited**: a finished video plays inline thro
 
 The three frontend video dropdowns (`createGenericVideoAspectDropdown` / `…Resolution…` / `…Duration…` in `aiControls.ts`) read their options straight off the selected model's `videoAspectRatios` / `videoResolutions` / `videoDurations`. The video-model dropdown filters models by the `video_generation` modality and is excluded from the text-model list. Because the current dropdown model is flat, synchronization publishes conservative VEO options that avoid invalid combinations instead of letting the provider silently rewrite the request.
 
+**BytePlus (Seedance) static injection.** BytePlus has no model-list API in the repo, so `synchronizeBytePlusModels` injects two **static** entries (mirroring the Stability path): `dreamina-seedance-2-0-260128` and `dreamina-seedance-2-0-fast-260128`, with `SEEDANCE_*` option lists (ratios `16:9`/`4:3`/`1:1`/`3:4`/`9:16`/`21:9`, resolutions `480p`/`720p`, durations `4s`–`15s`), `videoMaxReferenceImages: 9`, and **token pricing** (`{ measuringUnit: 'tokens', pricePer: '1000000', price }` — `$4.30`/1M standard, `$3.30`/1M fast). `videoMaxReferenceImages` is a new `AiModel` field read by the router and the branch resolver to cap references per provider (VEO 3, Seedance 9; absent → 3). v1 ships 480p/720p only — the official ceiling above 720p is unconfirmed.
+
 ## Usage Metering
 
-`reportVideoUsage` ([`usage-reporter.ts`](../../services/api/src/llm/usage/usage-reporter.ts)) computes per-second video cost from the selected model's pricing metadata and returns a `VideoUsageReport`.
+`reportVideoUsage` ([`usage-reporter.ts`](../../services/api/src/llm/usage/usage-reporter.ts)) branches on `pricing.video.measuringUnit`: `'seconds'` computes per-second cost (VEO, byte-identical to before), `'tokens'` computes `total_tokens × price / pricePer` (Seedance — `total_tokens` threaded from the ModelArk task response through `videoUsage`). It returns a `VideoUsageReport`.
 
 {% callout type="warning" %}
-Usage reports are computed and logged today; they are not published to NATS yet. Per-second billing reconciliation also depends on finalizing the placeholder VEO prices.
+Usage reports are computed and logged today; they are not published to NATS yet. Per-second VEO prices are still placeholders to reconcile; Seedance token pricing follows the Dreamina resource packs.
 {% /callout %}
 
 ## Media Library for Video
@@ -260,7 +290,7 @@ A completed `VideoCanvasNode` can be continued: the bubble-menu **Extend video i
 | Payload | base64 PNG/JPEG | multi-MB MP4 (validated by `ftyp`) |
 | Prompt display | `>` quote block | `<video_prompt>…</video_prompt>` XML tags |
 | Workflow node | `validateImagePrompt` → `executeImageGeneration` | `executeVideoGeneration` (no validate step) |
-| Pricing | per-image tiers | per-second of video |
+| Pricing | per-image tiers | per-second (VEO) or per-token (Seedance), via `pricing.video.measuringUnit` |
 | HTTP route | whole-object GET | Range-capable GET (seeking) |
 | Canvas playback | static texture | PIXI poster behind browser-composited `<video>` + SVG controls |
 | Model selection | auto-selects a default | opt-in (placeholder until chosen) |
@@ -277,9 +307,11 @@ services/api/src/
 │   ├── providers/
 │   │   ├── base-provider.ts          # routeAfterStream, executeVideoGeneration, VideoPublisher wiring
 │   │   ├── google-provider.ts        # runVeoGeneration (submit/poll/download), VEO config + input precedence
+│   │   ├── byteplus-provider.ts      # runSeedanceGeneration (ModelArk create/poll/download), video-only
+│   │   ├── byteplus-video-types.ts   # typed ModelArk REST client + buildSeedanceContent + pollVideoGenerationTask
 │   │   ├── anthropic-provider.ts     # generate_video injection + extraction
 │   │   ├── openai-provider.ts        # generate_video injection + extraction
-│   │   └── provider-registry.ts      # runVideoRouter dep, storeWorkspaceVideo
+│   │   └── provider-registry.ts      # runVideoRouter dep, storeWorkspaceVideo, Partial provider-ctor map
 │   ├── tools/
 │   │   ├── video-generation.ts       # generate_video tool def + per-provider extractors
 │   │   ├── video-router.ts           # VideoRouter — text model → transient VEO provider
@@ -289,8 +321,8 @@ services/api/src/
 │   │   ├── video-publisher.ts        # VIDEO_PENDING/GENERATING/COMPLETE/ERROR, MP4 validation
 │   │   ├── image-branch-resolver.ts  # VLM gate generalized to video; VEO ref mapping
 │   │   └── stream-publisher.ts       # videoGenerationTrace()
-│   ├── usage/usage-reporter.ts       # reportVideoUsage (per-second)
-│   ├── config.ts                     # VEO_POLL_INTERVAL_MS
+│   ├── usage/usage-reporter.ts       # reportVideoUsage (per-second VEO / per-token Seedance)
+│   ├── config.ts                     # VEO_POLL_INTERVAL_MS, BYTEPLUS_ARK_BASE_URL, BYTEPLUS_VIDEO_POLL_INTERVAL_MS
 │   └── prompts/
 │       ├── load-prompts.ts           # getSystemPrompt(includeVideoGeneration)
 │       └── video_generation_instructions.txt
@@ -327,6 +359,14 @@ packages/lixpi/constants/
 - VEO dialogue example: https://ai.google.dev/gemini-api/docs/video?example=dialogue
 - Veo 3.1 announcement: https://developers.googleblog.com/introducing-veo-3-1-and-new-creative-capabilities-in-the-gemini-api/
 - Gemini API pricing: https://ai.google.dev/gemini-api/docs/pricing
+
+### Vendor docs (BytePlus ModelArk — Seedance)
+
+- Create video generation task: https://docs.byteplus.com/en/docs/ModelArk/1520757
+- Retrieve video generation task: https://docs.byteplus.com/en/docs/ModelArk/1521309
+- Dreamina Seedance 2.0 tutorial: https://docs.byteplus.com/en/docs/ModelArk/2291680
+- Seedance 2.0 prompt guide: https://docs.byteplus.com/en/docs/ModelArk/2222480
+- Resource packs (pricing): https://docs.byteplus.com/en/docs/ModelArk/2191775
 
 ## Related Pages
 

--- a/infrastructure/init-script/setup-env.ts
+++ b/infrastructure/init-script/setup-env.ts
@@ -66,6 +66,7 @@ type EnvConfig = {
     anthropicApiKey: string
     googleApiKey: string
     stableDiffusionApiKey: string
+    arkApiKey: string
     stripePublicKey: string
 }
 
@@ -613,6 +614,15 @@ async function runInteractivePrompts(): Promise<EnvConfig | null> {
         return null
     }
 
+    const arkApiKey = await prompts.text({
+        message: 'BytePlus ModelArk API Key (ARK_API_KEY — for Seedance video; leave blank to skip)',
+        placeholder: '...',
+    })
+    if (prompts.isCancel(arkApiKey)) {
+        prompts.cancel('Setup cancelled')
+        return null
+    }
+
     // Only ask for Stripe key if not using LocalAuth0 mock (real Auth0 = real payments)
     let stripePublicKey = ''
     if (!useLocalAuth0Mock) {
@@ -664,6 +674,7 @@ async function runInteractivePrompts(): Promise<EnvConfig | null> {
         anthropicApiKey: (anthropicApiKey as string) || '',
         googleApiKey: (googleApiKey as string) || '',
         stableDiffusionApiKey: (stableDiffusionApiKey as string) || '',
+        arkApiKey: (arkApiKey as string) || '',
         stripePublicKey: (stripePublicKey as string) || '',
     }
 }
@@ -712,6 +723,7 @@ function generateEnvFileContent(config: EnvConfig): string {
         '{{ANTHROPIC_API_KEY}}': config.anthropicApiKey,
         '{{GOOGLE_API_KEY}}': config.googleApiKey,
         '{{STABLE_DIFFUSION_API_KEY}}': config.stableDiffusionApiKey,
+        '{{ARK_API_KEY}}': config.arkApiKey,
         '{{VITE_MOCK_AUTH}}': String(config.useLocalAuth0Mock),
         '{{VITE_MOCK_AUTH0_DOMAIN}}': config.useLocalAuth0Mock ? 'localhost:3000' : '',
         '{{VITE_API_URL}}': isLocal ? 'http://localhost:3005' : `https://api.${config.domainName}`,
@@ -868,6 +880,7 @@ async function main(): Promise<void> {
             anthropicApiKey: '',
             googleApiKey: '',
             stableDiffusionApiKey: '',
+            arkApiKey: '',
             stripePublicKey: '',
         }
 

--- a/infrastructure/init-script/templates/env.template
+++ b/infrastructure/init-script/templates/env.template
@@ -79,6 +79,12 @@ ANTHROPIC_API_KEY={{ANTHROPIC_API_KEY}}
 GOOGLE_API_KEY={{GOOGLE_API_KEY}}
 # Stability AI
 STABLE_DIFFUSION_API_KEY={{STABLE_DIFFUSION_API_KEY}}
+# BytePlus ModelArk (Seedance 2.0 video generation)
+ARK_API_KEY={{ARK_API_KEY}}
+# Optional overrides (code defaults shown; uncomment to change):
+# BYTEPLUS_ARK_API_KEY=                                                  # accepted instead of ARK_API_KEY
+# BYTEPLUS_ARK_BASE_URL=https://ark.ap-southeast.bytepluses.com/api/v3   # use China/Volcengine Ark (doubao-* ids) or a proxy
+# BYTEPLUS_VIDEO_POLL_INTERVAL_MS=10000
 
 
 

--- a/packages/lixpi/constants/ts/types.ts
+++ b/packages/lixpi/constants/ts/types.ts
@@ -1082,6 +1082,8 @@ export type AiModel = {
     videoAspectRatios?: ImageSizeOption[]
     videoResolutions?: ImageSizeOption[]
     videoDurations?: ImageSizeOption[]
+    // Max reference images this video model accepts (VEO 3, Seedance 9). Absent => 3.
+    videoMaxReferenceImages?: number
     pricing: {
         currency: string
         resaleMargin: string

--- a/packages/lixpi/constants/ts/types.ts
+++ b/packages/lixpi/constants/ts/types.ts
@@ -2,7 +2,7 @@
 
 import type { Merge, Except } from 'type-fest'
 
-export const PROVIDER_NAMES = ['OpenAI', 'Anthropic', 'Google', 'Stability'] as const
+export const PROVIDER_NAMES = ['OpenAI', 'Anthropic', 'Google', 'Stability', 'BytePlus'] as const
 export type ProviderName = typeof PROVIDER_NAMES[number]
 
 // Shared image upload/import validation limits (API routes, remote URL import, web-ui uploader).

--- a/services/api/src/llm/README.md
+++ b/services/api/src/llm/README.md
@@ -41,7 +41,7 @@ The factory returns `{ process, stop, shutdown, getSubscriptions }`. `getSubscri
 ```
 src/llm/
     index.ts                     # createLlmModule({ natsService, storeWorkspaceImage, storeWorkspaceVideo })
-    config.ts                    # LLM_TIMEOUT_MS, VEO_POLL_INTERVAL_MS
+    config.ts                    # LLM_TIMEOUT_MS, VEO_POLL_INTERVAL_MS, BYTEPLUS_ARK_BASE_URL, BYTEPLUS_VIDEO_POLL_INTERVAL_MS
     graph/
         state.ts                 # ProviderState type + channel reducers (partial-overlay semantics)
         stream-publisher.ts      # START_STREAM, STREAMING, END_STREAM + image/video trace events
@@ -55,14 +55,16 @@ src/llm/
         openai-provider.ts       # OpenAI Responses API + Image API (gpt-image-*)
         anthropic-provider.ts    # Anthropic messages.stream() + tool_use blocks
         google-provider.ts       # Google generateContentStream + native image generation + VEO submit/poll/download
+        byteplus-provider.ts     # BytePlus ModelArk Seedance 2.0 (video-only: create/poll/download)
+        byteplus-video-types.ts  # Typed ModelArk REST client + buildSeedanceContent + pollVideoGenerationTask
         stability-provider.ts    # Stability v2beta REST (multipart, no streaming)
     tools/
         image-generation.ts      # Tool definition, per-provider format builders, tool-call extractors
         image-generation-trace.ts # Final image-model prompt + reference-image trace payload builder
         image-router.ts          # Spawns transient image-model provider for generate_image tool calls
         video-generation.ts      # Tool definition, per-provider format builders, tool-call extractors
-        video-generation-trace.ts # Final video-model prompt + reference trace payload builder
-        video-router.ts          # Spawns transient VEO provider for generate_video tool calls
+        video-generation-trace.ts # Final video-model prompt (shared core + VEO/Seedance profiles) + reference trace builder
+        video-router.ts          # Spawns transient video provider (VEO or BytePlus/Seedance) for generate_video tool calls; provider-aware reference cap
     utils/
         attachments.ts           # nats-obj:// resolver, magic-byte MIME detection, sharp downscaling
     prompts/

--- a/services/api/src/llm/config.ts
+++ b/services/api/src/llm/config.ts
@@ -10,3 +10,12 @@ export const LLM_TIMEOUT_MS = Number(env.LLM_TIMEOUT_SECONDS ?? 1200) * 1000
 // and publishes a VIDEO_GENERATING keepalive ping so the browser does not look
 // frozen during a multi-minute generation.
 export const VEO_POLL_INTERVAL_MS = Number(env.VEO_POLL_INTERVAL_MS ?? 10000)
+
+// BytePlus ModelArk (Seedance) runtime base URL. International route by default;
+// override for China/Volcengine Ark (doubao-* model ids) or a proxy.
+export const BYTEPLUS_ARK_BASE_URL = env.BYTEPLUS_ARK_BASE_URL ?? 'https://ark.ap-southeast.bytepluses.com/api/v3'
+
+// How often the Seedance create+poll loop wakes to GET the task and publish a
+// VIDEO_GENERATING keepalive. Falls back to the VEO interval (10s) so the two
+// video providers behave consistently unless tuned independently.
+export const BYTEPLUS_VIDEO_POLL_INTERVAL_MS = Number(env.BYTEPLUS_VIDEO_POLL_INTERVAL_MS ?? env.VEO_POLL_INTERVAL_MS ?? 10000)

--- a/services/api/src/llm/graph/image-branch-resolver.test.ts
+++ b/services/api/src/llm/graph/image-branch-resolver.test.ts
@@ -78,6 +78,22 @@ const goatCandidate: NonNullable<ProviderState['imageBranchCandidateSnapshot']>[
     entityTags: ['goat'],
 }
 
+// Five plain base-context references for exercising the provider-aware video
+// reference cap (which replaced the old hardcoded .slice(0, 3)).
+function buildCapReferenceCandidates(): NonNullable<ProviderState['imageBranchCandidateSnapshot']>['candidates'] {
+    return Array.from({ length: 5 }, (_, i) => ({
+        nodeId: `cap-src-${i}`,
+        fileId: `cap-file-${i}`,
+        workspaceId: 'workspace-1',
+        imageUrl: `nats-obj://workspace-workspace-1-files/cap-file-${i}`,
+        roleHints: ['base-context'],
+        ancestorNodeIds: [`cap-src-${i}`],
+        sourceContextNodeIds: [`cap-src-${i}`],
+        visualStyleSummary: `reference ${i}`,
+        styleTags: ['ref'],
+    }))
+}
+
 function createState(overrides: {
     promptText?: string
     activeTargetNodeId?: string
@@ -497,5 +513,47 @@ describe('resolveImageBranch', () => {
         expect(update.imageBranchResolution?.targetImageNodeId).toBeNull()
         expect(update.videoReferenceImages).toEqual([resolvedTinyPngUrl])
         expect(update.videoFirstFrameImage).toBeUndefined()
+    })
+
+    it('caps videoReferenceImages at 3 for a default (VEO) video model', async () => {
+        const capCandidates = buildCapReferenceCandidates()
+        const refNodeIds = capCandidates.map((candidate) => candidate.nodeId)
+        const { deps } = createDeps(createParsedResolution({
+            mode: 'context-only',
+            operationKind: 'new_image',
+            referenceImageNodeIds: refNodeIds,
+            sourceContextNodeIds: refNodeIds,
+            styleReferenceNodeIds: refNodeIds,
+            decisions: refNodeIds.map((nodeId) => ({ nodeId, role: 'style-reference', reason: 'cap test reference' })),
+        }))
+
+        const update = await resolveImageBranch(createVideoState({ candidates: capCandidates }), deps)
+
+        // No videoModelMetaInfo on state => default cap of 3 (VEO baseline preserved).
+        expect(update.videoFirstFrameImage).toBeUndefined()
+        expect(update.videoReferenceImages).toHaveLength(3)
+    })
+
+    it('raises the videoReferenceImages cap to the model metadata value (Seedance 9)', async () => {
+        const capCandidates = buildCapReferenceCandidates()
+        const refNodeIds = capCandidates.map((candidate) => candidate.nodeId)
+        const { deps } = createDeps(createParsedResolution({
+            mode: 'context-only',
+            operationKind: 'new_image',
+            referenceImageNodeIds: refNodeIds,
+            sourceContextNodeIds: refNodeIds,
+            styleReferenceNodeIds: refNodeIds,
+            decisions: refNodeIds.map((nodeId) => ({ nodeId, role: 'style-reference', reason: 'cap test reference' })),
+        }))
+
+        const state: ProviderState = {
+            ...createVideoState({ candidates: capCandidates }),
+            videoModelMetaInfo: { provider: 'Google', model: 'Seedance', modelVersion: 'dreamina-seedance-2-0-260128', videoMaxReferenceImages: 9 },
+        }
+        const update = await resolveImageBranch(state, deps)
+
+        // 5 references all pass because the cap is raised to 9 (was 3).
+        expect(update.videoFirstFrameImage).toBeUndefined()
+        expect(update.videoReferenceImages).toHaveLength(5)
     })
 })

--- a/services/api/src/llm/graph/image-branch-resolver.ts
+++ b/services/api/src/llm/graph/image-branch-resolver.ts
@@ -16,6 +16,7 @@ import type {
 import { callStructuredVlm, type VlmCallArgs, type VlmCallResult, type VlmJsonSchema } from '../extraction/vlm-client.ts'
 import { resolveImageUrls } from '../utils/attachments.ts'
 import type { ChatMessage, ProviderState } from './state.ts'
+import { getVideoMaxReferenceImages } from './state.ts'
 import type { StreamPublisher } from './stream-publisher.ts'
 
 type ResolveImageBranchDeps = {
@@ -592,10 +593,11 @@ export const resolveImageBranch = async (state: ProviderState, deps: ResolveImag
             rationale: resolution.rationale,
         }, null, 0)}`)
 
-        // For video generation, map the VLM-selected references onto VEO inputs.
-        // VEO's `image` (first frame, image-to-video) and `referenceImages`
-        // (up to 3 style/content guides) are MUTUALLY EXCLUSIVE in the API,
-        // so we pick one path based on whether the resolver identified a target:
+        // For video generation, map the VLM-selected references onto the video
+        // provider's inputs. The first-frame (image-to-video) and reference-image
+        // (up to the provider's reference cap) paths are MUTUALLY EXCLUSIVE in
+        // both VEO and Seedance, so we pick one based on whether the resolver
+        // identified a target:
         //   - target set (edit / style_transfer / continuation) -> first-frame mode
         //   - no target, refs present                            -> referenceImages mode
         //   - no refs at all                                     -> text-to-video (both undefined)
@@ -610,7 +612,7 @@ export const resolveImageBranch = async (state: ProviderState, deps: ResolveImag
             if (resolution.targetImageNodeId) {
                 videoFirstFrameImage = urlByNodeId.get(resolution.targetImageNodeId) ?? orderedUrls[0]
             } else if (orderedUrls.length > 0) {
-                videoReferenceImages = orderedUrls.slice(0, 3)
+                videoReferenceImages = orderedUrls.slice(0, getVideoMaxReferenceImages(state.videoModelMetaInfo))
             }
         }
 

--- a/services/api/src/llm/graph/state.ts
+++ b/services/api/src/llm/graph/state.ts
@@ -28,6 +28,11 @@ export type VideoUsage = {
     durationSeconds: number
     resolution: string
     aspectRatio: string
+    // Vendor token usage for token-metered video providers (e.g. Seedance via
+    // ModelArk). Absent for per-second providers like VEO. Billing branches on
+    // pricing.video.measuringUnit (see usage-reporter.reportVideoUsage).
+    completionTokens?: number
+    totalTokens?: number
 }
 
 export type EventMeta = {

--- a/services/api/src/llm/graph/state.ts
+++ b/services/api/src/llm/graph/state.ts
@@ -47,8 +47,21 @@ export type AiModelMetaInfo = {
     defaultTemperature?: number
     supportsSystemPrompt?: boolean
     imagePromptMaxChars?: number
+    videoMaxReferenceImages?: number
     pricing?: Record<string, any>
     [key: string]: unknown
+}
+
+// Reference-image cap for the selected video model. VEO accepts 3, Seedance 9.
+// Reads from the video model's metadata and falls back to the VEO baseline when
+// the field is absent, so existing video models stay capped at 3. Single source
+// of truth shared by the VideoRouter and the image-branch resolver (the two
+// places the cap is applied) so the value is never duplicated.
+export const DEFAULT_VIDEO_MAX_REFERENCE_IMAGES = 3
+
+export const getVideoMaxReferenceImages = (meta: AiModelMetaInfo | undefined): number => {
+    const raw = meta?.videoMaxReferenceImages
+    return typeof raw === 'number' && raw > 0 ? raw : DEFAULT_VIDEO_MAX_REFERENCE_IMAGES
 }
 
 export type ChatMessage = {

--- a/services/api/src/llm/index.ts
+++ b/services/api/src/llm/index.ts
@@ -8,6 +8,7 @@ import { OpenAIProvider } from './providers/openai-provider.ts'
 import { AnthropicProvider } from './providers/anthropic-provider.ts'
 import { GoogleProvider } from './providers/google-provider.ts'
 import { StabilityProvider } from './providers/stability-provider.ts'
+import { BytePlusProvider } from './providers/byteplus-provider.ts'
 import { ImageRouter } from './tools/image-router.ts'
 import { VideoRouter } from './tools/video-router.ts'
 import { ExtractionOrchestrator } from './extraction/orchestrator.ts'
@@ -42,6 +43,7 @@ export const createLlmModule = (deps: LlmModuleDeps): LlmModule => {
             Anthropic: AnthropicProvider,
             Google: GoogleProvider,
             Stability: StabilityProvider,
+            BytePlus: BytePlusProvider,
         },
     )
 

--- a/services/api/src/llm/providers/base-provider.ts
+++ b/services/api/src/llm/providers/base-provider.ts
@@ -391,6 +391,8 @@ export abstract class BaseProvider {
                 durationSeconds: state.videoUsage.durationSeconds,
                 resolution: state.videoUsage.resolution,
                 aspectRatio: state.videoUsage.aspectRatio,
+                totalTokens: state.videoUsage.totalTokens,
+                completionTokens: state.videoUsage.completionTokens,
                 aiRequestReceivedAt: state.aiRequestReceivedAt,
                 aiRequestFinishedAt: state.aiRequestFinishedAt ?? Date.now(),
             })

--- a/services/api/src/llm/providers/byteplus-provider.test.ts
+++ b/services/api/src/llm/providers/byteplus-provider.test.ts
@@ -1,0 +1,42 @@
+'use strict'
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { BytePlusProvider } from './byteplus-provider.ts'
+
+// Construction only builds the LangGraph workflow (no deps are touched), so a
+// bare cast is enough to exercise the API-key guard + providerName.
+const noopDeps = {} as any
+
+describe('BytePlusProvider', () => {
+    const prevByteplus = process.env.BYTEPLUS_ARK_API_KEY
+    const prevArk = process.env.ARK_API_KEY
+
+    beforeEach(() => {
+        delete process.env.BYTEPLUS_ARK_API_KEY
+        delete process.env.ARK_API_KEY
+    })
+
+    afterEach(() => {
+        if (prevByteplus === undefined) delete process.env.BYTEPLUS_ARK_API_KEY
+        else process.env.BYTEPLUS_ARK_API_KEY = prevByteplus
+        if (prevArk === undefined) delete process.env.ARK_API_KEY
+        else process.env.ARK_API_KEY = prevArk
+    })
+
+    it('constructs with BYTEPLUS_ARK_API_KEY and reports providerName BytePlus', () => {
+        process.env.BYTEPLUS_ARK_API_KEY = 'test-key'
+        const provider = new BytePlusProvider('ws:thread:video', noopDeps)
+        expect(provider.providerName).toBe('BytePlus')
+    })
+
+    it('falls back to ARK_API_KEY', () => {
+        process.env.ARK_API_KEY = 'test-key'
+        const provider = new BytePlusProvider('ws:thread:video', noopDeps)
+        expect(provider.providerName).toBe('BytePlus')
+    })
+
+    it('throws a clear error when no API key is configured', () => {
+        expect(() => new BytePlusProvider('ws:thread:video', noopDeps)).toThrow(/ARK_API_KEY/)
+    })
+})

--- a/services/api/src/llm/providers/byteplus-provider.ts
+++ b/services/api/src/llm/providers/byteplus-provider.ts
@@ -1,0 +1,180 @@
+'use strict'
+
+import * as process from 'process'
+
+import { info, err } from '@lixpi/debug-tools'
+import type { ProviderName } from '@lixpi/constants'
+
+import { BaseProvider, type BaseProviderDeps } from './base-provider.ts'
+import type { ProviderState, VideoUsage } from '../graph/state.ts'
+import { extractPosterFrame, extractRepresentativeFrame } from '../../services/video-storage.ts'
+import { BYTEPLUS_ARK_BASE_URL, BYTEPLUS_VIDEO_POLL_INTERVAL_MS } from '../config.ts'
+import {
+    BytePlusModelArkError,
+    buildSeedanceContent,
+    createVideoGenerationTask,
+    downloadVideo,
+    pollVideoGenerationTask,
+    type BytePlusClientConfig,
+    type CreateVideoGenerationTaskPayload,
+} from './byteplus-video-types.ts'
+
+// First-party video provider for BytePlus ModelArk's official Seedance 2.0 API.
+// A clean peer of GoogleProvider: it is invoked as a transient provider by the
+// VideoRouter (instanceKey {ws}:{thread}:video, enableVideoGeneration=true) and
+// runs the async create+poll+download path inside the request, publishing the
+// shared video NATS lifecycle. It is video-only — text streaming throws a
+// capability error.
+export class BytePlusProvider extends BaseProvider {
+    readonly providerName: ProviderName = 'BytePlus'
+    private readonly clientConfig: BytePlusClientConfig
+
+    constructor(instanceKey: string, deps: BaseProviderDeps) {
+        super(instanceKey, deps)
+        const apiKey = process.env.BYTEPLUS_ARK_API_KEY || process.env.ARK_API_KEY
+        if (!apiKey) {
+            throw new Error('BYTEPLUS_ARK_API_KEY (or ARK_API_KEY) environment variable is required')
+        }
+        this.clientConfig = { baseUrl: BYTEPLUS_ARK_BASE_URL, apiKey }
+    }
+
+    protected override async streamImpl(state: ProviderState): Promise<Partial<ProviderState>> {
+        const modelVersion = state.modelVersion
+        const enableVideoGeneration = state.enableVideoGeneration ?? false
+        const isSeedanceVideo = enableVideoGeneration && /seedance/i.test(modelVersion)
+
+        if (!isSeedanceVideo) {
+            // Video-only provider: there is no text/image streaming path. The
+            // router only ever dispatches Seedance video here, so anything else
+            // is a misconfiguration worth surfacing loudly.
+            throw new Error(
+                `BytePlus provider supports Seedance video generation only ` +
+                `(model="${modelVersion}", enableVideoGeneration=${enableVideoGeneration}).`,
+            )
+        }
+
+        const videoUsage = await this.runSeedanceGeneration(state)
+        const responseId = videoUsage.responseId
+        return {
+            generatedVideos: ['seedance-complete'],
+            videoUsage,
+            aiVendorRequestId: responseId ? `byteplus-${responseId}` : undefined,
+        }
+    }
+
+    // Create + poll + download a Seedance task, then store the MP4 and publish
+    // the video lifecycle. Mirrors GoogleProvider.runVeoGeneration: emit
+    // VIDEO_PENDING on accept, VIDEO_GENERATING keepalives during the poll,
+    // VIDEO_COMPLETE on success (or VIDEO_ERROR + throw on failure, which the
+    // streamImpl catch in BaseProvider converts to update.error).
+    private async runSeedanceGeneration(state: ProviderState): Promise<VideoUsage & { responseId?: string }> {
+        const modelVersion = state.modelVersion
+        // VideoRouter passes the final prompt as the first user message's content.
+        const first = state.messages[0]
+        const prompt = typeof first?.content === 'string' ? first.content : ''
+        if (!prompt) throw new Error('Seedance: missing prompt in user message')
+
+        // References reaching the provider are already capped to the provider-aware
+        // budget upstream by the VideoRouter (which holds the full model metadata).
+        const content = buildSeedanceContent(prompt, {
+            videoSourceForExtension: state.videoSourceForExtension,
+            videoFirstFrameImage: state.videoFirstFrameImage,
+            videoReferenceImages: state.videoReferenceImages,
+        })
+        const duration = Number(state.videoDurationSeconds) || undefined
+
+        const payload: CreateVideoGenerationTaskPayload = {
+            model: modelVersion,
+            content,
+            ...(state.videoResolution ? { resolution: state.videoResolution } : {}),
+            ...(state.videoAspectRatio ? { ratio: state.videoAspectRatio } : {}),
+            ...(duration ? { duration } : {}),
+            generate_audio: true,
+            watermark: false,
+        }
+
+        const referenceCount = content.filter((c) => c.type === 'image_url' && c.role === 'reference_image').length
+        const hasFirstFrame = content.some((c) => c.type === 'image_url' && c.role === 'first_frame')
+        info(`[BytePlus:${this.instanceKey}] Seedance submit ${JSON.stringify({
+            model: modelVersion,
+            ratio: payload.ratio,
+            resolution: payload.resolution,
+            duration: payload.duration,
+            promptLen: prompt.length,
+            hasFirstFrame,
+            referenceCount,
+        }, null, 0)}`)
+
+        try {
+            const created = await createVideoGenerationTask(this.clientConfig, payload, this.signal)
+            const taskId = created.id
+            if (!taskId) throw new BytePlusModelArkError('ModelArk did not return a task id')
+
+            this.videoPub.pending()
+
+            const task = await pollVideoGenerationTask(this.clientConfig, taskId, {
+                pollIntervalMs: BYTEPLUS_VIDEO_POLL_INTERVAL_MS,
+                signal: this.signal,
+                shouldStop: () => this.shouldStop,
+                onKeepalive: () => this.videoPub.generating(),
+            })
+
+            if (task.status !== 'succeeded') {
+                const detail = task.error?.message ?? `task ${task.status}`
+                throw new BytePlusModelArkError(
+                    `Seedance task ${taskId} ${task.status}: ${detail}`,
+                    { code: task.error?.code },
+                )
+            }
+
+            const videoUrl = task.content?.video_url
+            if (!videoUrl) throw new BytePlusModelArkError('Seedance task succeeded but returned no video_url')
+
+            // Output URLs are cleaned after 24h — download immediately.
+            const videoBuffer = await downloadVideo(videoUrl, this.signal)
+            if (!videoBuffer || videoBuffer.length === 0) {
+                throw new Error('Seedance: empty video bytes after download')
+            }
+
+            const durationSeconds = Number(task.duration ?? state.videoDurationSeconds) || 0
+            const aspectRatio = task.ratio ?? state.videoAspectRatio ?? ''
+            const resolution = task.resolution ?? state.videoResolution ?? ''
+            const hasAudio = payload.generate_audio ?? true
+
+            const posterBuffer = await extractPosterFrame(videoBuffer)
+            const frameBuffer = await extractRepresentativeFrame(videoBuffer, durationSeconds > 0 ? durationSeconds / 2 : undefined)
+
+            await this.videoPub.complete({
+                videoBuffer,
+                posterBuffer,
+                frameBuffer,
+                durationSeconds,
+                aspectRatio,
+                hasAudio,
+                responseId: taskId,
+                revisedPrompt: prompt,
+                videoModelId: modelVersion,
+            })
+
+            info(`[BytePlus:${this.instanceKey}] Seedance complete ${JSON.stringify({
+                taskId,
+                durationSeconds,
+                totalTokens: task.usage?.total_tokens,
+            }, null, 0)}`)
+
+            return {
+                durationSeconds,
+                resolution,
+                aspectRatio,
+                completionTokens: task.usage?.completion_tokens,
+                totalTokens: task.usage?.total_tokens,
+                responseId: taskId,
+            }
+        } catch (e: any) {
+            const message = e?.message ?? String(e)
+            err(`[BytePlus:${this.instanceKey}] Seedance failed: ${message}`)
+            try { this.videoPub.error(message) } catch { /* publisher may not be initialized */ }
+            throw e
+        }
+    }
+}

--- a/services/api/src/llm/providers/byteplus-video-types.test.ts
+++ b/services/api/src/llm/providers/byteplus-video-types.test.ts
@@ -1,0 +1,183 @@
+'use strict'
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import {
+    SEEDANCE_EXTENSION_UNSUPPORTED_MESSAGE,
+    buildSeedanceContent,
+    createVideoGenerationTask,
+    downloadVideo,
+    pollVideoGenerationTask,
+    retrieveVideoGenerationTask,
+    type BytePlusClientConfig,
+    type CreateVideoGenerationTaskPayload,
+    type RetrieveVideoGenerationTaskResponse,
+} from './byteplus-video-types.ts'
+
+const config: BytePlusClientConfig = { baseUrl: 'https://ark.example/api/v3', apiKey: 'secret-key' }
+
+afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+})
+
+describe('buildSeedanceContent', () => {
+    it('produces a text-only content array for text-to-video', () => {
+        expect(buildSeedanceContent('a paper fox walking', {})).toEqual([
+            { type: 'text', text: 'a paper fox walking' },
+        ])
+    })
+
+    it('adds one first_frame image for image-to-video', () => {
+        const content = buildSeedanceContent('move', { videoFirstFrameImage: 'data:image/png;base64,AAA' })
+        expect(content).toEqual([
+            { type: 'text', text: 'move' },
+            { type: 'image_url', image_url: { url: 'data:image/png;base64,AAA' }, role: 'first_frame' },
+        ])
+    })
+
+    it('adds each reference image with role reference_image', () => {
+        const content = buildSeedanceContent('move', {
+            videoReferenceImages: ['data:image/png;base64,A', 'data:image/png;base64,B'],
+        })
+        expect(content[0]).toEqual({ type: 'text', text: 'move' })
+        expect(content.slice(1)).toEqual([
+            { type: 'image_url', image_url: { url: 'data:image/png;base64,A' }, role: 'reference_image' },
+            { type: 'image_url', image_url: { url: 'data:image/png;base64,B' }, role: 'reference_image' },
+        ])
+    })
+
+    it('uses first-frame mode when both a first frame and references are present (mutually exclusive)', () => {
+        const content = buildSeedanceContent('move', {
+            videoFirstFrameImage: 'data:image/png;base64,FF',
+            videoReferenceImages: ['data:image/png;base64,R'],
+        })
+        expect(content).toHaveLength(2)
+        expect(content[1]).toMatchObject({ role: 'first_frame' })
+    })
+
+    it('rejects source-video extension with the capability message', () => {
+        expect(() => buildSeedanceContent('move', { videoSourceForExtension: 'nats-obj://workspace-1-files/clip' }))
+            .toThrow(SEEDANCE_EXTENSION_UNSUPPORTED_MESSAGE)
+    })
+
+    it('refuses to send a private nats-obj:// URI to ModelArk', () => {
+        expect(() => buildSeedanceContent('move', { videoFirstFrameImage: 'nats-obj://workspace-1-files/frame' }))
+            .toThrow(/private object-store URI/)
+        expect(() => buildSeedanceContent('move', { videoReferenceImages: ['nats-obj://workspace-1-files/ref'] }))
+            .toThrow(/private object-store URI/)
+    })
+})
+
+describe('createVideoGenerationTask', () => {
+    it('POSTs the payload to the tasks endpoint with bearer auth and parses the task id', async () => {
+        const fetchMock = vi.fn(async () => new Response(
+            JSON.stringify({ id: 'task_abc', status: 'queued' }),
+            { status: 200 },
+        ))
+        vi.stubGlobal('fetch', fetchMock)
+
+        const payload: CreateVideoGenerationTaskPayload = {
+            model: 'dreamina-seedance-2-0-260128',
+            content: [{ type: 'text', text: 'hello' }],
+            resolution: '720p',
+            ratio: '16:9',
+            duration: 5,
+            generate_audio: true,
+            watermark: false,
+        }
+        const res = await createVideoGenerationTask(config, payload)
+
+        expect(res.id).toBe('task_abc')
+        const [url, init] = fetchMock.mock.calls[0]!
+        expect(url).toBe('https://ark.example/api/v3/contents/generations/tasks')
+        expect(init.method).toBe('POST')
+        expect(init.headers.Authorization).toBe('Bearer secret-key')
+        expect(init.headers['Content-Type']).toBe('application/json')
+        expect(JSON.parse(init.body)).toMatchObject({ model: 'dreamina-seedance-2-0-260128', resolution: '720p', ratio: '16:9', duration: 5 })
+    })
+
+    it('throws a BytePlusModelArkError preserving error.code and HTTP status on failure', async () => {
+        const fetchMock = vi.fn(async () => new Response(
+            JSON.stringify({ error: { code: 'InvalidParameter', message: 'bad ratio' } }),
+            { status: 400 },
+        ))
+        vi.stubGlobal('fetch', fetchMock)
+
+        await expect(createVideoGenerationTask(config, { model: 'm', content: [] }))
+            .rejects.toMatchObject({ name: 'BytePlusModelArkError', code: 'InvalidParameter', httpStatus: 400 })
+    })
+})
+
+describe('retrieveVideoGenerationTask', () => {
+    it('GETs the task by id with bearer auth and returns the status + content', async () => {
+        const fetchMock = vi.fn(async () => new Response(
+            JSON.stringify({ id: 'task_abc', status: 'succeeded', content: { video_url: 'https://cdn/x.mp4' }, usage: { total_tokens: 184320 } }),
+            { status: 200 },
+        ))
+        vi.stubGlobal('fetch', fetchMock)
+
+        const task = await retrieveVideoGenerationTask(config, 'task_abc')
+        expect(task.status).toBe('succeeded')
+        expect(task.content?.video_url).toBe('https://cdn/x.mp4')
+        expect(task.usage?.total_tokens).toBe(184320)
+        const [url, init] = fetchMock.mock.calls[0]!
+        expect(url).toBe('https://ark.example/api/v3/contents/generations/tasks/task_abc')
+        expect(init.method).toBe('GET')
+        expect(init.headers.Authorization).toBe('Bearer secret-key')
+    })
+})
+
+describe('downloadVideo', () => {
+    it('returns the MP4 bytes as a Buffer', async () => {
+        const bytes = new Uint8Array([0, 0, 0, 24, 0x66, 0x74, 0x79, 0x70])
+        const fetchMock = vi.fn(async () => new Response(bytes, { status: 200 }))
+        vi.stubGlobal('fetch', fetchMock)
+
+        const buffer = await downloadVideo('https://cdn/x.mp4')
+        expect(Buffer.isBuffer(buffer)).toBe(true)
+        expect(buffer.length).toBe(8)
+    })
+
+    it('throws on a non-OK download response', async () => {
+        const fetchMock = vi.fn(async () => new Response('gone', { status: 404 }))
+        vi.stubGlobal('fetch', fetchMock)
+
+        await expect(downloadVideo('https://cdn/expired.mp4'))
+            .rejects.toMatchObject({ name: 'BytePlusModelArkError', httpStatus: 404 })
+    })
+})
+
+describe('pollVideoGenerationTask', () => {
+    const statusTask = (status: string): RetrieveVideoGenerationTaskResponse =>
+        ({ id: 'task_abc', status: status as any })
+
+    it('polls until succeeded, emitting a keepalive on each non-terminal poll', async () => {
+        const statuses = ['queued', 'running', 'succeeded']
+        let i = 0
+        const retrieve = vi.fn(async () => statusTask(statuses[i++]!))
+        const onKeepalive = vi.fn()
+        const sleep = vi.fn(async () => {})
+
+        const task = await pollVideoGenerationTask(config, 'task_abc', { pollIntervalMs: 10, retrieve, onKeepalive, sleep })
+
+        expect(task.status).toBe('succeeded')
+        expect(retrieve).toHaveBeenCalledTimes(3)
+        expect(onKeepalive).toHaveBeenCalledTimes(2)
+        expect(sleep).toHaveBeenCalledTimes(2)
+    })
+
+    it('returns a failed task without throwing (caller decides how to react)', async () => {
+        const retrieve = vi.fn(async () => ({ id: 'task_abc', status: 'failed', error: { code: 'X', message: 'bad' } } as RetrieveVideoGenerationTaskResponse))
+        const task = await pollVideoGenerationTask(config, 'task_abc', { pollIntervalMs: 10, retrieve })
+        expect(task.status).toBe('failed')
+        expect(task.error?.code).toBe('X')
+    })
+
+    it('aborts before polling when shouldStop is already true', async () => {
+        const retrieve = vi.fn(async () => statusTask('running'))
+        await expect(pollVideoGenerationTask(config, 'task_abc', { pollIntervalMs: 10, retrieve, shouldStop: () => true }))
+            .rejects.toThrow('aborted')
+        expect(retrieve).not.toHaveBeenCalled()
+    })
+})

--- a/services/api/src/llm/providers/byteplus-video-types.ts
+++ b/services/api/src/llm/providers/byteplus-video-types.ts
@@ -1,0 +1,258 @@
+'use strict'
+
+// Typed request/response shapes + a thin REST client for the BytePlus ModelArk
+// Seedance 2.0 video-generation API. The surface is small (create task, poll
+// task, download the resulting MP4), so we use Node `fetch` + `AbortSignal`
+// rather than pulling in an SDK.
+//
+// Official international route (overridable via BYTEPLUS_ARK_BASE_URL):
+//   POST {base}/contents/generations/tasks            — create a task
+//   GET  {base}/contents/generations/tasks/{id}       — poll a task
+// Auth: `Authorization: Bearer $ARK_API_KEY`.
+//
+// NOTE: the ModelArk task body/content wire shapes below match the documented
+// API as of the proposal (re-verified 2026-06-04). They are intentionally kept
+// in this one module so a vendor-format change is a single-file edit.
+
+export type SeedanceTaskStatus = 'queued' | 'running' | 'succeeded' | 'failed' | 'cancelled' | 'expired'
+
+// content[] image roles. v1 uses first_frame and reference_image; the others are
+// reserved for the later asset-handoff phase.
+export type SeedanceImageRole = 'first_frame' | 'last_frame' | 'reference_image'
+
+export type SeedanceTextContent = {
+    type: 'text'
+    text: string
+}
+
+export type SeedanceImageContent = {
+    type: 'image_url'
+    image_url: { url: string }
+    role: SeedanceImageRole
+}
+
+export type SeedanceContentItem = SeedanceTextContent | SeedanceImageContent
+
+export type CreateVideoGenerationTaskPayload = {
+    model: string
+    content: SeedanceContentItem[]
+    resolution?: string
+    ratio?: string
+    duration?: number
+    generate_audio?: boolean
+    watermark?: boolean
+    seed?: number
+    return_last_frame?: boolean
+    callback_url?: string
+}
+
+export type CreateVideoGenerationTaskResponse = {
+    id: string
+    status?: SeedanceTaskStatus
+    [key: string]: unknown
+}
+
+export type SeedanceUsage = {
+    completion_tokens?: number
+    total_tokens?: number
+    [key: string]: unknown
+}
+
+export type RetrieveVideoGenerationTaskResponse = {
+    id: string
+    status: SeedanceTaskStatus
+    model?: string
+    content?: {
+        video_url?: string
+        [key: string]: unknown
+    }
+    usage?: SeedanceUsage
+    error?: { code?: string; message?: string }
+    // Echoed generation parameters (present on success).
+    duration?: number
+    resolution?: string
+    ratio?: string
+    seed?: number
+    [key: string]: unknown
+}
+
+export type BytePlusClientConfig = {
+    baseUrl: string
+    apiKey: string
+}
+
+// Carries ModelArk's `error.code` / HTTP status through to callers so the
+// provider can surface an actionable message instead of an opaque failure.
+export class BytePlusModelArkError extends Error {
+    readonly code?: string
+    readonly httpStatus?: number
+
+    constructor(message: string, opts: { code?: string; httpStatus?: number } = {}) {
+        super(message)
+        this.name = 'BytePlusModelArkError'
+        this.code = opts.code
+        this.httpStatus = opts.httpStatus
+    }
+}
+
+const parseJsonOrThrow = async (res: Response, action: string): Promise<any> => {
+    const text = await res.text()
+    let json: any
+    try {
+        json = text ? JSON.parse(text) : {}
+    } catch {
+        json = undefined
+    }
+
+    if (!res.ok) {
+        const code = json?.error?.code
+        const message = json?.error?.message ?? (text || res.statusText)
+        throw new BytePlusModelArkError(
+            `ModelArk ${action} failed (HTTP ${res.status}${code ? `, code=${code}` : ''}): ${message}`,
+            { code, httpStatus: res.status },
+        )
+    }
+
+    if (json === undefined) {
+        throw new BytePlusModelArkError(
+            `ModelArk ${action} returned a non-JSON response: ${text.slice(0, 200)}`,
+            { httpStatus: res.status },
+        )
+    }
+    return json
+}
+
+export const createVideoGenerationTask = async (
+    config: BytePlusClientConfig,
+    payload: CreateVideoGenerationTaskPayload,
+    signal?: AbortSignal,
+): Promise<CreateVideoGenerationTaskResponse> => {
+    const res = await fetch(`${config.baseUrl}/contents/generations/tasks`, {
+        method: 'POST',
+        headers: {
+            'Authorization': `Bearer ${config.apiKey}`,
+            'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(payload),
+        signal,
+    })
+    return parseJsonOrThrow(res, 'create video generation task')
+}
+
+export const retrieveVideoGenerationTask = async (
+    config: BytePlusClientConfig,
+    taskId: string,
+    signal?: AbortSignal,
+): Promise<RetrieveVideoGenerationTaskResponse> => {
+    const res = await fetch(`${config.baseUrl}/contents/generations/tasks/${encodeURIComponent(taskId)}`, {
+        method: 'GET',
+        headers: { 'Authorization': `Bearer ${config.apiKey}` },
+        signal,
+    })
+    return parseJsonOrThrow(res, 'retrieve video generation task')
+}
+
+// Downloads the hosted MP4. ModelArk output URLs are cleaned after 24 hours, so
+// the provider must call this inside the same request and persist the bytes.
+export const downloadVideo = async (videoUrl: string, signal?: AbortSignal): Promise<Buffer> => {
+    const res = await fetch(videoUrl, { signal })
+    if (!res.ok) {
+        throw new BytePlusModelArkError(
+            `Failed to download Seedance video (HTTP ${res.status})`,
+            { httpStatus: res.status },
+        )
+    }
+    const arrayBuffer = await res.arrayBuffer()
+    return Buffer.from(arrayBuffer)
+}
+
+export const SEEDANCE_TERMINAL_STATUSES: ReadonlySet<SeedanceTaskStatus> =
+    new Set(['succeeded', 'failed', 'cancelled', 'expired'])
+
+export const SEEDANCE_EXTENSION_UNSUPPORTED_MESSAGE =
+    'Seedance video extension requires provider-fetchable video URLs. ' +
+    'Use VEO for extension until external asset handoff is implemented.'
+
+export type SeedanceContentInputs = {
+    videoSourceForExtension?: string
+    videoFirstFrameImage?: string
+    videoReferenceImages?: string[]
+}
+
+// Seedance reads inline base64 data URLs (the resolver already supplies them) or
+// public https URLs. Internal nats-obj:// URIs are private and must never reach
+// ModelArk — fail explicitly rather than emit an opaque vendor error.
+const toModelArkImageUrl = (url: string, label: string): string => {
+    if (!url) throw new Error(`Seedance: empty ${label} URL`)
+    if (url.startsWith('nats-obj://')) {
+        throw new Error(
+            `Seedance: refusing to send a private object-store URI as a ${label}. ` +
+            `The resolver must supply a base64 data URL.`,
+        )
+    }
+    return url
+}
+
+// Build the ModelArk content[] array. Order: text first, then ONE input family —
+// first-frame OR reference-images. first_frame and reference_image are mutually
+// exclusive in Seedance, and the shared resolver only ever populates one of
+// videoFirstFrameImage / videoReferenceImages. Source-video extension has no
+// provider-fetchable asset handoff yet, so it is rejected with a capability error.
+// References are assumed already capped to the provider budget upstream.
+export const buildSeedanceContent = (prompt: string, inputs: SeedanceContentInputs): SeedanceContentItem[] => {
+    const content: SeedanceContentItem[] = [{ type: 'text', text: prompt }]
+
+    if (inputs.videoSourceForExtension) {
+        throw new Error(SEEDANCE_EXTENSION_UNSUPPORTED_MESSAGE)
+    }
+
+    if (inputs.videoFirstFrameImage) {
+        content.push({
+            type: 'image_url',
+            image_url: { url: toModelArkImageUrl(inputs.videoFirstFrameImage, 'first frame') },
+            role: 'first_frame',
+        })
+        return content
+    }
+
+    for (const ref of inputs.videoReferenceImages ?? []) {
+        content.push({
+            type: 'image_url',
+            image_url: { url: toModelArkImageUrl(ref, 'reference image') },
+            role: 'reference_image',
+        })
+    }
+    return content
+}
+
+export type PollVideoGenerationTaskOptions = {
+    pollIntervalMs: number
+    signal?: AbortSignal
+    // Abort hook (e.g. circuit breaker / user stop). Checked before every poll.
+    shouldStop?: () => boolean
+    // Called on every non-terminal poll so the caller can emit a keepalive.
+    onKeepalive?: () => void
+    // Injectable for tests; defaults to the real retrieve + setTimeout sleep.
+    retrieve?: (config: BytePlusClientConfig, taskId: string, signal?: AbortSignal) => Promise<RetrieveVideoGenerationTaskResponse>
+    sleep?: (ms: number) => Promise<void>
+}
+
+// Polls a task to a terminal status, emitting a keepalive on every non-terminal
+// poll. Returns the terminal task (succeeded OR failed/cancelled/expired — the
+// caller decides how to react). Throws only on abort.
+export const pollVideoGenerationTask = async (
+    config: BytePlusClientConfig,
+    taskId: string,
+    opts: PollVideoGenerationTaskOptions,
+): Promise<RetrieveVideoGenerationTaskResponse> => {
+    const retrieve = opts.retrieve ?? retrieveVideoGenerationTask
+    const sleep = opts.sleep ?? ((ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms)))
+
+    for (;;) {
+        if (opts.shouldStop?.()) throw new Error('Video generation aborted')
+        const task = await retrieve(config, taskId, opts.signal)
+        if (SEEDANCE_TERMINAL_STATUSES.has(task.status)) return task
+        opts.onKeepalive?.()
+        await sleep(opts.pollIntervalMs)
+    }
+}

--- a/services/api/src/llm/providers/provider-registry.ts
+++ b/services/api/src/llm/providers/provider-registry.ts
@@ -27,7 +27,10 @@ export class ProviderRegistry {
         private readonly natsService: NatsService,
         private readonly storeWorkspaceImage: StoreWorkspaceImageFn,
         private readonly storeWorkspaceVideo: StoreWorkspaceVideoFn,
-        ctors: Record<ProviderName, ProviderConstructor>,
+        // Partial: not every ProviderName must have a registered constructor
+        // (e.g. a video-only provider added before its class lands). Unregistered
+        // providers throw "Unsupported provider" on lookup in getOrCreate/createTransient.
+        ctors: Partial<Record<ProviderName, ProviderConstructor>>,
     ) {
         this.providerCtors = new Map(Object.entries(ctors) as Array<[ProviderName, ProviderConstructor]>)
         this.usageReporter = new UsageReporter()

--- a/services/api/src/llm/tools/video-generation-trace.test.ts
+++ b/services/api/src/llm/tools/video-generation-trace.test.ts
@@ -129,6 +129,59 @@ describe('buildVideoModelPrompt', () => {
         expect(prompt).toContain('Negative prompt:')
         expect(prompt).not.toContain('MANDATORY /use FEATURE TRANSFER FOR VIDEO')
     })
+
+    // Locks in VEO's reference-mode wording after it moved into the profile, so
+    // the generalization stays byte-identical for VEO in every input mode.
+    it('keeps the literal "VEO reference images" wording in VEO reference mode (byte-identical)', () => {
+        const prompt = buildVideoModelPrompt(createState({
+            videoFirstFrameImage: undefined,
+            videoReferenceImages: ['data:image/png;base64,ref-a', 'data:image/png;base64,ref-b'],
+            featureReferenceImages: [],
+            featureUsagePrompt: undefined,
+        }))
+
+        expect(prompt).toContain('VEO QUALITY DIRECTION')
+        expect(prompt).toContain('REFERENCE-IMAGE DIRECTION: use the attached VEO reference images')
+        expect(prompt).toContain(`Negative prompt: ${VEO_NEGATIVE_PROMPT}`)
+    })
+})
+
+describe('buildVideoModelPrompt — Seedance profile', () => {
+    // The /seedance/i model version selects the Seedance profile; provider name
+    // is irrelevant to prompt shaping (the providers gate on the same signal).
+    const seedanceOverrides = {
+        videoModelMetaInfo: { provider: 'Google', model: 'Seedance', modelVersion: 'dreamina-seedance-2-0-260128' },
+        videoModelVersion: 'dreamina-seedance-2-0-260128',
+    } as const
+
+    it('uses the Seedance quality direction and omits the negative-prompt line (positive phrasing only)', () => {
+        const prompt = buildVideoModelPrompt(createState(seedanceOverrides))
+
+        expect(prompt).toContain('SEEDANCE QUALITY DIRECTION')
+        expect(prompt).not.toContain('VEO QUALITY DIRECTION')
+        // Seedance backfires on negative phrasing — the wrapper must not append it.
+        expect(prompt).not.toContain('Negative prompt:')
+        expect(prompt).not.toContain(VEO_NEGATIVE_PROMPT)
+        // Shared core is preserved across providers.
+        expect(prompt).toContain('IMAGE-TO-VIDEO DIRECTION')
+        expect(prompt).toContain('MANDATORY /use FEATURE TRANSFER FOR VIDEO')
+        expect(prompt).toContain('USER VIDEO REQUEST:')
+        expect(prompt).toContain('Animate the portrait with a slow push-in')
+    })
+
+    it('drops the literal "VEO" from the reference-image direction for Seedance', () => {
+        const prompt = buildVideoModelPrompt(createState({
+            ...seedanceOverrides,
+            videoFirstFrameImage: undefined,
+            videoReferenceImages: ['data:image/png;base64,ref-a', 'data:image/png;base64,ref-b'],
+            featureReferenceImages: [],
+            featureUsagePrompt: undefined,
+        }))
+
+        expect(prompt).toContain('REFERENCE-IMAGE DIRECTION')
+        expect(prompt).not.toContain('VEO reference images')
+        expect(prompt).not.toContain('Negative prompt:')
+    })
 })
 
 describe('buildVideoGenerationTrace', () => {

--- a/services/api/src/llm/tools/video-generation-trace.ts
+++ b/services/api/src/llm/tools/video-generation-trace.ts
@@ -35,7 +35,48 @@ export const VEO_NEGATIVE_PROMPT = [
     'brand logos',
 ].join(', ')
 
-const buildInputModeDirection = (state: ProviderState): string => {
+// A video model's prompt profile: the provider-specific wording the shared
+// wrapper composes around the user's request. VEO and Seedance share the same
+// pipeline (buildVideoModelPrompt) but differ in three places: the headline
+// quality/cinematography direction, the reference-image input-mode wording
+// (VEO names its inputs "VEO reference images"), and how negatives are handled.
+// VEO appends an inline `Negative prompt:` line; Seedance 2.0 has no reliable
+// native negative field and negative phrasing backfires (the model renders the
+// tokens), so its profile omits the line entirely and relies on positive
+// phrasing. Provider differences live here, never in the shared routing.
+export type VideoModelProfileName = 'veo' | 'seedance'
+
+export type VideoModelProfile = {
+    qualityDirection: string
+    referenceImageDirection: string
+    // null => omit the trailing `Negative prompt: …` line (positive phrasing only).
+    negativePrompt: string | null
+}
+
+export const VIDEO_MODEL_PROFILES: Record<VideoModelProfileName, VideoModelProfile> = {
+    veo: {
+        qualityDirection: 'VEO QUALITY DIRECTION: produce one coherent continuous shot for a short clip, with stable identity, physically plausible motion, consistent scale, clean temporal continuity, and synchronized audio. Keep the subject sharp and materially consistent through the entire motion.',
+        referenceImageDirection: 'REFERENCE-IMAGE DIRECTION: use the attached VEO reference images as asset/content references for the subject, product, character, material, or visual ingredient they show. Preserve the useful visual evidence without blending unrelated identities.',
+        negativePrompt: VEO_NEGATIVE_PROMPT,
+    },
+    seedance: {
+        qualityDirection: 'SEEDANCE QUALITY DIRECTION: produce one cohesive cinematic shot with a clear subject, physically natural motion, stable identity, consistent scale, smooth temporal continuity, deliberate camera movement, filmic lighting, and synchronized audio. Keep the subject crisp and materially consistent throughout the motion, and render every described element affirmatively.',
+        referenceImageDirection: 'REFERENCE-IMAGE DIRECTION: use the attached reference images as asset/content references for the subject, product, character, material, or visual ingredient they show. Preserve the useful visual evidence without blending unrelated identities.',
+        negativePrompt: null,
+    },
+}
+
+// Selects the prompt profile from the SELECTED video model. Keyed off the model
+// version (the same `/seedance/i` vs `/veo/i` signal the providers gate on) so
+// the wrapper stays provider-agnostic and VEO output is byte-identical for every
+// non-Seedance model.
+export const getVideoModelProfile = (state: ProviderState): VideoModelProfile => {
+    const modelVersion = state.videoModelVersion ?? ''
+    if (/seedance/i.test(modelVersion)) return VIDEO_MODEL_PROFILES.seedance
+    return VIDEO_MODEL_PROFILES.veo
+}
+
+const buildInputModeDirection = (state: ProviderState, profile: VideoModelProfile): string => {
     if (state.videoSourceForExtension) {
         return 'EXTENSION CONTINUITY: continue from the final second of the source video. Preserve the existing motion direction, camera momentum, subject identity, lighting, spatial layout, and audio bed. Do not restart the scene or return to the opening composition.'
     }
@@ -45,7 +86,7 @@ const buildInputModeDirection = (state: ProviderState): string => {
     }
 
     if (state.videoReferenceImages && state.videoReferenceImages.length > 0) {
-        return 'REFERENCE-IMAGE DIRECTION: use the attached VEO reference images as asset/content references for the subject, product, character, material, or visual ingredient they show. Preserve the useful visual evidence without blending unrelated identities.'
+        return profile.referenceImageDirection
     }
 
     return 'TEXT-TO-VIDEO DIRECTION: generate one focused short-video moment with a clear subject, coherent physical action, deliberate camera movement, consistent lighting, and synchronized audio.'
@@ -55,20 +96,21 @@ export const buildVideoModelPrompt = (state: ProviderState): string => {
     const prompt = state.generatedVideoPrompt ?? ''
     if (!prompt) return ''
 
+    const profile = getVideoModelProfile(state)
     const featureReferenceImages = state.featureReferenceImages ?? []
     const hasFeatureReferences = featureReferenceImages.length > 0
     const featureUsagePrompt = state.featureUsagePrompt?.trim()
 
     return [
-        'VEO QUALITY DIRECTION: produce one coherent continuous shot for a short clip, with stable identity, physically plausible motion, consistent scale, clean temporal continuity, and synchronized audio. Keep the subject sharp and materially consistent through the entire motion.',
-        buildInputModeDirection(state),
+        profile.qualityDirection,
+        buildInputModeDirection(state, profile),
         hasFeatureReferences || featureUsagePrompt
             ? 'MANDATORY /use FEATURE TRANSFER FOR VIDEO: the feature reference image(s) and feature brief define a reusable visual medium or material, not optional inspiration. Transfer that medium into the moving subject itself so texture, palette, mark-making, grain, edge behavior, and material response remain visible on the subject during motion. Do not copy the feature sample subject, pose, composition, or layout.'
             : undefined,
         featureUsagePrompt ? `FEATURE BRIEF:\n${featureUsagePrompt}` : undefined,
         'USER VIDEO REQUEST:',
         prompt,
-        `Negative prompt: ${VEO_NEGATIVE_PROMPT}`,
+        profile.negativePrompt ? `Negative prompt: ${profile.negativePrompt}` : undefined,
     ].filter((part): part is string => typeof part === 'string' && part.length > 0).join('\n\n')
 }
 

--- a/services/api/src/llm/tools/video-router.test.ts
+++ b/services/api/src/llm/tools/video-router.test.ts
@@ -65,4 +65,35 @@ describe('VideoRouter', () => {
         expect(requestData.messages[0].content).toContain('MANDATORY /use FEATURE TRANSFER FOR VIDEO')
         expect(requestData.videoReferenceImages).toBeUndefined()
     })
+
+    it('caps routed reference images at 3 for VEO (default cap when metadata is absent)', async () => {
+        const { router, process } = createRouter()
+        const refs = Array.from({ length: 5 }, (_, i) => `data:image/png;base64,ref-${i}`)
+
+        await router.execute(createState({
+            videoReferenceImages: refs,
+            featureReferenceImages: [],
+            featureUsagePrompt: undefined,
+        }))
+
+        const requestData = process.mock.calls[0]?.[0]
+        expect(requestData.videoReferenceImages).toEqual(refs.slice(0, 3))
+    })
+
+    it('allows up to the Seedance 9-image cap when the model metadata sets videoMaxReferenceImages', async () => {
+        const { router, process } = createRouter()
+        const refs = Array.from({ length: 12 }, (_, i) => `data:image/png;base64,ref-${i}`)
+
+        await router.execute(createState({
+            videoModelMetaInfo: { provider: 'Google', model: 'Seedance', modelVersion: 'dreamina-seedance-2-0-260128', videoMaxReferenceImages: 9 },
+            videoModelVersion: 'dreamina-seedance-2-0-260128',
+            videoReferenceImages: refs,
+            featureReferenceImages: [],
+            featureUsagePrompt: undefined,
+        }))
+
+        const requestData = process.mock.calls[0]?.[0]
+        expect(requestData.videoReferenceImages).toHaveLength(9)
+        expect(requestData.videoReferenceImages).toEqual(refs.slice(0, 9))
+    })
 })

--- a/services/api/src/llm/tools/video-router.ts
+++ b/services/api/src/llm/tools/video-router.ts
@@ -4,9 +4,8 @@ import { info, warn, err } from '@lixpi/debug-tools'
 
 import type { ProviderRegistry } from '../providers/provider-registry.ts'
 import type { ProviderState } from '../graph/state.ts'
+import { getVideoMaxReferenceImages } from '../graph/state.ts'
 import { buildVideoModelPrompt } from './video-generation-trace.ts'
-
-const MAX_VEO_REFERENCE_IMAGES = 3
 
 const fingerprintRef = (url: string): string => {
     if (!url) return '<empty>'
@@ -21,18 +20,22 @@ const fingerprintRef = (url: string): string => {
     return `${url.slice(0, 60)}...`
 }
 
-const addUniqueReferenceImages = (target: string[], source: string[]): string[] => {
+const addUniqueReferenceImages = (target: string[], source: string[], max: number): string[] => {
     for (const imageUrl of source) {
-        if (target.length >= MAX_VEO_REFERENCE_IMAGES) break
+        if (target.length >= max) break
         if (!target.includes(imageUrl)) target.push(imageUrl)
     }
     return target
 }
 
 const buildRoutedVideoReferenceImages = (state: ProviderState): string[] | undefined => {
-    const referenceImages = addUniqueReferenceImages([], state.videoReferenceImages ?? [])
+    // Provider-aware cap from the selected video model's metadata (VEO 3,
+    // Seedance 9); defaults to 3 so VEO and any model without the field are
+    // unchanged. Without this, Seedance would silently receive at most 3 refs.
+    const max = getVideoMaxReferenceImages(state.videoModelMetaInfo)
+    const referenceImages = addUniqueReferenceImages([], state.videoReferenceImages ?? [], max)
     if (!state.videoSourceForExtension && !state.videoFirstFrameImage) {
-        addUniqueReferenceImages(referenceImages, state.featureReferenceImages ?? [])
+        addUniqueReferenceImages(referenceImages, state.featureReferenceImages ?? [], max)
     }
     return referenceImages.length > 0 ? referenceImages : undefined
 }

--- a/services/api/src/llm/usage/usage-reporter.test.ts
+++ b/services/api/src/llm/usage/usage-reporter.test.ts
@@ -1,0 +1,98 @@
+'use strict'
+
+import { describe, expect, it } from 'vitest'
+
+import { UsageReporter } from './usage-reporter.ts'
+import type { AiModelMetaInfo } from '../graph/state.ts'
+
+const reporter = new UsageReporter()
+
+const baseArgs = {
+    eventMeta: {},
+    aiVendorRequestId: 'req-1',
+    aiRequestReceivedAt: 1,
+    aiRequestFinishedAt: 2,
+}
+
+const veoMeta = {
+    provider: 'Google',
+    model: 'veo-3.1',
+    modelVersion: 'veo-3.1-generate-preview',
+    pricing: { currency: 'USD', resaleMargin: '1', video: { measuringUnit: 'seconds', pricePer: '1', price: '0.40' } },
+} as unknown as AiModelMetaInfo
+
+const seedanceMeta = {
+    provider: 'BytePlus',
+    model: 'dreamina-seedance-2-0-260128',
+    modelVersion: 'dreamina-seedance-2-0-260128',
+    pricing: { currency: 'USD', resaleMargin: '1', video: { measuringUnit: 'tokens', pricePer: '1000000', price: '4.30' } },
+} as unknown as AiModelMetaInfo
+
+describe('UsageReporter.reportVideoUsage', () => {
+    it('bills VEO per second (unchanged): price-per-second × duration', () => {
+        const report = reporter.reportVideoUsage({
+            ...baseArgs,
+            aiModelMetaInfo: veoMeta,
+            durationSeconds: 8,
+            resolution: '1080p',
+            aspectRatio: '16:9',
+        })
+
+        expect(report?.video.measuringUnit).toBe('seconds')
+        expect(report?.video.pricePerSecond).toBe('0.4')
+        expect(report?.video.purchasedFor).toBe('3.2')
+        expect(report?.video.soldToClientFor).toBe('3.2')
+        expect(report?.video.totalTokens).toBeUndefined()
+    })
+
+    it('applies the resale margin to the per-second sold price', () => {
+        const report = reporter.reportVideoUsage({
+            ...baseArgs,
+            aiModelMetaInfo: {
+                ...veoMeta,
+                pricing: { currency: 'USD', resaleMargin: '1.5', video: { measuringUnit: 'seconds', pricePer: '1', price: '0.40' } },
+            } as unknown as AiModelMetaInfo,
+            durationSeconds: 8,
+            resolution: '1080p',
+            aspectRatio: '16:9',
+        })
+
+        expect(report?.video.purchasedFor).toBe('3.2')
+        expect(report?.video.soldToClientFor).toBe('4.8') // 0.40 × 1.5 × 8
+    })
+
+    it('bills Seedance per token: total_tokens × price / pricePer', () => {
+        const report = reporter.reportVideoUsage({
+            ...baseArgs,
+            aiModelMetaInfo: seedanceMeta,
+            durationSeconds: 5,
+            resolution: '720p',
+            aspectRatio: '16:9',
+            totalTokens: 184320,
+            completionTokens: 184320,
+        })
+
+        expect(report?.video.measuringUnit).toBe('tokens')
+        expect(report?.video.totalTokens).toBe(184320)
+        expect(report?.video.pricePer).toBe('1000000')
+        expect(report?.video.price).toBe('4.3')
+        // 184320 × 4.30 / 1_000_000 = 0.792576 (the proposal's "$0.000793" is an arithmetic slip).
+        expect(report?.video.purchasedFor).toBe('0.792576')
+        expect(report?.video.soldToClientFor).toBe('0.792576')
+        expect(report?.video.pricePerSecond).toBeUndefined()
+    })
+
+    it('treats a token-metered model with no token usage as zero cost', () => {
+        const report = reporter.reportVideoUsage({
+            ...baseArgs,
+            aiModelMetaInfo: seedanceMeta,
+            durationSeconds: 5,
+            resolution: '720p',
+            aspectRatio: '16:9',
+        })
+
+        expect(report?.video.measuringUnit).toBe('tokens')
+        expect(report?.video.totalTokens).toBe(0)
+        expect(report?.video.purchasedFor).toBe('0')
+    })
+})

--- a/services/api/src/llm/usage/usage-reporter.ts
+++ b/services/api/src/llm/usage/usage-reporter.ts
@@ -67,11 +67,18 @@ export type VideoUsageReport = {
     aiRequestReceivedAt: number
     aiRequestFinishedAt: number
     video: {
+        measuringUnit: string
         durationSeconds: number
         resolution: string
         aspectRatio: string
-        pricePerSecond: string
-        pricePerSecondResale: string
+        // Per-second metered (VEO).
+        pricePerSecond?: string
+        pricePerSecondResale?: string
+        // Token metered (Seedance via ModelArk).
+        totalTokens?: number
+        completionTokens?: number
+        pricePer?: string
+        price?: string
         purchasedFor: string
         soldToClientFor: string
     }
@@ -199,7 +206,10 @@ export class UsageReporter {
         }
     }
 
-    // Video models (VEO) are billed per second of generated video.
+    // Video models are billed either per second (VEO) or per vendor token
+    // (Seedance via ModelArk). The branch is driven by pricing.video.measuringUnit
+    // so a token-metered provider needs no new call-site — VEO's per-second math
+    // is byte-identical to before.
     reportVideoUsage(args: {
         eventMeta: EventMeta
         aiModelMetaInfo: AiModelMetaInfo
@@ -207,19 +217,52 @@ export class UsageReporter {
         durationSeconds: number
         resolution: string
         aspectRatio: string
+        totalTokens?: number
+        completionTokens?: number
         aiRequestReceivedAt: number
         aiRequestFinishedAt: number
     }): VideoUsageReport | undefined {
         try {
-            const { eventMeta, aiModelMetaInfo, aiVendorRequestId, durationSeconds, resolution, aspectRatio, aiRequestReceivedAt, aiRequestFinishedAt } = args
+            const { eventMeta, aiModelMetaInfo, aiVendorRequestId, durationSeconds, resolution, aspectRatio, totalTokens, completionTokens, aiRequestReceivedAt, aiRequestFinishedAt } = args
             const pricing = aiModelMetaInfo.pricing ?? {}
             const resaleMargin = dec(pricing.resaleMargin, '1.0')
             const videoPricing = (pricing as any).video ?? {}
-            const pricePerSecond = dec(videoPricing.price, '0')
-            const pricePerSecondResale = pricePerSecond.mul(resaleMargin)
-            const seconds = dec(durationSeconds, '0')
-            const purchased = pricePerSecond.mul(seconds)
-            const sold = pricePerSecondResale.mul(seconds)
+            const measuringUnit = videoPricing.measuringUnit ?? 'seconds'
+            const price = dec(videoPricing.price, '0')
+            const priceResale = price.mul(resaleMargin)
+
+            const video: VideoUsageReport['video'] = {
+                measuringUnit,
+                durationSeconds: Number(durationSeconds) || 0,
+                resolution,
+                aspectRatio,
+                purchasedFor: '0',
+                soldToClientFor: '0',
+            }
+
+            let purchased: Decimal
+            let sold: Decimal
+            if (measuringUnit === 'tokens') {
+                // total_tokens × price / pricePer (per-1M-token resource packs).
+                const pricePer = dec(videoPricing.pricePer, '1000000')
+                const tokens = dec(totalTokens, '0')
+                purchased = price.div(pricePer).mul(tokens)
+                sold = priceResale.div(pricePer).mul(tokens)
+                video.totalTokens = Number(totalTokens) || 0
+                video.completionTokens = Number(completionTokens) || 0
+                video.price = price.toString()
+                video.pricePer = pricePer.toString()
+            } else {
+                // seconds (VEO) — unchanged: price-per-second × duration.
+                const seconds = dec(durationSeconds, '0')
+                purchased = price.mul(seconds)
+                sold = priceResale.mul(seconds)
+                video.pricePerSecond = price.toString()
+                video.pricePerSecondResale = priceResale.toString()
+            }
+
+            video.purchasedFor = purchased.toString()
+            video.soldToClientFor = sold.toString()
 
             const report: VideoUsageReport = {
                 eventMeta,
@@ -227,15 +270,7 @@ export class UsageReporter {
                 aiVendorRequestId,
                 aiRequestReceivedAt,
                 aiRequestFinishedAt,
-                video: {
-                    durationSeconds: Number(durationSeconds) || 0,
-                    resolution,
-                    aspectRatio,
-                    pricePerSecond: pricePerSecond.toString(),
-                    pricePerSecondResale: pricePerSecondResale.toString(),
-                    purchasedFor: purchased.toString(),
-                    soldToClientFor: sold.toString(),
-                },
+                video,
             }
 
             // TODO: publish to NATS once usage.videos.ai subject is wired up.

--- a/services/api/src/workloads/functions/ai-models-synchronization/ai-models-synchronization.test.ts
+++ b/services/api/src/workloads/functions/ai-models-synchronization/ai-models-synchronization.test.ts
@@ -2,6 +2,8 @@
 
 import { describe, it, expect, beforeAll } from 'vitest'
 
+import { PROVIDER_NAMES } from '@lixpi/constants'
+
 import { AiModelsSync } from './ai-models-synchronization.ts'
 
 // =============================================================================
@@ -98,5 +100,69 @@ describe('AiModelsSync — VEO video model mapping', () => {
         expect(modalities).toContain('image_generation')
         expect(modalities).not.toContain('video_generation')
         expect(nano.title).toBe('Nano Banana 2')
+    })
+
+    it('does NOT give VEO models a reference cap (absent => provider-aware default of 3)', () => {
+        const veo = sync.mapGoogleModelToAiModel({ name: 'veo-3.1-generate-preview' }, 8)
+        expect(veo.videoMaxReferenceImages).toBeUndefined()
+    })
+})
+
+// =============================================================================
+// BYTEPLUS / SEEDANCE 2.0 VIDEO MODEL SYNC — static injection (mirrors VEO)
+// =============================================================================
+
+describe('AiModelsSync — BytePlus Seedance video model mapping', () => {
+    let sync: any
+
+    beforeAll(() => {
+        process.env.ORG_NAME = process.env.ORG_NAME || 'test-org'
+        process.env.STAGE = process.env.STAGE || 'test'
+        sync = new AiModelsSync({
+            dynamoDBService: {} as any,
+            openaiApiKey: 'test-key',
+            anthropicApiKey: 'test-key',
+            googleApiKey: 'test-key',
+        })
+    })
+
+    it('registers BytePlus as a provider name', () => {
+        expect(PROVIDER_NAMES).toContain('BytePlus')
+    })
+
+    it('exposes both Seedance models in the static list', () => {
+        const ids = sync.getBytePlusModels().map((m: any) => m.id)
+        expect(ids).toEqual(['dreamina-seedance-2-0-260128', 'dreamina-seedance-2-0-fast-260128'])
+    })
+
+    it('maps dreamina-seedance-2-0-260128 with video modalities, token pricing, option lists, and a 9-image reference cap', () => {
+        const model = sync.mapBytePlusModelToAiModel({ id: 'dreamina-seedance-2-0-260128', displayName: 'Seedance 2.0' }, 1)
+        const modalities = model.modalities.map((m: any) => m.modality)
+
+        expect(model.provider).toBe('BytePlus')
+        expect(modalities).toContain('video_generation')
+        expect(modalities).toContain('video')
+        expect(modalities).not.toContain('image_generation')
+
+        expect(model.pricing.video?.measuringUnit).toBe('tokens')
+        expect(model.pricing.video?.pricePer).toBe('1000000')
+        expect(model.pricing.video?.price).toBe('4.30')
+
+        expect(model.videoAspectRatios?.map((o: any) => o.value)).toEqual(['16:9', '4:3', '1:1', '3:4', '9:16', '21:9'])
+        expect(model.videoResolutions?.map((o: any) => o.value)).toEqual(['480p', '720p'])
+        expect(model.videoDurations?.map((o: any) => o.value)).toEqual(['4', '5', '6', '7', '8', '9', '10', '11', '12', '13', '14', '15'])
+        expect(model.videoMaxReferenceImages).toBe(9)
+
+        expect(model.title).toBe('Seedance 2.0')
+        expect(model.shortTitle).toBe('Seedance 2.0')
+    })
+
+    it('maps the fast variant to the cheaper per-1M-token price and a Fast title', () => {
+        const model = sync.mapBytePlusModelToAiModel({ id: 'dreamina-seedance-2-0-fast-260128', displayName: 'Seedance 2.0 Fast' }, 2)
+        expect(model.pricing.video?.measuringUnit).toBe('tokens')
+        expect(model.pricing.video?.price).toBe('3.30')
+        expect(model.videoMaxReferenceImages).toBe(9)
+        expect(model.title).toBe('Seedance 2.0 Fast')
+        expect(model.shortTitle).toBe('Seedance 2.0 Fast')
     })
 })

--- a/services/api/src/workloads/functions/ai-models-synchronization/ai-models-synchronization.ts
+++ b/services/api/src/workloads/functions/ai-models-synchronization/ai-models-synchronization.ts
@@ -58,6 +58,37 @@ const VEO_SAFE_DURATIONS: ImageSizeOption[] = [
     { value: '8', label: '8s' },
 ]
 
+// Seedance 2.0 (BytePlus ModelArk) option lists. Same ImageSizeOption { value,
+// label } shape as VEO so the frontend video dropdowns consume them identically.
+// v1 ships 480p/720p only — 1080p/2k are reported only by aggregators; the
+// official ceiling is unconfirmed (see proposal Risks). No adaptive/auto values.
+const SEEDANCE_ASPECT_RATIOS: ImageSizeOption[] = [
+    { value: '16:9', label: '16:9' },
+    { value: '4:3', label: '4:3' },
+    { value: '1:1', label: '1:1' },
+    { value: '3:4', label: '3:4' },
+    { value: '9:16', label: '9:16' },
+    { value: '21:9', label: '21:9' },
+]
+const SEEDANCE_RESOLUTIONS: ImageSizeOption[] = [
+    { value: '480p', label: '480p' },
+    { value: '720p', label: '720p' },
+]
+const SEEDANCE_DURATIONS: ImageSizeOption[] = [
+    { value: '4', label: '4s' },
+    { value: '5', label: '5s' },
+    { value: '6', label: '6s' },
+    { value: '7', label: '7s' },
+    { value: '8', label: '8s' },
+    { value: '9', label: '9s' },
+    { value: '10', label: '10s' },
+    { value: '11', label: '11s' },
+    { value: '12', label: '12s' },
+    { value: '13', label: '13s' },
+    { value: '14', label: '14s' },
+    { value: '15', label: '15s' },
+]
+
 // OpenAI API types (using SDK types)
 type OpenAIModel = OpenAI.Models.Model
 type AnthropicModel = {
@@ -92,6 +123,7 @@ type ModelDefaults = Pick<
     videoAspectRatios?: ImageSizeOption[]
     videoResolutions?: ImageSizeOption[]
     videoDurations?: ImageSizeOption[]
+    videoMaxReferenceImages?: number
     // Not part of AiModel, used only for provider-grouped sorting
     starSortingPosition: number
     // Transform functions for model properties
@@ -140,6 +172,12 @@ export interface AiModelsSyncResult {
         updatedModels: number
         deletedModels: number
     }
+    byteplus: {
+        processed: number
+        newModels: number
+        updatedModels: number
+        deletedModels: number
+    }
     totalProcessed: number
     totalNew: number
     totalUpdated: number
@@ -181,7 +219,7 @@ export class AiModelsSync {
     }
 
     // Blacklist rules per provider: exact, prefix, and contains (partial-name) patterns
-    private static readonly MODELS_BLACKLIST: { OpenAI: ProviderBlacklist; Anthropic: ProviderBlacklist; Google: ProviderBlacklist; Stability: ProviderBlacklist } = {
+    private static readonly MODELS_BLACKLIST: { OpenAI: ProviderBlacklist; Anthropic: ProviderBlacklist; Google: ProviderBlacklist; Stability: ProviderBlacklist; BytePlus: ProviderBlacklist } = {
         OpenAI: {
             // Exact matches (use for cases like 'gpt-4' to avoid excluding 'gpt-4o')
             exact: [
@@ -272,11 +310,18 @@ export class AiModelsSync {
             exact: [],
             prefix: [],
             contains: []
+        },
+        // BytePlus models are a fixed static list (no list-models API), so nothing
+        // needs blacklisting — kept for shape parity with the other providers.
+        BytePlus: {
+            exact: [],
+            prefix: [],
+            contains: []
         }
     }
 
     // Default model capability/settings per provider.
-    private static readonly MODELS_DEFAULTS: { OpenAI: ProviderModelDefaults; Anthropic: ProviderModelDefaults; Google: ProviderModelDefaults; Stability: ProviderModelDefaults } = {
+    private static readonly MODELS_DEFAULTS: { OpenAI: ProviderModelDefaults; Anthropic: ProviderModelDefaults; Google: ProviderModelDefaults; Stability: ProviderModelDefaults; BytePlus: ProviderModelDefaults } = {
         // OpenAI model defaults sourced from offline docs provided in temp-openai-models-info/.
         // Only differences from fallback are specified; remaining fields inherit via mergeWithFallback.
         OpenAI: {
@@ -602,6 +647,60 @@ export class AiModelsSync {
                     }
                 }
             }
+        },
+        // BytePlus ModelArk — Seedance 2.0 video generation. Static entries (no
+        // model-list API in the repo); token-metered per the Dreamina resource
+        // packs ($4.30/1M tokens, Fast $3.30/1M). videoMaxReferenceImages=9 lets
+        // the provider-aware cap (Phase 2) pass up to 9 references.
+        BytePlus: {
+            exact: {
+                'dreamina-seedance-2-0-260128': {
+                    pricing: { video: { measuringUnit: 'tokens', pricePer: '1000000', price: '4.30' } },
+                },
+                'dreamina-seedance-2-0-fast-260128': {
+                    pricing: { video: { measuringUnit: 'tokens', pricePer: '1000000', price: '3.30' } },
+                },
+            },
+            prefix: [],
+            contains: [],
+            fallback: {
+                contextWindow: 0,
+                maxCompletionSize: 0,
+                defaultTemperature: 0.7,
+                supportsSystemPrompt: false,
+                modalities: ['video', 'video_generation'],
+                videoAspectRatios: SEEDANCE_ASPECT_RATIOS,
+                videoResolutions: SEEDANCE_RESOLUTIONS,
+                videoDurations: SEEDANCE_DURATIONS,
+                videoMaxReferenceImages: 9,
+                pricing: {
+                    currency: 'USD',
+                    resaleMargin: '1',
+                    video: { measuringUnit: 'tokens', pricePer: '1000000', price: '4.30' }
+                },
+                // Brand color is a reasonable default; iconName 'seedanceIcon' is a
+                // forward-compatible key (AI_AVATAR_ICONS lookup degrades to no icon
+                // until an SVG is registered under it) — cosmetic, confirm asset.
+                color: '#1664FF',
+                iconName: 'seedanceIcon',
+                starSortingPosition: 250,
+                transforms: {
+                    title: (modelId: string) => {
+                        const names: Record<string, string> = {
+                            'dreamina-seedance-2-0-260128': 'Seedance 2.0',
+                            'dreamina-seedance-2-0-fast-260128': 'Seedance 2.0 Fast',
+                        }
+                        return names[modelId] || modelId
+                    },
+                    shortTitle: (modelId: string) => {
+                        const names: Record<string, string> = {
+                            'dreamina-seedance-2-0-260128': 'Seedance 2.0',
+                            'dreamina-seedance-2-0-fast-260128': 'Seedance 2.0 Fast',
+                        }
+                        return names[modelId] || modelId
+                    }
+                }
+            }
         }
     }
 
@@ -633,6 +732,7 @@ export class AiModelsSync {
             videoAspectRatios: Array.isArray(p.videoAspectRatios) ? p.videoAspectRatios : fallback.videoAspectRatios,
             videoResolutions: Array.isArray(p.videoResolutions) ? p.videoResolutions : fallback.videoResolutions,
             videoDurations: Array.isArray(p.videoDurations) ? p.videoDurations : fallback.videoDurations,
+            videoMaxReferenceImages: typeof p.videoMaxReferenceImages === 'number' ? p.videoMaxReferenceImages : fallback.videoMaxReferenceImages,
             pricing: this.mergePricingWithFallback(p.pricing as any, fallback.pricing),
             color: typeof (p as any).color === 'string' ? (p as any).color : fallback.color,
             iconName: typeof (p as any).iconName === 'string' ? (p as any).iconName : fallback.iconName,
@@ -956,6 +1056,7 @@ export class AiModelsSync {
             videoAspectRatios: modelDefaults.videoAspectRatios,
             videoResolutions: modelDefaults.videoResolutions,
             videoDurations: modelDefaults.videoDurations,
+            videoMaxReferenceImages: modelDefaults.videoMaxReferenceImages,
             pricing: modelDefaults.pricing,
             createdAt: now,
             updatedAt: now
@@ -1438,6 +1539,150 @@ export class AiModelsSync {
         }
     }
 
+    // BytePlus ModelArk models (hardcoded — no list-models API in the repo).
+    // Seedance 2.0 video generation; mirrors the Stability static-injection path.
+    private getBytePlusModels(): Array<{ id: string; displayName: string }> {
+        return [
+            { id: 'dreamina-seedance-2-0-260128', displayName: 'Seedance 2.0' },
+            { id: 'dreamina-seedance-2-0-fast-260128', displayName: 'Seedance 2.0 Fast' },
+        ]
+    }
+
+    // Map a BytePlus model to our AiModel format. Mirrors mapStabilityModelToAiModel
+    // but carries the video option lists + reference cap (Seedance is video-only).
+    private mapBytePlusModelToAiModel(model: { id: string; displayName: string }, sortingPosition: number): AiModel {
+        const modelDefaults = this.resolveModelDefaults('BytePlus', model.id)
+
+        const now = Date.now()
+
+        const aiModel: AiModel = {
+            provider: 'BytePlus',
+            model: model.id,
+            title: model.displayName,
+            shortTitle: model.displayName,
+            modelVersion: model.id,
+            imagePromptMaxChars: modelDefaults.imagePromptMaxChars,
+            contextWindow: modelDefaults.contextWindow,
+            maxCompletionSize: modelDefaults.maxCompletionSize,
+            defaultTemperature: modelDefaults.defaultTemperature,
+            supportsSystemPrompt: modelDefaults.supportsSystemPrompt,
+            color: modelDefaults.color,
+            iconName: modelDefaults.iconName,
+            sortingPosition: modelDefaults.starSortingPosition + sortingPosition,
+            modalities: generateModalitiesWithMetadata(modelDefaults.modalities),
+            imageSizes: modelDefaults.imageSizes,
+            videoAspectRatios: modelDefaults.videoAspectRatios,
+            videoResolutions: modelDefaults.videoResolutions,
+            videoDurations: modelDefaults.videoDurations,
+            videoMaxReferenceImages: modelDefaults.videoMaxReferenceImages,
+            pricing: modelDefaults.pricing,
+            createdAt: now,
+            updatedAt: now
+        }
+
+        // Apply transforms to model properties
+        if (modelDefaults.transforms) {
+            for (const [key, transformFn] of Object.entries(modelDefaults.transforms)) {
+                if (transformFn) {
+                    (aiModel as any)[key] = transformFn(model.id)
+                }
+            }
+        }
+
+        return aiModel
+    }
+
+    // Synchronize BytePlus (Seedance) models with database. Mirrors the Stability
+    // path exactly (static list -> map -> diff against DB -> delete/insert/update).
+    private async synchronizeBytePlusModels() {
+        if (!this.aiModelsListTableName) {
+            throw new Error('AI_MODELS_LIST_TABLE_NAME environment variable is required')
+        }
+
+        info('🔄 Starting BytePlus models synchronization')
+
+        try {
+            const bytePlusModels = this.getBytePlusModels()
+            info(`📡 Using ${bytePlusModels.length} hardcoded BytePlus models`)
+
+            const mappedModels: AiModel[] = bytePlusModels.map((model, index) =>
+                this.mapBytePlusModelToAiModel(model, index + 1)
+            )
+
+            info(`🔧 Mapped ${mappedModels.length} BytePlus models to our format:`)
+            mappedModels.forEach((model, index) => {
+                info(`  ${index + 1}. ${model.model} - ${model.title}`)
+            })
+
+            const existingModelsResult = await this.dynamoDBService.queryItems({
+                tableName: this.aiModelsListTableName,
+                keyConditions: { provider: 'BytePlus' },
+                fetchAllItems: true,
+                origin: `Service::${this.serviceName}`
+            })
+
+            const existingModels = existingModelsResult.items
+            const existingModelIds: string[] = existingModels.map((model: any) => model.model)
+            const fetchedModelIds: string[] = mappedModels.map(model => model.model)
+
+            info(`Found ${existingModels.length} existing BytePlus models in database`)
+
+            const modelsToDelete = existingModels.filter((existingModel: any) =>
+                fetchedModelIds.indexOf(existingModel.model) === -1
+            )
+
+            const newModels = mappedModels.filter(model => existingModelIds.indexOf(model.model) === -1)
+            const modelsToUpdate = mappedModels.filter(model => existingModelIds.indexOf(model.model) !== -1)
+
+            info(`Processing ${newModels.length} new BytePlus models, ${modelsToUpdate.length} existing models, and ${modelsToDelete.length} models to delete`)
+
+            if (modelsToDelete.length > 0) {
+                info(`🗑️ Deleting ${modelsToDelete.length} obsolete BytePlus models`)
+
+                for (const modelToDelete of modelsToDelete) {
+                    try {
+                        await this.dynamoDBService.deleteItems({
+                            tableName: this.aiModelsListTableName,
+                            key: { provider: (modelToDelete as any).provider, model: (modelToDelete as any).model },
+                            origin: `Service::${this.serviceName}`
+                        })
+                        info(`Deleted obsolete BytePlus model: ${(modelToDelete as any).model}`)
+                    } catch (error) {
+                        err(`Failed to delete BytePlus model ${(modelToDelete as any).model}:`, error)
+                        throw error
+                    }
+                }
+                info(`✅ Successfully deleted ${modelsToDelete.length} obsolete BytePlus models`)
+            }
+
+            if (newModels.length > 0) {
+                await this.dynamoDBService.batchWriteItems({
+                    tableName: this.aiModelsListTableName,
+                    items: newModels,
+                    origin: `Service::${this.serviceName}`
+                })
+                info(`Inserted ${newModels.length} new BytePlus models`)
+            }
+
+            if (modelsToUpdate.length > 0) {
+                await this.updateModelsSequentially(modelsToUpdate, this.aiModelsListTableName, `Service::${this.serviceName}`)
+            }
+
+            info('✅ BytePlus models synchronization completed successfully')
+
+            return {
+                processed: mappedModels.length,
+                newModels: newModels.length,
+                updatedModels: modelsToUpdate.length,
+                deletedModels: modelsToDelete.length
+            }
+
+        } catch (error) {
+            err('❌ BytePlus models synchronization failed:', error)
+            throw error
+        }
+    }
+
     // Main synchronization method
     async synchronizeModels(): Promise<AiModelsSyncResult> {
         info(`🚀 Starting AI models synchronization - Service: ${this.serviceName}`)
@@ -1459,15 +1704,20 @@ export class AiModelsSync {
             const stabilityResult = await this.synchronizeStabilityModels()
             info(`Stability AI synchronization completed: ${JSON.stringify(stabilityResult)}`)
 
+            // Synchronize BytePlus (Seedance) models
+            const bytePlusResult = await this.synchronizeBytePlusModels()
+            info(`BytePlus synchronization completed: ${JSON.stringify(bytePlusResult)}`)
+
             const totalResult = {
                 openAI: openAIResult,
                 anthropic: anthropicResult,
                 google: googleResult,
                 stability: stabilityResult,
-                totalProcessed: openAIResult.processed + anthropicResult.processed + googleResult.processed + stabilityResult.processed,
-                totalNew: openAIResult.newModels + anthropicResult.newModels + googleResult.newModels + stabilityResult.newModels,
-                totalUpdated: openAIResult.updatedModels + anthropicResult.updatedModels + googleResult.updatedModels + stabilityResult.updatedModels,
-                totalDeleted: openAIResult.deletedModels + anthropicResult.deletedModels + googleResult.deletedModels + stabilityResult.deletedModels
+                byteplus: bytePlusResult,
+                totalProcessed: openAIResult.processed + anthropicResult.processed + googleResult.processed + stabilityResult.processed + bytePlusResult.processed,
+                totalNew: openAIResult.newModels + anthropicResult.newModels + googleResult.newModels + stabilityResult.newModels + bytePlusResult.newModels,
+                totalUpdated: openAIResult.updatedModels + anthropicResult.updatedModels + googleResult.updatedModels + stabilityResult.updatedModels + bytePlusResult.updatedModels,
+                totalDeleted: openAIResult.deletedModels + anthropicResult.deletedModels + googleResult.deletedModels + stabilityResult.deletedModels + bytePlusResult.deletedModels
             }
 
             info('✅ AI models synchronization completed successfully')


### PR DESCRIPTION
## Summary

Adds a first-party **BytePlus** provider that generates video through **BytePlus ModelArk's** official Seedance 2.0 API, plugging into the existing shared video pipeline as a clean peer of the VEO (Google) provider. Implements the proposal in `documentation/memory/SEEDANCE-2.0-VIDEO-GENERATION.md`.

VEO behaviour, dropdowns, and pricing stay **byte-identical**. No new database table, no new NATS subjects.

## Phased delivery (each phase is a separate commit)

- [x] **Phase 1 — prompt generalization**: `buildVideoModelPrompt` → shared core + per-provider `VIDEO_MODEL_PROFILES` (`veo`/`seedance`). VEO output byte-identical; Seedance uses positive-only phrasing and omits the negative-prompt line.
- [x] **Phase 2 — provider-aware reference cap**: metadata-driven `videoMaxReferenceImages` (VEO 3, Seedance 9) via one shared `getVideoMaxReferenceImages` helper in the router + branch resolver.
- [x] **Phase 3 — model metadata**: `BytePlus` in `PROVIDER_NAMES`; registry ctor map made `Partial`; static Seedance entries + option lists + token pricing in model sync (mirrors the Stability path).
- [x] **Phase 4 — `BytePlusProvider`**: typed ModelArk REST client (create/poll/download), text-to-video, first-frame, reference-image (≤9), reject extension + private `nats-obj://` URIs; download + store in-request; existing video NATS lifecycle.
- [x] **Phase 5 — token billing**: `reportVideoUsage` branches on `pricing.video.measuringUnit` (seconds = VEO, tokens = Seedance); token usage threaded from the provider response.
- [x] **Phase 6 — config + docs**: `ARK_API_KEY` wired through the init script + env template (with `BYTEPLUS_ARK_*` overrides); `VIDEO-GENERATION.md` + `llm/README.md` updated.
- [x] **Phase 7 — verification**: full API suite **176/176 green**, no regressions.

## Testing

Run via vitest inside the `lixpi-api` container against the worktree code (the live container bind-mounts the main checkout, so the worktree `src` is copied into a temp dir there). **31 files / 176 tests pass**, covering prompt generalization (VEO byte-identical + Seedance), the provider-aware ref cap, model-sync mapping, the ModelArk REST client + payload construction + poll transitions (mocked `fetch`), and per-second/per-token billing.

## Notes for reviewers (open items)

- **Proposal arithmetic fix:** happy-path step 13 says `184320 × 4.30 / 1_000_000 ≈ $0.000793` — that actually equals **0.792576** (~$0.79, a ~1000× slip). The code + test use the correct value.
- **Vendor facts to confirm at integration** (proposal Risks; docs are JS-rendered so unverified here): the ModelArk `content[]` image-item wire shape `{type:'image_url', image_url:{url}, role}` (isolated in one module), the 720p resolution ceiling (v1 ships 480p/720p only), and whether a native negative-prompt field exists (v1 omits negatives either way).
- **Cosmetic:** `iconName: 'seedanceIcon'` is a forward-compatible placeholder (the icon lookup degrades to no-icon until an SVG is registered); `color` is a reasonable default. Confirm the brand asset.
- **Out of scope (Phase 8):** source-video extension / reference-video / reference-audio need a provider-fetchable asset handoff.

Closes #213
