### PR TITLE
LIX-224 # Add private NEX workload volume

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -279,6 +279,7 @@ services:
             - ./.aws/config:/root/.aws/config:cached    # AWS SSO credentials
             - caddy-certs:/opt/nex/certs:ro    # Cluster CA (only needed when 4222 uses TLS, e.g. AWS)
             - nex-1-data:/data                 # Persistent nex resource/config dir across restarts
+            - nex-workloads:/opt/nex/private-workloads:ro # Private repos place native workload binaries here
 
             # @lixpi workspace packages the workload imports (mirrors lixpi-api)
             - ./packages/lixpi/constants:/usr/src/service/packages/lixpi/constants:cached
@@ -632,6 +633,8 @@ volumes:
     nats-2-data:   # Persistent JetStream storage for NATS node 2
     nats-3-data:   # Persistent JetStream storage for NATS node 3
     nex-1-data:    # Persistent nex resource/config dir for the NEX node
+    nex-workloads: # Shared native workload binary volume for private repos
+        name: lixpi-nex-workloads
 
 networks:
     nats:

--- a/documentation/knowledge/INTERNAL-SERVICE-NATS-AUTH-PATTERN.md
+++ b/documentation/knowledge/INTERNAL-SERVICE-NATS-AUTH-PATTERN.md
@@ -108,6 +108,15 @@ The NEX key variables have different owners:
 - `NATS_NEX_NODE_NKEY_PUBLIC` is safe verification material. NEX needs it for the native NATS client flags, the NATS server config needs it to advertise the nonce required by native NKey auth, and `services/api` needs it in `serviceAuthConfigs` so the auth callout can verify the raw NKey signature.
 - The NATS server's static nkey user entry is not the final authorization decision in the current centralized auth-callout design. It enables the native NKey challenge; NATS forwards the auth decision to the API and enforces the returned user JWT.
 
+Local private-repo NEX workloads should currently use `file://` artifacts placed
+in the shared Docker volume mounted at `/opt/nex/private-workloads`, not
+`nats://` Object Store artifacts. NEX 0.4.1 can fetch Object Store artifacts in
+compatible credential setups, but the `--issuer-nkey` path used by Lixpi mints
+NKey credentials while the native artifact fetcher connects with
+`UserJWTAndSeed`. With centralized auth callout enabled, that artifact-fetch
+connection has no usable `auth_token` or raw `nkey` challenge fields and is
+rejected.
+
 ## Code samples
 
 The samples below show the concrete implementation shape. If you need to read the full files:

--- a/documentation/knowledge/NATS-NEX-EXECUTION-ENGINE-EXPLAINED.md
+++ b/documentation/knowledge/NATS-NEX-EXECUTION-ENGINE-EXPLAINED.md
@@ -156,6 +156,14 @@ The native nexlet (`agents/native`) is the one you get for free. It runs an OS e
 **You can deliver workload binaries over NATS today.** The Object Store path (`nats://`) is fully implemented — you can push a binary into a JetStream Object Store bucket and reference it by `uri`, instead of baking it into the node’s host/image. OCI-registry delivery is anticipated by the URI parser but not yet wired up; don’t plan on `oci://` working at `0.4.1`.
 {% /callout %}
 
+For Lixpi's current centralized auth-callout deployment, prefer `file://`
+artifacts mounted into the NEX node over `nats://` artifacts. The NEX 0.4.1
+`NkeyMinter` path hands the native nexlet NKey credentials, but its Object Store
+artifact fetcher opens the NATS connection with `UserJWTAndSeed`. That mismatch
+causes the auth callout to receive a connection with no usable token or raw NKey
+challenge fields. `nats://` is still valid NEX behavior in compatible NATS
+credential setups; it is not the local Lixpi private-repo path right now.
+
 The native nexlet supports the `service` and `job` lifecycles (it is described in the docs as the reference "process runner which deploys jobs and services"). It does **not** do `function`.
 
 ## 7. Every way to run NEX

--- a/documentation/platform/deployment/NEX-EXECUTION-ENGINE.md
+++ b/documentation/platform/deployment/NEX-EXECUTION-ENGINE.md
@@ -81,6 +81,22 @@ Credential ownership is intentionally split:
 
 Keeping the node in its own account means its `$NEX.>` control plane and feeds stay isolated from application subjects. The auth decision still goes through the centralized API callout; the isolation comes from the issued JWT targeting `NEX` with NEX-only permissions. For the conceptual auth model see [Authentication](../AUTHENTICATION.md).
 
+Local private-repo workloads are delivered through the shared Docker volume
+`lixpi-nex-workloads`, mounted in the node at `/opt/nex/private-workloads`
+read-only. Private repos write native executable artifacts into that volume and
+deploy Nexfiles that use `file:///opt/nex/private-workloads/...` URIs. This keeps
+the public repo responsible for the NEX substrate while letting private repos
+supply private binaries without baking them into the public image.
+
+NEX 0.4.1 also supports `nats://<bucket>/<object>` Object Store artifacts in the
+native nexlet, but Lixpi does not use that path with the current `--issuer-nkey`
+setup. The `NkeyMinter` supplies NKey credentials, while the native artifact
+fetcher opens the Object Store connection with `UserJWTAndSeed`; under
+centralized auth callout that produces a connection with no usable token or raw
+NKey challenge fields, so the API correctly rejects it. Use the shared volume
+path locally unless Lixpi moves to a compatible NATS JWT/operator setup or a
+patched NEX artifact fetcher.
+
 ## Completion event
 
 After each run the workload publishes `aiModels.syncCompleted` (constant `AI_MODELS_SUBJECTS.MODELS_SYNC_COMPLETED`) with the run totals — `{ totalNew, totalUpdated, totalDeleted, totalProcessed, ranAt }` — using the NATS credentials the native nexlet mints for it, so the event originates in the `NEX` account.

--- a/packages/lixpi/nats-auth-callout-service/README.md
+++ b/packages/lixpi/nats-auth-callout-service/README.md
@@ -77,8 +77,8 @@ await startNatsAuthCalloutService({
             userId: 'svc:nex-node',
             account: 'NEX',
             permissions: {
-                pub: { allow: ['$NEX.>', '_INBOX.>', 'aiModels.syncCompleted'] },
-                sub: { allow: ['$NEX.>', '_INBOX.>'] }
+                pub: { allow: ['$NEX.>', '$JS.API.>', '$JS.lixpi.API.>', '_INBOX.>', 'aiModels.syncCompleted'] },
+                sub: { allow: ['$NEX.>', '$JS.API.>', '$JS.lixpi.API.>', '_INBOX.>'] }
             }
         }
     ]

--- a/services/nex/README.md
+++ b/services/nex/README.md
@@ -1,8 +1,6 @@
 # services/nex — NATS NEX execution-engine node
 
-A Lixpi-owned [NATS NEX](https://github.com/synadia-io/nex) **node**: a process
-that connects to the existing NATS cluster as a client and runs Lixpi background
-workloads on the bus — no cloud-vendor function runtime (no Lambda/GCP/Azure).
+A Lixpi-owned [NATS NEX](https://github.com/synadia-io/nex) **node**: a process that connects to the existing NATS cluster as a client and runs Lixpi background workloads on the bus — no cloud-vendor function runtime (no Lambda/GCP/Azure).
 
 - **Deployment & operation:** [`documentation/platform/deployment/NEX-EXECUTION-ENGINE.md`](../../documentation/platform/deployment/NEX-EXECUTION-ENGINE.md)
 - **General NEX reference:** [`documentation/knowledge/NATS-NEX-EXECUTION-ENGINE-EXPLAINED.md`](../../documentation/knowledge/NATS-NEX-EXECUTION-ENGINE-EXPLAINED.md)
@@ -16,24 +14,14 @@ workloads on the bus — no cloud-vendor function runtime (no Lambda/GCP/Azure).
 
 ## How it works
 
-The image (`Dockerfile`) is a `node:23-alpine` base + the pinned static `nex`
-binary. On start, [`entrypoint.sh`](./entrypoint.sh):
+The image (`Dockerfile`) is a `node:23-alpine` base + the pinned static `nex` binary. On start, [`entrypoint.sh`](./entrypoint.sh):
 
-1. `pnpm install` — resolves the workload's `@lixpi/*` + provider-SDK deps from
-   the pnpm workspace (mirrors `services/api`).
-2. `nex node up` — connects with the NEX nkey; the API auth callout verifies the
-   raw NKey challenge response and issues a NATS user JWT for the `NEX` account.
-   The node starts the bundled **native nexlet** and mints the same NEX nkey for
-   the nexlet/workloads (`--issuer-nkey`). Runs in the background.
-3. Deploys `ai-models-sync` via `nex workload start`, **injecting** the runtime
-   env (`ORG_NAME`, `STAGE`, `AWS_*`, `DYNAMODB_ENDPOINT`, provider keys, …) into
-   the start-request — the native nexlet does **not** inherit the container env.
+1. `pnpm install` — resolves the workload's `@lixpi/*` + provider-SDK deps from the pnpm workspace (mirrors `services/api`).
+2. `nex node up` — connects with the NEX nkey; the API auth callout verifies the raw NKey challenge response and issues a NATS user JWT for the `NEX` account. The node starts the bundled **native nexlet** and mints the same NEX nkey for the nexlet/workloads (`--issuer-nkey`). Runs in the background.
+3. Deploys `ai-models-sync` via `nex workload start`, **injecting** the runtime env (`ORG_NAME`, `STAGE`, `AWS_*`, `DYNAMODB_ENDPOINT`, provider keys, …) into the start-request — the native nexlet does **not** inherit the container env.
 4. Supervises the node in the foreground.
 
-State is intentionally **not** persisted (`--state kv` omitted): the entrypoint
-re-deploys the workload on every boot (idempotent), so there is exactly one
-workload instance per node and no orphaned KV buckets. See the proposal's
-"Re-evaluation notes" for the full rationale.
+State is intentionally **not** persisted (`--state kv` omitted): the entrypoint re-deploys the workload on every boot (idempotent), so there is exactly one workload instance per node and no orphaned KV buckets. See the proposal's "Re-evaluation notes" for the full rationale.
 
 ## Run it locally
 
@@ -43,27 +31,17 @@ docker compose --profile main up -d --build lixpi-nex-1   # rebuild just this no
 docker logs -f lixpi-nex-1              # node + workload startup output
 ```
 
-Required env (supplied by `docker-compose.yml` from `.env.<stage>`):
-`NATS_SERVERS`, `NATS_NEX_NODE_NKEY_PUBLIC`, `NATS_NEX_NODE_NKEY_SEED`,
-`ORG_NAME`, `STAGE`, `AWS_REGION`, `AWS_PROFILE`, `DYNAMODB_ENDPOINT`,
-`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GOOGLE_API_KEY`. Optional:
-`LIXPI_SYNC_INTERVAL_MS` (default `3600000`).
+Required env (supplied by `docker-compose.yml` from `.env.<stage>`): `NATS_SERVERS`, `NATS_NEX_NODE_NKEY_PUBLIC`, `NATS_NEX_NODE_NKEY_SEED`, `ORG_NAME`, `STAGE`, `AWS_REGION`, `AWS_PROFILE`, `DYNAMODB_ENDPOINT`, `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GOOGLE_API_KEY`. Optional: `LIXPI_SYNC_INTERVAL_MS` (default `3600000`).
 
 Credential ownership matters:
 
 - `NATS_NEX_NODE_NKEY_SEED` is secret and belongs only in this NEX container.
-- `NATS_NEX_NODE_NKEY_PUBLIC` is used here as the public half of the native NATS
-  NKey credential and in `services/api` as verification material for auth
-  callout.
-- The NATS server config also lists the NEX public key so the server advertises
-  the nonce required by native NKey auth. That static entry is not the final
-  authorization decision; the API auth callout verifies the raw NKey challenge
-  response and NATS enforces the returned `NEX` account user JWT.
+- `NATS_NEX_NODE_NKEY_PUBLIC` is used here as the public half of the native NATS NKey credential and in `services/api` as verification material for auth callout.
+- The NATS server config also lists the NEX public key so the server advertises the nonce required by native NKey auth. That static entry is not the final authorization decision; the API auth callout verifies the raw NKey challenge response and NATS enforces the returned `NEX` account user JWT.
 
 ## Operate
 
-The `nex` CLI needs the connection flags; the container already has them in env,
-so wrap calls in `sh -c` to expand them:
+The `nex` CLI needs the connection flags; the container already has them in env, so wrap calls in `sh -c` to expand them:
 
 ```bash
 # list nodes / inspect the node + its agents
@@ -76,23 +54,14 @@ docker exec lixpi-nex-1 sh -c 'nex -s "$NATS_SERVERS" --nats.nkey "$NATS_NEX_NOD
 docker exec lixpi-nex-1 sh -c 'nex -s "$NATS_SERVERS" --nats.nkey "$NATS_NEX_NODE_NKEY_PUBLIC" --nats.seed "$NATS_NEX_NODE_NKEY_SEED" --namespace lixpi workload start -f /usr/src/service/workloads/system-reporter/Nexfile'
 ```
 
-Workload stdout/stderr stream on `$NEX.FEED.lixpi.logs.>` and lifecycle events on
-`$NEX.FEED.lixpi.event.>` **within the NEX account** (observe with any NATS
-subscriber holding the NEX nkey). The fastest local check that the real workload
-ran is the DynamoDB `AI_MODELS_LIST` table being (re)populated. To watch it run
-quickly, set `LIXPI_SYNC_INTERVAL_MS` to a small value and rebuild.
+Workload stdout/stderr stream on `$NEX.FEED.lixpi.logs.>` and lifecycle events on `$NEX.FEED.lixpi.event.>` **within the NEX account** (observe with any NATS subscriber holding the NEX nkey). The fastest local check that the real workload ran is the DynamoDB `AI_MODELS_LIST` table being (re)populated. To watch it run quickly, set `LIXPI_SYNC_INTERVAL_MS` to a small value and rebuild.
 
 ## Adding a workload
 
-Add `workloads/<name>/` with a thin entrypoint wrapper + a `Nexfile`, declare any
-new deps in `package.json`, and point the entrypoint deploy at it (or deploy it
-manually). Heavy Node workloads run `native` (as `ai-models-sync` does); see the
-proposal for the `job`/`function` and Object-Store-artifact escalation paths.
+Add `workloads/<name>/` with a thin entrypoint wrapper + a `Nexfile`, declare any new deps in `package.json`, and point the entrypoint deploy at it (or deploy it manually). Heavy Node workloads run `native` (as `ai-models-sync` does); see the proposal for the `job`/`function` tradeoffs.
+
+Private repos should not bake private binaries into this public image. For local Docker, put native executable artifacts in the shared Docker volume `lixpi-nex-workloads`, which this node mounts read-only at `/opt/nex/private-workloads`, then deploy a Nexfile with a `file://` URI pointing at that path. This avoids the NEX 0.4.1 `nats://` Object Store artifact fetch credential mismatch in the current `--issuer-nkey` + centralized auth-callout setup.
 
 ## On AWS
 
-Provisioned by Pulumi as an internal-only Fargate service (no public IP / no
-Route53), `desiredCount: 1`, with a task role granting DynamoDB access to
-`AI_MODELS_LIST`. The node connects to the cluster over CloudMap; if `:4222`
-terminates TLS there, set `NATS_TLS_CA_FILE` (+ `NATS_TLS_FIRST=true`) and use
-`tls://` URLs in `NATS_SERVERS` (the entrypoint adds the CA flags).
+Provisioned by Pulumi as an internal-only Fargate service (no public IP / no Route53), `desiredCount: 1`, with a task role granting DynamoDB access to `AI_MODELS_LIST`. The node connects to the cluster over CloudMap; if `:4222` terminates TLS there, set `NATS_TLS_CA_FILE` (+ `NATS_TLS_FIRST=true`) and use `tls://` URLs in `NATS_SERVERS` (the entrypoint adds the CA flags).


### PR DESCRIPTION
Summary

- Add a shared Docker volume for private native NEX workload artifacts.
- Document why local private workloads should use file:// artifacts with the current NEX 0.4.1 issuer-nkey setup.
- Keep the public repo as the NATS/NEX substrate while private repos provide private workload binaries.

Relates to #224

Verification

- git diff --cached --check before commit.
- No Docker, Go, or test commands were run.