### PR TITLE
LIX-234 # Move AI chat context previews into composer

### DIFF
--- a/documentation/ai-chat/CHAT-PANEL-AND-SESSIONS.md
+++ b/documentation/ai-chat/CHAT-PANEL-AND-SESSIONS.md
@@ -1,20 +1,20 @@
 ---
 title: Chat Panel and Sessions
-description: The workspace-owned AI Chat panel, its tabbed surface, standalone and extraction sessions, context tray, and persistence model.
+description: The workspace-owned AI Chat panel, its tabbed surface, standalone and extraction sessions, composer context previews, and persistence model.
 ---
 
 # Chat Panel and Sessions
 
 The AI Chat panel is a workspace-owned right-side surface that opens, persists,
 and restores independently of any canvas node. It hosts durable standalone chat
-tabs, extraction tabs, prompt drafts, explicit context chips, automatic
-workspace relevance feedback, and a collapsible Sessions list that merges
+tabs, extraction tabs, prompt drafts, explicit composer context previews,
+automatic workspace relevance feedback, and a collapsible Sessions list that merges
 standalone chats with feature-extraction sessions for the workspace.
 
 The panel is a presentation surface, not a conversation entity. Opening it,
-resizing it, toggling Sessions, editing a draft, or changing context chips all
-persist through `CanvasState.aiChatPanel` — but none of them create a durable
-session record. A standalone chat exists only once the user submits a prompt.
+resizing it, toggling Sessions, editing a draft, or changing composer context all
+persist through `CanvasState.aiChatPanel` until submit — but none of them create
+a durable session record. A standalone chat exists only once the user submits a prompt.
 This page covers the panel surface and the session model; the relevance engine
 that selects context for each turn is owned by
 [Workspace Context Relevance](./CONTEXT-RELEVANCE.md), what happens when a turn
@@ -35,16 +35,18 @@ Current context relevance is documented in
 
 **AI Chat Panel** — A singleton workspace surface. It can be open with zero
 tabs. Opening, closing, resizing, toggling Sessions, editing a draft, and
-changing explicit context chips persist through `CanvasState.aiChatPanel`; none
-of these create a durable session record by themselves.
+changing explicit composer context persist through `CanvasState.aiChatPanel`
+until the next submit; none of these create a durable session record by
+themselves.
 
 **Standalone Chat** — An `AiChatThread` with owner `{ type: 'standalone' }`,
 created only when the user submits the first prompt from a panel draft. Its
 outgoing context is explicit chips plus the API's automatic workspace relevance
 selection for that turn.
 
-**Context Chip** — A persisted explicit force-include in the panel's context
-tray. Chips are removable and sanitized against live canvas nodes. The chip vs
+**Context Preview** — A composer-embedded explicit force-include preview.
+Previews are removable, sanitized against live canvas nodes, and cleared after
+submit so the next turn falls back to automatic workspace relevance. The chip vs
 auto-chip distinction and the relevance engine that consumes them live in
 [Workspace Context Relevance](./CONTEXT-RELEVANCE.md).
 
@@ -94,7 +96,7 @@ flowchart TB
     subgraph Panel["AI Chat Panel"]
         Strip[Tab strip<br/>pinned top, always visible]
         Body[Active tab body]
-        Tray[Context chip tray + composer]
+        Composer[Composer<br/>context previews inside input]
         Sessions[Sessions list<br/>collapsed by default]
     end
 
@@ -106,7 +108,7 @@ flowchart TB
     Strip --> Body
     Body --> Thread
     Body --> Extraction
-    Body --> Tray
+    Body --> Composer
     Strip -.toggle.-> Sessions
 ```
 
@@ -117,7 +119,7 @@ flowchart TB
   a centered text label, truncates to the available segment width, and reveals a
   close control on the left while hovered. The active tab is the sliding
   indicator surface, not a per-tab border.
-- **Selecting canvas nodes** can add explicit context chips while the panel is
+- **Selecting canvas nodes** can add explicit composer context while the panel is
   open; it does not create or activate a canvas thread node.
 - **All extraction triggers** open a new `extraction` tab.
 - **Closing the last tab** leaves the durable session reopenable from Sessions;
@@ -126,20 +128,25 @@ flowchart TB
   `settings.aiChatThread.panelTabs.minTabWidth`, not an overflow dropdown. This
   keeps tab positions predictable, matching Cursor.
 
-## Context Tray
+## Composer Context Previews
 
-The old Follow / Pinned / With Sources controls are gone. The panel now uses a
-chip tray above the composer:
+The old Follow / Pinned / With Sources controls are gone. The panel now renders
+explicit and automatic context as media/document previews inside the prompt
+input's white composer area:
 
-- Explicit chips persist in `CanvasState.aiChatPanel.contextChips`.
-- Selecting eligible canvas nodes while the panel is open can add chips.
-- Removing a chip does not tear down the ProseMirror composer or draft.
+- Explicit previews are stored in `CanvasState.aiChatPanel.contextChips` as the
+  current draft's forced node ids.
+- Selecting eligible canvas nodes while the panel is open can add previews.
+- Removing a preview does not tear down the ProseMirror composer or draft.
 - Deleted nodes and duplicate IDs are sanitized out of persisted panel state.
 - Generated branch roots are normal media chip targets; their provenance is
   reconstructed from `generatedBy` metadata rather than from a separate canvas
   node.
 - Auto chips render after `CONTEXT_RELEVANCE_RESOLVED` and can be removed from
-  the visible tray without persisting.
+  the visible composer without persisting.
+- Submitting a prompt snapshots the explicit preview ids for that turn, clears
+  the explicit set, and lets the next prompt fall back to automatic workspace
+  relevance unless the user selects new context.
 
 On submit, explicit chips are resolved through the same extraction path used by
 canvas-thread context. The browser also sends a `WorkspaceContextSnapshot`, a
@@ -148,7 +155,7 @@ snapshot, force-includes chip and edge-connected nodes, and streams its
 resolution back to the panel.
 
 {% callout type="tip" %}
-The chip tray is the panel's surface for context; the ranking, self-heal,
+The composer preview strip is the panel's surface for context; the ranking, self-heal,
 force-include, and auto-chip behavior all live in the relevance engine. For the
 chip vs auto-chip contract and the resolver flow, see
 [Workspace Context Relevance](./CONTEXT-RELEVANCE.md).
@@ -272,7 +279,7 @@ aiChatPanel?: {
 | `isSessionHistoryOpen` | Whether the Sessions list is expanded |
 | `tabs` | Ordered tab presentation: thread vs extraction, ref id, title |
 | `activeTabId` | The currently focused tab |
-| `contextChips` | Explicit force-include chip node IDs |
+| `contextChips` | Current draft's explicit force-include preview node IDs; cleared after submit |
 | `width` | Persisted panel width |
 | `drafts` | Per-tab ProseMirror draft content |
 
@@ -292,7 +299,7 @@ canvas state.
 
 ## Current Status
 
-The panel, standalone ownership model, context chip tray, workspace relevance
+The panel, standalone ownership model, composer context previews, workspace relevance
 feedback, Sessions projection, and extraction-session history are implemented in
 the web UI and API:
 
@@ -331,7 +338,7 @@ the last persisted state, not the tokens that were streaming at reload time.
 | Sliding switch primitive | `services/web-ui/src/components/slidingSwitch/slidingSwitch.ts` |
 | Tab pill primitive | `services/web-ui/src/components/tagPill/tagPill.ts` |
 | Launcher + persistence | `services/web-ui/src/components/WorkspaceCanvas.svelte` |
-| Panel state + chip sanitization | `services/web-ui/src/infographics/workspace/aiChatPanelState.ts` |
+| Panel state + draft context sanitization | `services/web-ui/src/infographics/workspace/aiChatPanelState.ts` |
 | Panel tab settings | `services/web-ui/src/settings.ts` |
 | Standalone thread model | `services/api/src/models/ai-chat-thread.ts` |
 | Standalone thread subjects | `services/api/src/NATS/subscriptions/ai-chat-thread-subjects.ts` |

--- a/documentation/ai-chat/CONTEXT-RELEVANCE.md
+++ b/documentation/ai-chat/CONTEXT-RELEVANCE.md
@@ -33,9 +33,10 @@ nodes. `MediaDescriptor` remains an alias for media nodes, but the shared shape
 is `ContentDescriptor`. Full lifecycle, sourcing, and self-heal detail live in
 [Media and Content Descriptors](./MEDIA-DESCRIPTORS.md).
 
-**Context Chip** — A persisted explicit force-include in the AI Chat panel.
-Chips live in `CanvasState.aiChatPanel.contextChips`, render above the composer,
-and are removable by the user.
+**Context Chip** — An explicit force-include selected in the AI Chat panel.
+Chips live in `CanvasState.aiChatPanel.contextChips` for the current draft,
+render as media/document previews inside the composer, are removable by the
+user, and clear after submit.
 
 **Auto Chip** — An ephemeral chip created from `CONTEXT_RELEVANCE_RESOLVED`. Auto
 chips show what the relevance engine selected. They are visually distinct from
@@ -113,7 +114,7 @@ the media bytes the resolver pulls stills from.
 %%{init: {'theme': 'base', 'themeVariables': { 'primaryColor': '#F6C7B3', 'primaryTextColor': '#5a3a2a', 'primaryBorderColor': '#d4956a', 'secondaryColor': '#C3DEDD', 'secondaryTextColor': '#1a3a47', 'secondaryBorderColor': '#4a8a9d', 'tertiaryColor': '#DCECE9', 'tertiaryTextColor': '#1a3a47', 'tertiaryBorderColor': '#82B2C0', 'lineColor': '#d4956a', 'textColor': '#5a3a2a'}}}%%
 flowchart TB
     subgraph Browser["Browser Workspace"]
-        Panel[AI Chat Panel<br/>context chip tray]
+        Panel[AI Chat Panel<br/>composer context previews]
         Snapshot[buildWorkspaceContextSnapshot<br/>descriptors only]
         AIS[AiInteractionService]
         Canvas[WorkspaceCanvas.ts<br/>generation placement + branch-tree layout]
@@ -250,7 +251,7 @@ without invoking pixel branch routing.
 
 ## Context Chips vs Auto Chips
 
-The AI Chat panel owns the context tray. Opening the panel creates no session
+The AI Chat panel owns the composer context previews. Opening the panel creates no session
 and no hidden canvas node; the first submit creates a standalone `AiChatThread`
 only when a prompt is sent (see
 [Chat Panel and Sessions](./CHAT-PANEL-AND-SESSIONS.md)).
@@ -258,14 +259,16 @@ only when a prompt is sent (see
 | Aspect | Context Chip (explicit) | Auto Chip |
 |--------|-------------------------|-----------|
 | Origin | User selects an eligible canvas node | Relevance engine selection in `CONTEXT_RELEVANCE_RESOLVED` |
-| Persistence | Stored in `CanvasState.aiChatPanel.contextChips` | Ephemeral; never persisted |
+| Persistence | Stored as the current draft's `CanvasState.aiChatPanel.contextChips`; cleared after submit | Ephemeral; never persisted |
 | Selection role | `forced-chip` | `auto` |
-| Force-included? | Always, on every turn | No — re-evaluated each turn |
-| Removal | User removes; persists | User removes from the visible turn surface only |
+| Force-included? | Yes, for the submitted turn | No — re-evaluated each turn |
+| Removal | User removes from the current draft | User removes from the visible turn surface only |
 
-Explicit chips are persisted in `CanvasState.aiChatPanel.contextChips`.
-Selecting canvas nodes while the panel is open can add new eligible nodes as
-chips. Deleted nodes and duplicate IDs are sanitized out of panel state.
+Explicit chips are stored in `CanvasState.aiChatPanel.contextChips` while the
+prompt is being drafted. Selecting canvas nodes while the panel is open can add
+new eligible nodes as chips. Deleted nodes and duplicate IDs are sanitized out
+of panel state, and submit clears the explicit chip set after the turn snapshots
+it.
 Generated-media branch roots are normal image/video nodes. They can be selected
 as context like other media, and their branch provenance is reconstructed from
 `generatedBy` metadata (see [Branch Lineage](../media-generation/BRANCH-LINEAGE.md)).
@@ -386,7 +389,7 @@ There is no live context-region feature page.
 ## References
 
 - [Media and Content Descriptors](./MEDIA-DESCRIPTORS.md) — descriptor shape, sourcing, self-heal, indicator
-- [Chat Panel and Sessions](./CHAT-PANEL-AND-SESSIONS.md) — the panel that owns the context tray
+- [Chat Panel and Sessions](./CHAT-PANEL-AND-SESSIONS.md) — the panel that owns composer context previews
 - [AI Generation Pipeline](../platform/AI-GENERATION-PIPELINE.md) — the `resolveWorkspaceContext` workflow node, routing, and usage
 - [Streaming and Events](../platform/STREAMING-AND-EVENTS.md) — `CONTEXT_RELEVANCE_RESOLVED` and the full event catalog
 - [Branch Lineage](../media-generation/BRANCH-LINEAGE.md) — `resolveImageBranch`, structured VLM media-role assignment, placement anchors

--- a/services/web-ui/src/components/proseMirror/components/editor.ts
+++ b/services/web-ui/src/components/proseMirror/components/editor.ts
@@ -277,6 +277,7 @@ export class ProseMirrorEditor {
                     onSubmit: (data) => this.onPromptSubmit?.(data),
                     onStop: () => this.onPromptStop?.(),
                     isReceiving: () => this.isPromptReceiving?.() ?? false,
+                    createContextTray: this.promptControlFactories?.createContextTray,
                     createModelDropdown: this.promptControlFactories?.createModelDropdown,
                     createImageModelDropdown: this.promptControlFactories?.createImageModelDropdown,
                     createImageSizeDropdown: this.promptControlFactories?.createImageSizeDropdown,

--- a/services/web-ui/src/components/proseMirror/plugins/aiPromptInputPlugin/README.md
+++ b/services/web-ui/src/components/proseMirror/plugins/aiPromptInputPlugin/README.md
@@ -9,6 +9,7 @@ This plugin powers prompt input editors. It provides:
 - An AI model selector dropdown
 - An image model selector dropdown (with size selector)
 - Contextual help tooltips for the reasoning, image, and video model sections
+- Optional injected context-preview strip for surfaces that need composer-owned context chrome
 - A submit/stop button
 - Placeholder text when the input is empty
 - Keyboard shortcut support (Cmd/Ctrl + Enter to submit)
@@ -60,6 +61,7 @@ graph TD
 - **Decoupled from threads:** The plugin only handles input composition and extraction, never touches thread state or streaming
 - **Adapter pattern:** NodeView controls bridge ProseMirror node attrs (`aiModel`, `imageGenerationSize`) to UI controls via getter/setter adapters
 - **Factory injection:** UI controls (dropdowns, buttons) are injected via factory functions, keeping the plugin framework-agnostic
+- **Optional context chrome:** Host surfaces can inject a context preview strip into the white input area without making the plugin own context state
 - **Polling for external state:** Receiving state is synced via a 200ms polling interval since it's owned by external services, not plugin state
 
 ## Data Flow
@@ -163,6 +165,7 @@ The `createAiPromptInputNodeView` factory returns a ProseMirror NodeView with th
 
 ```
 div.ai-prompt-input-wrapper [data-empty="true"|"false"]
+├── [Optional context preview strip]   ← injected via createContextTray()
 ├── div.ai-prompt-input-content        ← contentDOM (editable)
 └── div.ai-prompt-input-controls
     ├── button.ai-prompt-model-menu-trigger
@@ -185,17 +188,18 @@ const modelControls: AiModelControls = {
 }
 ```
 
-This keeps the controls stateless — the ProseMirror document is the single source of truth. The bottom control row only shows the model settings trigger and submit button by default; model dropdowns live in the shared `BubbleMenu` surface. Section help uses the reusable `helpTooltip` TypeScript-html component, which positions its tooltip against the visible viewport instead of assuming there is room on one side.
+This keeps the controls stateless — the ProseMirror document is the single source of truth. The bottom control row only shows the model settings trigger and submit button by default; model dropdowns live in the shared `BubbleMenu` surface. Section help uses the reusable `helpTooltip` TypeScript-html component, which positions its tooltip against the visible viewport instead of assuming there is room on one side. When `createContextTray()` is supplied, the returned element is inserted before the editable content so context previews occupy the white input area and increase composer height without changing the gradient border container.
 
 ### State Synchronization
 
 - **Empty state:** `data-empty` attribute on the wrapper toggles placeholder visibility via SCSS. Updated on every `update()` call.
+- **Placeholder owner:** The NodeView copies `placeholderText` onto `.ai-prompt-input-content`, so injected context previews can push the editable content down while the placeholder stays aligned with the text insertion point.
 - **Receiving state:** The `receiving` CSS class on `.ai-prompt-input-controls` is polled every 200ms via `options.isReceiving()`. This external state comes from `AiPromptInputController.isReceiving()` which tracks which thread IDs are currently streaming.
 
 ### NodeView Lifecycle
 
 - **`ignoreMutation()`** — Returns `true` for mutations inside the controls container, preventing ProseMirror from recreating the NodeView when dropdowns or buttons change.
-- **`stopEvent()`** — Returns `true` for events targeting the controls container, preventing ProseMirror from stealing focus/clicks from dropdowns and buttons.
+- **`stopEvent()`** — Returns `true` for events targeting the controls container or injected context preview strip, preventing ProseMirror from stealing focus/clicks from dropdowns, buttons, and context preview remove controls.
 - **`update()`** — Accepts updates only for `aiPromptInput` nodes. Syncs empty state, receiving state, and calls `update()` on every model dropdown.
 - **`destroy()`** — Clears the receiving poll interval, destroys the model `BubbleMenu`, and calls `destroy()` on dropdowns.
 
@@ -218,6 +222,7 @@ createAiPromptInputPlugin({
     onSubmit: (data) => { /* { contentJSON, aiModel, imageOptions } */ },
     onStop: () => { /* stop streaming */ },
     isReceiving: () => boolean,
+    createContextTray: () => HTMLElement | null,
     createModelDropdown: (controls, dropdownId) => ({ dom, update, destroy }),
     createImageModelDropdown: (controls, dropdownId) => ({ dom, update, destroy }),
     createImageSizeDropdown: (controls, dropdownId) => ({ dom, update, destroy }),
@@ -244,7 +249,10 @@ A single decoration layer: **placeholder decoration**. When the `aiPromptInput` 
 - Class: `empty-node-placeholder`
 - Attribute: `data-placeholder` set to the configured `placeholderText`
 
-SCSS renders the placeholder via `::before` pseudo-element using `content: attr(data-placeholder)`.
+The visible placeholder is rendered by `.ai-prompt-input-content::before`. The
+NodeView copies `placeholderText` onto the content element so the placeholder
+belongs to the editable text area, not to the wrapper that can also contain
+injected context previews.
 
 ## Integration with WorkspaceCanvas
 

--- a/services/web-ui/src/components/proseMirror/plugins/aiPromptInputPlugin/ai-prompt-input.scss
+++ b/services/web-ui/src/components/proseMirror/plugins/aiPromptInputPlugin/ai-prompt-input.scss
@@ -137,6 +137,11 @@
     }
 }
 
+.ai-prompt-input-wrapper.empty-node-placeholder[data-placeholder]::before {
+    display: none;
+    content: none;
+}
+
 .ai-prompt-input-content {
     position: relative;
     flex: 1;

--- a/services/web-ui/src/components/proseMirror/plugins/aiPromptInputPlugin/aiPromptInputNode.ts
+++ b/services/web-ui/src/components/proseMirror/plugins/aiPromptInputPlugin/aiPromptInputNode.ts
@@ -121,6 +121,8 @@ type AiPromptInputNodeViewOptions = {
     onSubmit: () => void
     onStop: () => void
     isReceiving: () => boolean
+    placeholderText?: string
+    createContextTray?: () => HTMLElement | null
     createModelDropdown: (controls: AiModelControls, dropdownId: string) => DropdownView
     createImageModelDropdown: (controls: ImageModelControls, dropdownId: string) => DropdownView
     createImageSizeDropdown: (controls: ImageSizeControls, dropdownId: string) => DropdownView
@@ -306,8 +308,10 @@ function createModelMenuTrigger(onClick: (event: MouseEvent) => void): HTMLButto
 export function createAiPromptInputNodeView(options: AiPromptInputNodeViewOptions) {
     return (node: ProseMirrorNode, view: EditorView, getPos: () => number | undefined) => {
         const dom = html`<div className="ai-prompt-input-wrapper"></div>` as HTMLDivElement
+        const contextTrayEl = options.createContextTray?.() ?? null
         const contentDOM = html`<div className="ai-prompt-input-content"></div>` as HTMLDivElement
         const controlsEl = html`<div className="ai-prompt-input-controls"></div>` as HTMLDivElement
+        contentDOM.setAttribute('data-placeholder', options.placeholderText ?? '')
         applyModelMenuStyleSettings(dom)
 
         // Build controls adapters that read/write ProseMirror node attrs
@@ -446,6 +450,7 @@ export function createAiPromptInputNodeView(options: AiPromptInputNodeViewOption
         controlsEl.appendChild(modelMenuTrigger)
         controlsEl.appendChild(submitButton)
 
+        if (contextTrayEl) dom.appendChild(contextTrayEl)
         dom.appendChild(contentDOM)
         dom.appendChild(controlsEl)
 
@@ -499,6 +504,9 @@ export function createAiPromptInputNodeView(options: AiPromptInputNodeViewOption
             dom,
             contentDOM,
             ignoreMutation: (mutation: MutationRecord) => {
+                if (contextTrayEl && (mutation.target === contextTrayEl || contextTrayEl.contains(mutation.target as Node))) {
+                    return true
+                }
                 if (mutation.target === controlsEl || controlsEl.contains(mutation.target as Node)) {
                     return true
                 }
@@ -527,10 +535,13 @@ export function createAiPromptInputNodeView(options: AiPromptInputNodeViewOption
             },
             stopEvent: (e: Event) => {
                 // Prevent ProseMirror from stealing focus/clicks from controls
-                const isControl = controlsEl.contains(e.target as Node)
+                const target = e.target as Node
+                const isControl = controlsEl.contains(target)
+                const isContextTray = Boolean(contextTrayEl?.contains(target))
                 if (isControl) {
                     return true
                 }
+                if (isContextTray) return true
                 return false
             },
         }

--- a/services/web-ui/src/components/proseMirror/plugins/aiPromptInputPlugin/aiPromptInputPlugin.ts
+++ b/services/web-ui/src/components/proseMirror/plugins/aiPromptInputPlugin/aiPromptInputPlugin.ts
@@ -26,6 +26,7 @@ type AiPromptInputPluginOptions = {
     onSubmit: SubmitHandler
     onStop: StopHandler
     isReceiving: () => boolean
+    createContextTray?: Parameters<typeof createAiPromptInputNodeView>[0]['createContextTray']
     createModelDropdown: Parameters<typeof createAiPromptInputNodeView>[0]['createModelDropdown']
     createImageModelDropdown: Parameters<typeof createAiPromptInputNodeView>[0]['createImageModelDropdown']
     createImageSizeDropdown: Parameters<typeof createAiPromptInputNodeView>[0]['createImageSizeDropdown']
@@ -139,6 +140,7 @@ export function createAiPromptInputPlugin(options: AiPromptInputPluginOptions): 
         onSubmit,
         onStop,
         isReceiving,
+        createContextTray,
         createModelDropdown,
         createImageModelDropdown,
         createImageSizeDropdown,
@@ -226,6 +228,8 @@ export function createAiPromptInputPlugin(options: AiPromptInputPluginOptions): 
                     },
                     onStop,
                     isReceiving,
+                    placeholderText,
+                    createContextTray,
                     createModelDropdown,
                     createImageModelDropdown,
                     createImageSizeDropdown,

--- a/services/web-ui/src/infographics/workspace/README.md
+++ b/services/web-ui/src/infographics/workspace/README.md
@@ -29,9 +29,9 @@ When you open a workspace, you see a canvas. On that canvas are nodes (documents
 - **Add images** via the toolbar button which opens an upload modal
 - **Open the Media Library** from the independent bottom-right icon above the original zoom badge to browse Features, explicitly saved Images, or explicitly saved Videos; the canvas-owned full-height drawer shifts left when AI chat is open and covers its launcher while open
 - **Save media for reuse** from an image or video bubble menu; saved Media Library items are independent Object Store copies that survive removal of the source canvas node. Saving confirms in place (no panel switch) and re-saving the same source media reuses the existing item instead of duplicating it
-- **Connect nodes** by dragging from a handle, then use the AI Chat panel context tray and workspace relevance to decide what the next prompt sees
-- **Provide AI context** from explicit context chips while also sending a compact workspace descriptor snapshot with each chat turn
-- **Use the AI Chat panel composer** to send prompts with explicit context chips and workspace relevance
+- **Connect nodes** by dragging from a handle, then use AI Chat composer context previews and workspace relevance to decide what the next prompt sees
+- **Provide AI context** from explicit composer previews while also sending a compact workspace descriptor snapshot with each chat turn
+- **Use the AI Chat panel composer** to send prompts with per-message context previews and workspace relevance
 - **Select edges** by clicking the connector line
 - **Delete edges** using Delete/Backspace (when an edge is selected), or by dragging an endpoint to empty space
 
@@ -78,9 +78,9 @@ All of this happens without the Svelte component knowing the details. It just pa
 
 ### AI Chat Panel And Sessions
 
-The canvas owns a singleton right-side AI Chat panel. The outside top-right toggle shows the chat icon while closed and the collapse icon while open, shifting left when the panel opens; it opens the panel with zero tabs if needed, without creating an `AiChatThread`. The first prompt creates a standalone history record. Open/closed panel state, ordered tabs, active tab, width, prompt drafts, and explicit context chips are stored in `canvasState.aiChatPanel`. Open tabs render through the shared SVG `components/slidingTabsSwitch` primitive, with geometry and slide timing configured by `settings.aiChatThread.panelTabs`; the context chip tray sits above the composer, persists forced node ids, and can update without tearing down the ProseMirror draft.
+The canvas owns a singleton right-side AI Chat panel. The outside top-right toggle shows the chat icon while closed and the collapse icon while open, shifting left when the panel opens; it opens the panel with zero tabs if needed, without creating an `AiChatThread`. The first prompt creates a standalone history record. Open/closed panel state, ordered tabs, active tab, width, prompt drafts, and draft context previews are stored in `canvasState.aiChatPanel`. Open tabs render through the shared SVG `components/slidingTabsSwitch` primitive, with geometry and slide timing configured by `settings.aiChatThread.panelTabs`; the context previews render inside the ProseMirror composer, snapshot forced node ids on submit, clear after submit, and can update without tearing down the ProseMirror draft.
 
-The Sessions surface includes standalone chats and feature-extraction sessions. It is collapsed by default and toggled from the history icon in the context-control row; when expanded it renders directly under that row and above the tab switch. The plus control beside the history toggle starts a fresh draft with no context chips and no active tab; the durable chat is still created only when the user submits. Closing the last open tab uses that same blank-draft path so stale context chips, active thread ids, and legacy last-active-thread state cannot carry into the next prompt. Each history row shows a title, absolute update date plus relative recency, and session metadata such as chat message count, status, extraction provider, or source count. Its expanded state is persisted in `canvasState.aiChatPanel`. Closing any tab leaves its session reopenable. Standalone chats and extraction sessions can be deleted explicitly; deleting an extraction session does not delete a separately saved Feature.
+The Sessions surface includes standalone chats and feature-extraction sessions. It is collapsed by default and toggled from the history icon in the panel control row; when expanded it renders directly under that row and above the tab switch. The plus control beside the history toggle starts a fresh draft with no context chips and no active tab; the durable chat is still created only when the user submits. Closing the last open tab uses that same blank-draft path so stale context chips, active thread ids, and legacy last-active-thread state cannot carry into the next prompt. Each history row shows a title, absolute update date plus relative recency, and session metadata such as chat message count, status, extraction provider, or source count. Its expanded state is persisted in `canvasState.aiChatPanel`. Closing any tab leaves its session reopenable. Standalone chats and extraction sessions can be deleted explicitly; deleting an extraction session does not delete a separately saved Feature.
 
 ### Legacy AI Chat Thread Nodes
 This section documents the older canvas-thread implementation that still has code and persisted data types in the repository. The current workspace renderer does not create or draw `aiChatThread` canvas nodes; active chat sessions live in the right-side AI Chat panel.
@@ -361,15 +361,15 @@ Edges are stored in `canvasState.edges` and rendered by the PIXI edge renderer. 
 
 ### AI Chat Context Extraction
 
-Standalone chat tabs use the panel's context chips as explicit forced context. Chips are resolved through the existing extraction service, and each submit also sends a `WorkspaceContextSnapshot`: a descriptors-only index of context-bearing workspace nodes with chip and edge-forced flags for the API relevance stage. When the API streams `CONTEXT_RELEVANCE_RESOLVED`, the panel adds distinct ephemeral auto chips for non-explicit selections and patches any `improvedDescriptors` into local canvas state so descriptor chrome updates without a reload.
+Standalone chat tabs use the composer context previews as explicit forced context for the next submitted message. Preview node ids are resolved through the existing extraction service, each submit snapshots then clears the explicit set, and each submit also sends a `WorkspaceContextSnapshot`: a descriptors-only index of context-bearing workspace nodes with chip and edge-forced flags for the API relevance stage. When the API streams `CONTEXT_RELEVANCE_RESOLVED`, the panel adds distinct ephemeral auto previews for non-explicit selections and patches any `improvedDescriptors` into local canvas state so descriptor chrome updates without a reload.
 
 ```mermaid
 %%{init: {'theme': 'base', 'themeVariables': { 'primaryColor': '#F6C7B3', 'primaryTextColor': '#5a3a2a', 'primaryBorderColor': '#d4956a', 'secondaryColor': '#C3DEDD', 'secondaryTextColor': '#1a3a47', 'secondaryBorderColor': '#4a8a9d', 'tertiaryColor': '#DCECE9', 'tertiaryTextColor': '#1a3a47', 'tertiaryBorderColor': '#82B2C0', 'lineColor': '#d4956a', 'textColor': '#5a3a2a'}}}%%
 flowchart LR
-    DOC[Document Node] -->|explicit chip| CTX[ExtractedContext]
-    IMG[Image Node] -->|explicit chip| CTX
+    DOC[Document Node] -->|explicit preview| CTX[ExtractedContext]
+    IMG[Image Node] -->|explicit preview| CTX
     VID[Video Node] -->|representative still| CTX
-    CHAT[Canvas AI Chat Panel] -->|context chips| CTX
+    CHAT[Canvas AI Chat Panel] -->|composer context previews| CTX
     CHAT -->|WorkspaceContextSnapshot| SNAP[Descriptor Index]
     CTX -->|buildContextMessage| MSG[Multimodal Message]
     SNAP -->|descriptors only| MSG
@@ -377,7 +377,7 @@ flowchart LR
 
 The extraction flow:
 
-1. **Context source** - Standalone tabs call `extractSelectedContext({ nodeIds })` for explicit context chips
+1. **Context source** - Standalone tabs call `extractSelectedContext({ nodeIds })` for the explicit composer previews snapshotted on submit
 2. **Content extraction** - Documents and AI threads have their ProseMirror content parsed; embedded images are collected. Image nodes are fetched and converted to base64; video nodes contribute their representative still (`frameFileId`, falling back to poster) for normal model context
 3. **Workspace snapshot** - `buildWorkspaceContextSnapshot()` indexes all context-bearing nodes by descriptor summary/tags plus media object references and force-include flags; it never embeds pixel data
 4. **Resolution feedback** - `CONTEXT_RELEVANCE_RESOLVED` bypasses markdown parsing, renders removable auto chips for engine selections, and applies improved descriptors to the live canvas

--- a/services/web-ui/src/infographics/workspace/WorkspaceCanvas.ts
+++ b/services/web-ui/src/infographics/workspace/WorkspaceCanvas.ts
@@ -42,7 +42,7 @@ import { getGeneratedImageTurnInfoFromThreadContent } from '$src/components/pros
 import { createAiResponseMessageShell, createAiUserMessageShell } from '$src/components/proseMirror/plugins/aiChatThreadPlugin/aiChatMessageShells.ts'
 import { createImageGenerationTraceDetails } from '$src/components/proseMirror/plugins/aiChatThreadPlugin/imageGenerationTraceDetails.ts'
 import AiInteractionService from '$src/services/ai-interaction-service.ts'
-import { imageResizeCornerIcon, aiChatThreadRailBoundaryCircle, brokenImageIcon, infoCircleIcon, trashBinIcon, xIcon, aiChatPanelToggleHistoryIcon, xCircleIcon as plusIcon } from '$src/svgIcons/index.ts'
+import { imageResizeCornerIcon, aiChatThreadRailBoundaryCircle, brokenImageIcon, infoCircleIcon, trashBinIcon, aiChatPanelToggleHistoryIcon, xCircleIcon, documentIcon, videoPlayGlyphIcon } from '$src/svgIcons/index.ts'
 import { type Document } from '$src/stores/documentStore.ts'
 import { createCanvasImageLifecycleTracker } from '$src/infographics/workspace/canvasImageLifecycle.ts'
 import { createCanvasVideoLifecycleTracker } from '$src/infographics/workspace/canvasVideoLifecycle.ts'
@@ -296,6 +296,7 @@ export function createWorkspaceCanvas(options: WorkspaceCanvasOptions) {
     let activeAiChatPromptEditor: any = null
     let activeAiChatPromptGradient: { destroy: () => void; triggerAnimation: () => void } | null = null
     let activeContextChipTrayEl: HTMLDivElement | null = null
+    let contextPreviewRefreshVersion = 0
     let autoContextSelections: WorkspaceContextSelection[] = []
     const removedAutoContextChipNodeIds: Set<string> = new Set()
     let mediaLibraryPanelInstance: ReturnType<typeof createMediaLibraryPanel> | null = null
@@ -1907,8 +1908,8 @@ export function createWorkspaceCanvas(options: WorkspaceCanvasOptions) {
         pixiMediaLayer?.setSelectedImageNodes(nextSelectedNodeIds)
         scheduleEdgesRender()
         // Selecting canvas nodes while the panel is open force-includes them as
-        // explicit context chips. Only newly-selected ids are added so removing a
-        // chip whose node stays selected doesn't immediately re-add it.
+        // explicit composer previews. Only newly-selected ids are added so a
+        // removed preview whose node stays selected isn't immediately re-added.
         if (currentCanvasState && aiChatPanelState.isOpen) {
             addContextChips(Array.from(selectedNodeIds).filter((nodeId) => !prevSelectedNodeIds.has(nodeId)))
         }
@@ -2099,6 +2100,7 @@ export function createWorkspaceCanvas(options: WorkspaceCanvasOptions) {
 
     function getPromptControlFactories() {
         return {
+            createContextTray: createAiChatPanelContextTrayElement,
             createModelDropdown: createGenericAiModelDropdown,
             createImageModelDropdown: createGenericImageModelDropdown,
             createImageSizeDropdown: createGenericImageSizeDropdown,
@@ -2438,9 +2440,8 @@ export function createWorkspaceCanvas(options: WorkspaceCanvasOptions) {
         commitCanvasMetadataState(persistedState)
     }
 
-    // A short, human-readable label for a context chip. Prefer the node's ready
-    // descriptor summary (Phase 2) and fall back to a type label so a chip is
-    // never blank while its descriptor is still being generated.
+    // A short visible label for context metadata. Media previews are already
+    // visual, so unresolved image/video descriptors stay label-free.
     function getContextChipLabel(node: CanvasNode): string {
         const descriptor = isDescriptorCanvasNode(node) ? node.descriptor : undefined
         const summary = descriptor && descriptor.status === 'ready' ? descriptor.summary : ''
@@ -2448,11 +2449,215 @@ export function createWorkspaceCanvas(options: WorkspaceCanvasOptions) {
         if (trimmed) return trimmed
         switch (node.type) {
             case 'document': return 'Document'
+            case 'aiChatThread': return 'Chat'
+            case 'image':
+            case 'video': return ''
+            default: return node.type
+        }
+    }
+
+    function getContextPreviewTitle(node: CanvasNode): string {
+        if (node.type === 'document') {
+            const document = currentDocuments.find((doc) => doc.documentId === node.referenceId)
+            const title = document?.title?.trim()
+            if (title) return title
+        }
+        if (node.type === 'aiChatThread') {
+            const thread = currentAiChatThreads.find((item) => item.threadId === node.referenceId)
+            const title = thread?.title?.trim()
+            if (title) return title
+        }
+        if (node.type === 'image' || node.type === 'video') return ''
+        return getContextChipLabel(node)
+    }
+
+    function getContextPreviewText(node: CanvasNode): string {
+        const descriptor = isDescriptorCanvasNode(node) && node.descriptor?.status === 'ready'
+            ? node.descriptor.summary.trim()
+            : ''
+        if (descriptor) return descriptor
+
+        if (node.type === 'document') {
+            const document = currentDocuments.find((doc) => doc.documentId === node.referenceId)
+            const { text } = extractContentFromProseMirror((document?.content ?? '') as string | object)
+            return text.trim()
+        }
+
+        if (node.type === 'aiChatThread') {
+            const thread = currentAiChatThreads.find((item) => item.threadId === node.referenceId)
+            const { text } = extractContentFromProseMirror((thread?.content ?? '') as string | object)
+            return text.trim()
+        }
+
+        return ''
+    }
+
+    function getContextPreviewTypeLabel(node: CanvasNode): string {
+        switch (node.type) {
+            case 'document': return 'Document'
             case 'image': return 'Image'
             case 'video': return 'Video'
             case 'aiChatThread': return 'Chat'
             default: return node.type
         }
+    }
+
+    function buildContextPreviewInitialMediaSrc(mediaUrl: string): string {
+        if (!mediaUrl) return ''
+        if (mediaUrl.startsWith('data:') || mediaUrl.startsWith('blob:')) return mediaUrl
+        if (mediaUrl.startsWith('/api/') || mediaUrl.startsWith('http')) return mediaUrl
+        return `data:image/png;base64,${mediaUrl}`
+    }
+
+    function setContextPreviewMediaTokenParam(mediaUrl: string, token: string): string {
+        if (!token) return mediaUrl
+        const isAbsoluteUrl = /^[a-z][a-z0-9+.-]*:\/\//i.test(mediaUrl)
+        try {
+            const url = isAbsoluteUrl ? new URL(mediaUrl) : new URL(mediaUrl, window.location.origin)
+            url.searchParams.set('token', token)
+            if (isAbsoluteUrl) return url.toString()
+            return `${url.pathname}${url.search}${url.hash}`
+        } catch {
+            const separator = mediaUrl.includes('?') ? '&' : '?'
+            return `${mediaUrl}${separator}token=${encodeURIComponent(token)}`
+        }
+    }
+
+    async function buildContextPreviewAuthenticatedMediaSrc(mediaUrl: string): Promise<string> {
+        if (!mediaUrl) return ''
+        if (mediaUrl.startsWith('data:') || mediaUrl.startsWith('blob:')) return mediaUrl
+        if (mediaUrl.startsWith('/api/')) {
+            const token = await AuthService.getTokenSilently()
+            const apiBaseUrl = (import.meta.env.VITE_API_URL || '').replace(/\/$/, '')
+            const sourceUrl = apiBaseUrl ? `${apiBaseUrl}${mediaUrl}` : mediaUrl
+            return setContextPreviewMediaTokenParam(sourceUrl, token)
+        }
+        if (mediaUrl.startsWith('http')) {
+            if (mediaUrl.includes('/api/videos/') || mediaUrl.includes('/api/images/')) {
+                const token = await AuthService.getTokenSilently()
+                return setContextPreviewMediaTokenParam(mediaUrl, token)
+            }
+            return mediaUrl
+        }
+        return `data:image/png;base64,${mediaUrl}`
+    }
+
+    function hydrateContextPreviewMedia(el: HTMLImageElement | HTMLVideoElement, mediaUrl: string, attr: 'src' | 'poster' = 'src'): void {
+        if (!mediaUrl) return
+        void (async () => {
+            try {
+                const src = await buildContextPreviewAuthenticatedMediaSrc(mediaUrl)
+                if (!src || !el.isConnected) return
+                if (attr === 'poster' && el instanceof HTMLVideoElement) {
+                    el.poster = src
+                    return
+                }
+                el.src = src
+            } catch (error) {
+                console.warn('Failed to resolve context preview media URL:', error)
+            }
+        })()
+    }
+
+    function setContextPreviewVideoSources(videoEl: HTMLVideoElement, node: VideoCanvasNode): void {
+        const initialSrc = buildContextPreviewInitialMediaSrc(node.src)
+        const initialPoster = buildContextPreviewInitialMediaSrc(node.posterSrc)
+        if (initialSrc) videoEl.src = initialSrc
+        if (initialPoster) videoEl.poster = initialPoster
+        hydrateContextPreviewMedia(videoEl, node.src)
+        hydrateContextPreviewMedia(videoEl, node.posterSrc, 'poster')
+    }
+
+    function renderContextImagePreview(node: ImageCanvasNode, label: string, size: 'mini' | 'large'): HTMLElement {
+        const imageEl = html`<img
+            className=${`workspace-ai-chat-panel-context-preview-image workspace-ai-chat-panel-context-preview-image-${size}`}
+            src=${buildImageSrc(node.src, '', false)}
+            alt=""
+            loading="lazy"
+        />` as HTMLImageElement
+        imageEl.setAttribute('aria-label', label)
+        hydrateContextPreviewMedia(imageEl, node.src)
+        return imageEl
+    }
+
+    function renderContextVideoPreview(node: VideoCanvasNode, label: string, size: 'mini' | 'large'): HTMLElement {
+        if (size === 'large') {
+            const previewEl = html`<div className="workspace-ai-chat-panel-context-preview-video workspace-ai-chat-panel-context-preview-video-large">
+                <video
+                    muted="true"
+                    playsinline="true"
+                    preload="metadata"
+                    controls="true"
+                    aria-label=${label}
+                ></video>
+                <span className="workspace-ai-chat-panel-context-preview-video-glyph" innerHTML=${videoPlayGlyphIcon}></span>
+            </div>` as HTMLElement
+            const videoEl = previewEl.querySelector('video')
+            if (videoEl) setContextPreviewVideoSources(videoEl, node)
+            return previewEl
+        }
+
+        const previewEl = html`<div className="workspace-ai-chat-panel-context-preview-video workspace-ai-chat-panel-context-preview-video-mini">
+            <video
+                muted="true"
+                playsinline="true"
+                preload="metadata"
+                aria-label=${label}
+            ></video>
+            <span className="workspace-ai-chat-panel-context-preview-video-glyph" innerHTML=${videoPlayGlyphIcon}></span>
+        </div>` as HTMLElement
+        const videoEl = previewEl.querySelector('video')
+        if (videoEl) setContextPreviewVideoSources(videoEl, node)
+        return previewEl
+    }
+
+    function renderContextDocumentPreview(node: DocumentCanvasNode | AiChatThreadCanvasNode, title: string, text: string, size: 'mini' | 'large'): HTMLElement {
+        if (size === 'mini') {
+            return html`<div className="workspace-ai-chat-panel-context-preview-document workspace-ai-chat-panel-context-preview-document-mini">
+                <span className="workspace-ai-chat-panel-context-preview-document-icon" innerHTML=${documentIcon}></span>
+                <span className="workspace-ai-chat-panel-context-preview-document-skeleton" aria-label=${title}>
+                    <span></span>
+                    <span></span>
+                    <span></span>
+                </span>
+            </div>` as HTMLElement
+        }
+
+        return html`<div className=${`workspace-ai-chat-panel-context-preview-document workspace-ai-chat-panel-context-preview-document-${size}`}>
+            <span className="workspace-ai-chat-panel-context-preview-document-icon" innerHTML=${documentIcon}></span>
+            <span className="workspace-ai-chat-panel-context-preview-document-lines">
+                <span className="workspace-ai-chat-panel-context-preview-document-title">${title}</span>
+                <span className="workspace-ai-chat-panel-context-preview-document-text">${text || getContextPreviewTypeLabel(node)}</span>
+            </span>
+        </div>` as HTMLElement
+    }
+
+    function renderContextPreviewVisual(node: CanvasNode, title: string, text: string, size: 'mini' | 'large'): HTMLElement {
+        if (node.type === 'image') return renderContextImagePreview(node, title, size)
+        if (node.type === 'video') return renderContextVideoPreview(node, title, size)
+        if (node.type === 'document' || node.type === 'aiChatThread') {
+            return renderContextDocumentPreview(node, title, text, size)
+        }
+        return html`<div className="workspace-ai-chat-panel-context-preview-document">${title}</div>` as HTMLElement
+    }
+
+    function renderContextPreviewPopoverMeta(title: string, text: string): HTMLElement {
+        return html`<div className="workspace-ai-chat-panel-context-preview-popover-meta">
+            ${title ? html`<span className="workspace-ai-chat-panel-context-preview-popover-title">${title}</span>` : ''}
+            ${text ? html`<span className="workspace-ai-chat-panel-context-preview-popover-text">${text}</span>` : ''}
+        </div>` as HTMLElement
+    }
+
+    function createAiChatPanelContextTrayElement(): HTMLDivElement {
+        const trayEl = html`<div
+            className="workspace-ai-chat-panel-context-chips"
+            role="list"
+            aria-label="Chat context previews"
+            contenteditable="false"
+        ></div>` as HTMLDivElement
+        activeContextChipTrayEl = trayEl
+        refreshContextChipTray()
+        return trayEl
     }
 
     function addContextChips(nodeIds: Iterable<string>): void {
@@ -2482,6 +2687,13 @@ export function createWorkspaceCanvas(options: WorkspaceCanvasOptions) {
         refreshContextChipTray()
     }
 
+    function clearExplicitContextChips(): void {
+        if (aiChatPanelState.contextChips.length === 0) return
+        aiChatPanelState = { ...aiChatPanelState, contextChips: [] }
+        persistAiChatSidebarState()
+        refreshContextChipTray()
+    }
+
     function removeAutoContextChip(nodeId: string): void {
         if (!autoContextSelections.some((selection) => selection.nodeId === nodeId)) return
         removedAutoContextChipNodeIds.add(nodeId)
@@ -2495,33 +2707,61 @@ export function createWorkspaceCanvas(options: WorkspaceCanvasOptions) {
         refreshContextChipTray()
     }
 
+    function updateActiveAiChatPanelRailHeight(): void {
+        if (!activeAiChatPanelEl) return
+        const panelRail = activeAiChatPanelEl.querySelector<HTMLElement>('.workspace-ai-chat-floating-panel-rail')
+        if (!panelRail) return
+        panelRail.style.setProperty('--rail-thread-height', `${measureActiveAiChatPanelRailThreadHeight(activeAiChatPanelEl)}px`)
+    }
+
+    function restoreAiChatPanelHistoryScroll(historyScrollerEl: HTMLElement | null | undefined, scrollTop: number | null, refreshVersion: number): void {
+        if (!historyScrollerEl || scrollTop === null) return
+        historyScrollerEl.scrollTop = scrollTop
+        requestAnimationFrame(() => {
+            if (refreshVersion !== contextPreviewRefreshVersion) return
+            if (historyScrollerEl.isConnected) historyScrollerEl.scrollTop = scrollTop
+            updateActiveAiChatPanelRailHeight()
+        })
+    }
+
     function renderContextChip({
         nodeId,
-        label,
+        node,
         kind,
         role,
     }: {
         nodeId: string
-        label: string
+        node: CanvasNode
         kind: 'explicit' | 'auto'
         role?: WorkspaceContextSelection['role']
-    }): HTMLSpanElement {
+    }): HTMLDivElement {
+        const title = getContextPreviewTitle(node)
+        const text = getContextPreviewText(node)
+        const accessibleLabel = title || getContextPreviewTypeLabel(node)
+        const shouldRenderPopoverMeta = (node.type === 'image' || node.type === 'video') && Boolean(title || text)
         const removeLabel = kind === 'auto'
-            ? `Remove ${label} from automatic context`
-            : `Remove ${label} from context`
-        const chipEl = html`<span
+            ? `Remove ${accessibleLabel} from automatic context`
+            : `Remove ${accessibleLabel} from context`
+        const chipEl = html`<div
             className=${`workspace-ai-chat-panel-context-chip workspace-ai-chat-panel-context-chip-${kind}`}
             data=${{ nodeId, contextKind: kind, contextRole: role ?? kind }}
-            title=${label}
+            role="listitem"
+            tabindex="0"
         >
-            <span className="workspace-ai-chat-panel-context-chip-label">${label}</span>
+            <div className="workspace-ai-chat-panel-context-preview-main">
+                ${renderContextPreviewVisual(node, accessibleLabel, text, 'mini')}
+            </div>
             <button
                 type="button"
                 className="workspace-ai-chat-panel-context-chip-remove"
                 aria-label=${removeLabel}
-                innerHTML=${xIcon}
+                innerHTML=${xCircleIcon}
             ></button>
-        </span>` as HTMLSpanElement
+            <div className="workspace-ai-chat-panel-context-preview-popover" aria-hidden="true">
+                ${renderContextPreviewVisual(node, accessibleLabel, text, 'large')}
+                ${shouldRenderPopoverMeta ? renderContextPreviewPopoverMeta(title, text) : ''}
+            </div>
+        </div>` as HTMLDivElement
         chipEl.querySelector('.workspace-ai-chat-panel-context-chip-remove')
             ?.addEventListener('click', () => {
                 if (kind === 'auto') {
@@ -2533,11 +2773,16 @@ export function createWorkspaceCanvas(options: WorkspaceCanvasOptions) {
         return chipEl
     }
 
-    // Re-render just the chip tray in place (not the whole panel) so adding or
-    // removing a chip never tears down the ProseMirror composer or its draft.
+    // Re-render just the composer preview strip in place so adding or removing
+    // context never tears down the ProseMirror composer or its draft.
     function refreshContextChipTray(): void {
         const trayEl = activeContextChipTrayEl
         if (!trayEl) return
+        const historyScrollerEl = activeAiChatPanelEl?.querySelector<HTMLElement>(
+            '.workspace-ai-chat-panel-body-pane:not(.workspace-ai-chat-panel-body-pane-hidden)'
+        )
+        const previousScrollTop = historyScrollerEl?.scrollTop ?? null
+        const refreshVersion = ++contextPreviewRefreshVersion
         trayEl.replaceChildren()
         const explicitChipNodeIds = aiChatPanelState.contextChips
         const explicitChipNodeIdSet = new Set(explicitChipNodeIds)
@@ -2554,26 +2799,29 @@ export function createWorkspaceCanvas(options: WorkspaceCanvasOptions) {
             autoChipSelections.push(selection)
         }
         if (explicitChipNodeIds.length === 0 && autoChipSelections.length === 0) {
-            trayEl.appendChild(
-                html`<span className="workspace-ai-chat-panel-context-chips-empty">Select nodes to add context</span>` as HTMLSpanElement
-            )
+            trayEl.hidden = true
+            restoreAiChatPanelHistoryScroll(historyScrollerEl, previousScrollTop, refreshVersion)
+            updateActiveAiChatPanelRailHeight()
             return
         }
+        trayEl.hidden = false
         for (const nodeId of explicitChipNodeIds) {
             const node = nodesById.get(nodeId)
-            const label = node ? getContextChipLabel(node) : 'Node'
-            trayEl.appendChild(renderContextChip({ nodeId, label, kind: 'explicit' }))
+            if (!node) continue
+            trayEl.appendChild(renderContextChip({ nodeId, node, kind: 'explicit' }))
         }
         for (const selection of autoChipSelections) {
             const node = nodesById.get(selection.nodeId)
-            const label = node ? getContextChipLabel(node) : 'Node'
+            if (!node) continue
             trayEl.appendChild(renderContextChip({
                 nodeId: selection.nodeId,
-                label,
+                node,
                 kind: 'auto',
                 role: selection.role,
             }))
         }
+        restoreAiChatPanelHistoryScroll(historyScrollerEl, previousScrollTop, refreshVersion)
+        updateActiveAiChatPanelRailHeight()
     }
 
     function getPersistedFeatureExtractionState(extractionRunId: string): CanvasFeatureExtractionState | undefined {
@@ -2992,15 +3240,12 @@ export function createWorkspaceCanvas(options: WorkspaceCanvasOptions) {
 
         const controlsEl = html`<div className="workspace-ai-chat-panel-context-controls">
             <div className="workspace-ai-chat-panel-context-mode">
-                <span className="workspace-ai-chat-panel-context-heading">Context</span>
-                <div className="workspace-ai-chat-panel-context-chips" role="list" aria-label="Chat context chips"></div>
                 <div className="workspace-ai-chat-panel-history-control">
-                    <span className="workspace-ai-chat-panel-context-divider" aria-hidden="true"></span>
                     <button
                         type="button"
                         className="workspace-ai-chat-panel-new-chat"
                         aria-label="Start new chat"
-                        innerHTML=${plusIcon}
+                        innerHTML=${xCircleIcon}
                     ></button>
                     <button
                         type="button"
@@ -3013,8 +3258,6 @@ export function createWorkspaceCanvas(options: WorkspaceCanvasOptions) {
                 </div>
             </div>
         </div>` as HTMLDivElement
-        activeContextChipTrayEl = controlsEl.querySelector<HTMLDivElement>('.workspace-ai-chat-panel-context-chips')
-        refreshContextChipTray()
         panelEl.appendChild(controlsEl)
         const newChatEl = controlsEl.querySelector<HTMLButtonElement>('.workspace-ai-chat-panel-new-chat')!
         newChatEl.addEventListener('click', startNewAiChatDraft)
@@ -3192,7 +3435,7 @@ export function createWorkspaceCanvas(options: WorkspaceCanvasOptions) {
                         // Explicit context chips are always force-included. For a canvas
                         // thread node we also pull its edge-connected context; chip and
                         // edge items are deduped by nodeId so an overlapping node isn't sent twice.
-                        const chipNodeIds = aiChatPanelState.contextChips
+                        const chipNodeIds = aiChatPanelState.contextChips.slice()
                         const edgeContext = rootNode
                             ? await aiChatThreadService.extractConnectedContext(rootNode.nodeId)
                             : []
@@ -3233,7 +3476,7 @@ export function createWorkspaceCanvas(options: WorkspaceCanvasOptions) {
                                 nodes: currentCanvasState.nodes,
                                 edges: currentCanvasState.edges,
                                 rootNodeId: rootNode?.nodeId,
-                                contextChipNodeIds: aiChatPanelState.contextChips,
+                                contextChipNodeIds: chipNodeIds,
                                 titlesByNodeId: buildWorkspaceContextTitlesByNodeId(currentCanvasState.nodes),
                             })
                             : undefined
@@ -3266,6 +3509,7 @@ export function createWorkspaceCanvas(options: WorkspaceCanvasOptions) {
                             imageBranchCandidateSnapshot,
                             workspaceContextSnapshot,
                         })
+                        clearExplicitContextChips()
                     } catch (error) {
                         console.error('Failed to gather AI chat context:', error)
                         throw error
@@ -3331,6 +3575,7 @@ export function createWorkspaceCanvas(options: WorkspaceCanvasOptions) {
                 if (currentTab?.type === 'extraction') {
                     const userText = extractPromptTextFromContentJSON(data.contentJSON)
                     if (!userText) return
+                    clearAutoContextChips()
                     const ctx = {
                         ...(getPendingExtractionContext(currentTab.refId) ?? {}),
                         aiModel: data.aiModel,
@@ -3340,6 +3585,7 @@ export function createWorkspaceCanvas(options: WorkspaceCanvasOptions) {
                         getState: getPersistedFeatureExtractionState,
                         saveState: persistFeatureExtractionState,
                     })
+                    clearExplicitContextChips()
                     return
                 }
 

--- a/services/web-ui/src/infographics/workspace/workspace-canvas.scss
+++ b/services/web-ui/src/infographics/workspace/workspace-canvas.scss
@@ -849,7 +849,8 @@
 .workspace-ai-chat-panel-context-controls {
     display: flex;
     flex: 0 0 auto;
-    padding: 10px 0 12px;
+    justify-content: flex-end;
+    padding: 10px 0 8px;
     color: #39455d;
     font-size: 12px;
 }
@@ -857,96 +858,331 @@
 .workspace-ai-chat-panel-context-mode {
     display: flex;
     align-items: center;
+    justify-content: flex-end;
     flex: 1 1 auto;
     width: 100%;
     gap: 8px;
     min-width: 0;
 }
 
-.workspace-ai-chat-panel-context-heading {
-    flex: 0 0 auto;
-}
-
 .workspace-ai-chat-panel-context-chips {
     display: flex;
-    flex: 1 1 auto;
+    flex: 0 0 auto;
     flex-wrap: wrap;
-    align-items: center;
+    align-items: flex-start;
     gap: 6px;
-    min-width: 0;
+    min-width: 100%;
+    padding: 10px 14px 0;
+    box-sizing: border-box;
+}
+
+.workspace-ai-chat-panel-context-chips[hidden] {
+    display: none;
 }
 
 .workspace-ai-chat-panel-context-chips-empty {
-    color: #8a93a6;
-    font-size: 11px;
-    white-space: nowrap;
+    display: none;
 }
 
 .workspace-ai-chat-panel-context-chip {
-    display: inline-flex;
-    align-items: center;
-    gap: 4px;
-    max-width: 168px;
-    padding: 3px 4px 3px 9px;
-    border: 1px solid transparent;
-    border-radius: 999px;
-    background: rgba(130, 178, 192, 0.18);
-    color: #1a3a47;
-    font-size: 11px;
-    line-height: 1.3;
+    position: relative;
+    display: block;
+    flex: 0 0 58px;
+    width: 58px;
+    min-width: 0;
+    padding: 0;
+    border: 0;
+    background: transparent;
+    box-sizing: border-box;
+    outline: none;
 }
 
 .workspace-ai-chat-panel-context-chip-explicit {
-    border: 1px solid rgba(130, 178, 192, 0.32);
+    border: 0;
 }
 
 .workspace-ai-chat-panel-context-chip-auto {
-    border: 1px dashed rgba(212, 149, 106, 0.72);
-    background: rgba(246, 199, 179, 0.22);
+    border: 0;
+    background: transparent;
     color: #5a3a2a;
 }
 
-.workspace-ai-chat-panel-context-chip-label {
+.workspace-ai-chat-panel-context-chip:hover,
+.workspace-ai-chat-panel-context-chip:focus-within {
+    z-index: 5;
+    background: transparent;
+}
+
+.workspace-ai-chat-panel-context-chip::before {
+    content: '';
+    position: absolute;
+    left: -6px;
+    right: -6px;
+    bottom: 100%;
+    display: none;
+    height: 10px;
+}
+
+.workspace-ai-chat-panel-context-chip:hover::before,
+.workspace-ai-chat-panel-context-chip:focus-within::before {
+    display: block;
+}
+
+.workspace-ai-chat-panel-context-preview-main {
+    display: block;
+    min-width: 0;
+}
+
+.workspace-ai-chat-panel-context-preview-image,
+.workspace-ai-chat-panel-context-preview-video,
+.workspace-ai-chat-panel-context-preview-document {
+    width: 100%;
+    border-radius: 6px;
+    background: transparent;
     overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
+}
+
+.workspace-ai-chat-panel-context-preview-image {
+    display: block;
+}
+
+.workspace-ai-chat-panel-context-preview-image-mini {
+    height: 42px;
+    object-fit: cover;
+}
+
+.workspace-ai-chat-panel-context-preview-image-large {
+    width: 100%;
+    height: auto;
+}
+
+.workspace-ai-chat-panel-context-preview-video {
+    position: relative;
+    display: block;
+}
+
+.workspace-ai-chat-panel-context-preview-video video {
+    display: block;
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    background: #0f1721;
+}
+
+.workspace-ai-chat-panel-context-preview-video-mini {
+    height: 42px;
+}
+
+.workspace-ai-chat-panel-context-preview-video-large {
+    width: 100%;
+    height: 132px;
+}
+
+.workspace-ai-chat-panel-context-preview-video-glyph {
+    position: absolute;
+    inset: 50% auto auto 50%;
+    display: grid;
+    place-items: center;
+    width: 24px;
+    height: 24px;
+    border-radius: 50%;
+    background: rgba(255, 255, 255, 0.84);
+    color: #1a3a47;
+    transform: translate(-50%, -50%);
+    pointer-events: none;
+}
+
+.workspace-ai-chat-panel-context-preview-video-glyph svg {
+    width: 13px;
+    height: 13px;
+    fill: currentColor;
+}
+
+.workspace-ai-chat-panel-context-preview-video-large .workspace-ai-chat-panel-context-preview-video-glyph {
+    display: none;
+}
+
+.workspace-ai-chat-panel-context-preview-document {
+    display: flex;
+    align-items: flex-start;
+    gap: 6px;
+    box-sizing: border-box;
+    color: #243045;
+}
+
+.workspace-ai-chat-panel-context-preview-document-mini {
+    justify-content: center;
+    height: 42px;
+    padding: 6px 7px;
+}
+
+.workspace-ai-chat-panel-context-preview-document-skeleton {
+    display: flex;
+    flex: 1 1 auto;
+    flex-direction: column;
+    gap: 5px;
+    min-width: 0;
+}
+
+.workspace-ai-chat-panel-context-preview-document-skeleton span {
+    display: block;
+    height: 4px;
+    border-radius: 999px;
+    background: rgba(105, 115, 136, 0.32);
+}
+
+.workspace-ai-chat-panel-context-preview-document-skeleton span:nth-child(2) {
+    width: 82%;
+}
+
+.workspace-ai-chat-panel-context-preview-document-skeleton span:nth-child(3) {
+    width: 64%;
+}
+
+.workspace-ai-chat-panel-context-preview-document-large {
+    width: 100%;
+    height: 116px;
+    padding: 10px;
+    overflow-y: auto;
+}
+
+.workspace-ai-chat-panel-context-preview-popover > .workspace-ai-chat-panel-context-preview-document-large:only-child {
+    height: 100%;
+}
+
+.workspace-ai-chat-panel-context-preview-document-icon {
+    display: grid;
+    place-items: center;
+    flex: 0 0 auto;
+    width: 18px;
+    height: 18px;
+    color: #697388;
+}
+
+.workspace-ai-chat-panel-context-preview-document-icon svg {
+    width: 18px;
+    height: 18px;
+    fill: currentColor;
+}
+
+.workspace-ai-chat-panel-context-preview-document-lines {
+    display: flex;
+    flex: 1 1 auto;
+    flex-direction: column;
+    min-width: 0;
+    gap: 3px;
+}
+
+.workspace-ai-chat-panel-context-preview-document-title {
+    font-size: 11px;
+    font-weight: 700;
+    line-height: 1.2;
+    overflow-wrap: anywhere;
+}
+
+.workspace-ai-chat-panel-context-preview-document-text {
+    display: block;
+    color: rgba(57, 69, 93, 0.76);
+    font-size: 10px;
+    line-height: 1.25;
+    overflow-wrap: anywhere;
+}
+
+.workspace-ai-chat-panel-context-preview-document-large .workspace-ai-chat-panel-context-preview-document-text {
+    font-size: 11px;
+}
+
+.workspace-ai-chat-panel-context-preview-popover {
+    position: absolute;
+    left: 0;
+    bottom: calc(100% + 10px);
+    display: none;
+    flex-direction: column;
+    gap: 8px;
+    width: 280px;
+    max-width: min(280px, calc(100vw - 24px));
+    height: min(430px, calc(100vh - 32px));
+    padding: 8px;
+    border-radius: 8px;
+    background: #fff;
+    box-shadow: 0 16px 38px rgba(57, 69, 93, 0.18), 0 2px 8px rgba(57, 69, 93, 0.12);
+    box-sizing: border-box;
+    overflow: hidden;
+    pointer-events: auto;
+}
+
+.workspace-ai-chat-panel-context-chip:hover .workspace-ai-chat-panel-context-preview-popover,
+.workspace-ai-chat-panel-context-chip:focus-within .workspace-ai-chat-panel-context-preview-popover {
+    display: flex;
+}
+
+.workspace-ai-chat-panel-context-preview-popover-title {
+    color: #1a3a47;
+    font-size: 12px;
+    font-weight: 700;
+    line-height: 1.25;
+    overflow: visible;
+    overflow-wrap: anywhere;
+    white-space: normal;
+}
+
+.workspace-ai-chat-panel-context-preview-popover-meta {
+    display: flex;
+    flex: 1 1 auto;
+    flex-direction: column;
+    gap: 3px;
+    min-height: 0;
+    overflow-y: auto;
+    padding-right: 2px;
+}
+
+.workspace-ai-chat-panel-context-preview-popover-text {
+    display: block;
+    color: rgba(57, 69, 93, 0.82);
+    font-size: 11px;
+    line-height: 1.3;
+    overflow: visible;
+    overflow-wrap: anywhere;
 }
 
 .workspace-ai-chat-panel-context-chip-remove {
     display: grid;
     place-items: center;
+    position: absolute;
+    top: -6px;
+    right: -6px;
     flex: 0 0 auto;
-    width: 15px;
-    height: 15px;
+    width: 16px;
+    height: 16px;
     padding: 0;
     border: 0;
     border-radius: 50%;
     background: transparent;
-    color: inherit;
+    color: #39455d;
     cursor: pointer;
-    opacity: 0.7;
+    opacity: 0;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.62);
+    transition: opacity 120ms ease, color 120ms ease;
+}
+
+.workspace-ai-chat-panel-context-chip:hover .workspace-ai-chat-panel-context-chip-remove,
+.workspace-ai-chat-panel-context-chip:focus-within .workspace-ai-chat-panel-context-chip-remove {
+    opacity: 1;
 }
 
 .workspace-ai-chat-panel-context-chip-remove:hover,
 .workspace-ai-chat-panel-context-chip-remove:focus-visible {
-    background: rgba(26, 58, 71, 0.16);
+    background: transparent;
+    color: #000;
+    box-shadow: 0 2px 5px rgba(0, 0, 0, 0.82);
     opacity: 1;
     outline: none;
 }
 
 .workspace-ai-chat-panel-context-chip-remove svg {
-    width: 8px;
-    height: 8px;
+    width: 16px;
+    height: 16px;
     fill: currentColor;
-}
-
-.workspace-ai-chat-panel-context-divider {
-    display: block;
-    flex: 0 0 auto;
-    width: 1px;
-    height: 20px;
-    margin: 0 1px;
-    background: rgba(57, 69, 93, 0.17);
 }
 
 .workspace-ai-chat-panel-history-control {
@@ -1156,6 +1392,7 @@
     min-width: 0;
     min-height: 0;
     overflow-y: auto;
+    overflow-anchor: none;
 }
 
 .workspace-ai-chat-panel-body-pane-hidden {


### PR DESCRIPTION
Summary:
- Move selected AI chat context previews into the composer input area.
- Render media/document previews in the composer, with hover previews and per-message reset behavior.
- Preserve automatic context fallback, placeholder behavior, rail height recalculation, and chat history scroll stability.

Closes #234