### PR TITLE
LIX-250 # Fix workspace media storage durability races

### DIFF
--- a/documentation/canvas/USER-FLOWS.md
+++ b/documentation/canvas/USER-FLOWS.md
@@ -185,7 +185,7 @@ When an image node is removed from the canvas — by user action or programmatic
 sequenceDiagram
     participant User
     participant Canvas as WorkspaceCanvas.ts
-    participant Tracker as canvasImageLifecycle
+    participant Tracker as canvasMediaNodeLifecycle
     participant NATS as NATS Client
     participant API as API Service
     participant ObjStore as NATS Object Store
@@ -228,7 +228,7 @@ sequenceDiagram
     end
 ```
 
-Video nodes follow the same shape over the `DELETE_VIDEO` subject. Neither deletion path touches Media Library items, which are independent saved copies; the full lifecycle is described in [Image Lifecycle Management](./WORKSPACE-MODEL.md#image-lifecycle-management).
+Video nodes follow the same shape over the `DELETE_VIDEO` subject. Neither deletion path touches Media Library items, which are independent saved copies; the full lifecycle is described in [Media Node Lifecycle Management](./WORKSPACE-MODEL.md#media-node-lifecycle-management).
 
 ## Editing Content
 

--- a/documentation/canvas/WORKSPACE-MODEL.md
+++ b/documentation/canvas/WORKSPACE-MODEL.md
@@ -275,6 +275,8 @@ The currently open workspace with full canvas state.
 }
 ```
 
+The `files` array is metadata for objects in the workspace's NATS Object Store bucket. Backend file registration uses atomic DynamoDB append, and file removal uses a conditional indexed remove instead of rewriting the whole list, so a delete cannot overwrite concurrent media registrations.
+
 ### documentsStore
 
 Documents belonging to the current workspace.
@@ -364,16 +366,15 @@ Canvas-state changes are debounced (1 second) before persisting, which prevents 
 
 AI chat panel state is stored inside `canvasState.aiChatPanel`. Opening or closing the panel, expanding or collapsing Sessions, opening or closing tabs, resizing it, changing context controls, and editing prompt drafts persist workspace UI state but do **not** create a conversation entity. Submitting from an empty panel creates a standalone chat session. Sessions is collapsed by default and toggled from the history icon in the panel control row; when expanded it lists standalone chats and extraction sessions. Closing a tab only changes panel presentation and the session remains reopenable; explicit standalone or extraction deletion removes that session and its saved prompt draft, while a saved Feature remains independent when its extraction session is deleted. The full panel and Sessions behavior is documented in [Chat Panel & Sessions](../ai-chat/CHAT-PANEL-AND-SESSIONS.md).
 
-## Image Lifecycle Management
+## Media Node Lifecycle Management
 
-Images on the canvas are tracked by [`canvasImageLifecycle.ts`](../../services/web-ui/src/infographics/workspace/canvasImageLifecycle.ts). When an image node is removed from the canvas state:
+Media nodes on the canvas are tracked by [`canvasMediaNodeLifecycle.ts`](../../services/web-ui/src/infographics/workspace/canvasMediaNodeLifecycle.ts). Each supported node type provides a small tracking/deletion config, so images, videos, and future media types share one state-diff implementation. When a tracked media node is removed from the canvas state:
 
 1. The tracker compares the previous and current canvas states.
-2. It detects which `fileId`s are missing from the current canvas state.
-3. It calls `deleteImage()` from [`imageUtils.ts`](../../services/web-ui/src/utils/imageUtils.ts) to delete the object from storage.
-4. The same `deleteImage()` utility is shared with ProseMirror's `imageLifecyclePlugin`, so inline-document images and canvas images use one deletion path.
+2. It detects which tracked media keys are missing from the current canvas state.
+3. It calls the configured deletion utility for that node type.
 
-This ensures orphaned workspace-node images do not accumulate in storage. Video nodes use the parallel `WORKSPACE_SUBJECTS.VIDEO_SUBJECTS.DELETE_VIDEO` path. Neither path deletes Media Library items — those are intentionally independent saved copies with their own scope and deletion lifecycle (see [Media Library](../library/MEDIA-LIBRARY.md)).
+This ensures orphaned workspace-node media does not accumulate in storage. Image nodes use `deleteImage()` from [`imageUtils.ts`](../../services/web-ui/src/utils/imageUtils.ts). Video nodes use `deleteVideo()` from [`videoUtils.ts`](../../services/web-ui/src/utils/videoUtils.ts), which deletes the MP4 and best-effort poster image. Neither path deletes Media Library items — those are intentionally independent saved copies with their own scope and deletion lifecycle (see [Media Library](../library/MEDIA-LIBRARY.md)).
 
 ## Workspace Load and Visibility Tracking
 

--- a/documentation/library/MEDIA-LIBRARY.md
+++ b/documentation/library/MEDIA-LIBRARY.md
@@ -397,6 +397,8 @@ The `Features` category continues to use `WORKSPACE_SUBJECTS.FEATURE_SUBJECTS`, 
 
 Saving writes the library object before publishing item metadata. If the metadata records cannot be created, the handler attempts to delete the copied object instead of leaving a usable item pointing nowhere.
 
+Workspace-scoped Media Library objects are stored in a workspace-owned Object Store bucket created during workspace creation. Save/copy paths expect that bucket to already exist; they do not auto-create a replacement if it is missing.
+
 Changing scope follows the same copy-first rule. It writes the destination object, updates the item and metadata records, and then removes the old object. If metadata update fails, the copied destination object is retained for reconciliation rather than deleting a possible recovery copy. If removing the old object fails after a successful move, the item still points at the new canonical copy.
 
 Deleting a library image removes its records and then attempts to remove its current library object. Deleting a library video also removes its copied poster when present. Deleting a library item does not remove canvas copies previously materialized from that item.

--- a/documentation/library/WORKSPACE-EXPORT-IMPORT.md
+++ b/documentation/library/WORKSPACE-EXPORT-IMPORT.md
@@ -232,7 +232,7 @@ sequenceDiagram
     %% ═══════════════════════════════════════════════════════════════
     rect rgb(246, 199, 179)
         Note over User, ObjStore: PHASE 4 - RESTORE — Recreate content from archive
-        API->>ObjStore: ensureObjectStore(bucketName)
+        API->>ObjStore: createObjectStore(bucketName)
         activate ObjStore
         loop For each image in ZIP
             API->>ObjStore: putObject(bucketName, fileId, data)
@@ -271,7 +271,7 @@ sequenceDiagram
 - **In-memory extraction**: The ZIP is buffered by `multer` and extracted with `adm-zip` — no temporary files on disk.
 - **Auth**: Uses `Authorization: Bearer` header (standard `fetch` POST, not `window.open`).
 - **Validation-first**: The archive is fully parsed and validated before any existing data is deleted. Invalid archives produce a 400 error with zero data loss.
-- **Bucket wipe**: The NATS Object Store bucket is deleted entirely via `deleteObjectStore()`, then recreated via `ensureObjectStore()`. This is faster than deleting individual objects and guarantees no orphans.
+- **Bucket wipe**: The NATS Object Store bucket is deleted entirely via `deleteObjectStore()`, then created explicitly with `createObjectStore()` as part of the import restore transaction. Normal media writes do not auto-create missing buckets.
 - **File size**: Accepts uploads up to 1GB via multer memory storage.
 - **Post-import reload**: The frontend automatically reloads workspace data, documents, and AI chat threads if the imported workspace is currently open.
 

--- a/documentation/media-generation/VIDEO-GENERATION.md
+++ b/documentation/media-generation/VIDEO-GENERATION.md
@@ -195,7 +195,7 @@ Video reuses the workspace bucket and the **same content-hash dedup as images**.
 
 Authentication mirrors the image route (Bearer or `?token=`). The poster reuses `GET /api/images/...`.
 
-**Deletion.** `workspace.video.delete` (`video-subjects.ts`) removes the MP4 from the Object Store and its `workspace.files` entry. On the canvas, `canvasVideoLifecycle.ts` tracks `VideoCanvasNode`s across state commits and, when one disappears, fires `deleteVideo(fileId, workspaceId, posterFileId)` — the MP4 via the video subject and the poster via the image-delete subject (the poster is a normal image). Workspace deletion cleans up video Media Library items by branching on `item.kind`.
+**Deletion.** `workspace.video.delete` (`video-subjects.ts`) removes the MP4 from the Object Store and its `workspace.files` entry. On the canvas, `canvasMediaNodeLifecycle.ts` tracks configured media node types across state commits. For `VideoCanvasNode`, when the node disappears it fires `deleteVideo(fileId, workspaceId, posterFileId)` — the MP4 via the video subject and the poster via the image-delete subject (the poster is a normal image). Workspace deletion cleans up video Media Library items by branching on `item.kind`.
 
 ## The `VideoCanvasNode`
 
@@ -339,7 +339,7 @@ services/web-ui/src/
 ├── infographics/workspace/
 │   ├── WorkspaceCanvas.ts            # VideoCanvasNode placement, lifecycle callbacks, extend-in-new-thread
 │   ├── rendering/videoNodeHandler.ts # PIXI poster + authenticated DOM video element
-│   ├── canvasVideoLifecycle.ts       # delete MP4 + poster when a node disappears
+│   ├── canvasMediaNodeLifecycle.ts   # generic media-node storage cleanup configs
 │   ├── pixiMediaLayer.ts             # dispatch non-image nodes to the registry
 │   └── canvasBubbleMenuItems.ts      # CANVAS_VIDEO_CONTEXT (extend / connect / delete)
 ├── components/videoControls/         # shared SVG playback controls

--- a/packages/lixpi/dynamodb-service/src/dynamodb-service.ts
+++ b/packages/lixpi/dynamodb-service/src/dynamodb-service.ts
@@ -403,6 +403,7 @@ export default class DynamoDBService {
         updateExpression = '',    // Use this if you need to provide a custom update expression
         expressionAttributeNames = {},    // Use this if you need to provide custom attribute names
         expressionAttributeValues = {},    // Use this if you need to provide custom attribute values
+        conditionExpression = '',
         origin = 'unknown'
     }) {
         if (!tableName || Object.keys(key).length === 0) {
@@ -431,6 +432,10 @@ export default class DynamoDBService {
         } else {
             console.error("Either 'updates' or 'updateExpression' must be provided.")
             return
+        }
+
+        if (conditionExpression) {
+            params.ConditionExpression = conditionExpression
         }
 
         try {

--- a/packages/lixpi/nats-service/README.md
+++ b/packages/lixpi/nats-service/README.md
@@ -147,11 +147,11 @@ const os = await natsService.createObjectStore('my-bucket', {
 // Or open an existing bucket
 const os = await natsService.getObjectStore('my-bucket')
 
-// Store an object (bytes)
+// Store an object (bytes) in an existing bucket
 const data = new TextEncoder().encode('Hello World')
 await natsService.putObject('my-bucket', 'hello.txt', data)
 
-// Store from a ReadableStream
+// Store from a ReadableStream in an existing bucket
 await natsService.putObjectFromReadable('my-bucket', 'large-file.bin', readableStream)
 
 // Retrieve an object as bytes

--- a/packages/lixpi/nats-service/python/nats_service.py
+++ b/packages/lixpi/nats-service/python/nats_service.py
@@ -677,15 +677,6 @@ class NatsService:
         js = self._get_jetstream()
         return await js.object_store(bucket_name)
 
-    async def ensure_object_store(self, bucket_name: str) -> ObjectStore:
-        """Open a bucket, auto-creating it if it was wiped or never existed."""
-        js = self._get_jetstream()
-        try:
-            return await js.object_store(bucket_name)
-        except Exception:
-            warn(f"Object Store bucket missing, recreating: {bucket_name}")
-            return await js.create_object_store(bucket_name, config=ObjectStoreConfig(replicas=1))
-
     async def delete_object_store(self, bucket_name: str) -> bool:
         """Delete an Object Store bucket."""
         js = self._get_jetstream()
@@ -701,7 +692,7 @@ class NatsService:
         meta: Optional[ObjectMeta] = None
     ) -> ObjectInfo:
         """Store data as an object."""
-        os = await self.ensure_object_store(bucket_name)
+        os = await self.get_object_store(bucket_name)
         result = await os.put(name, data, meta=meta)
         info(f"Object stored: {bucket_name}/{name} ({len(data)} bytes)")
         return result
@@ -714,14 +705,14 @@ class NatsService:
         meta: Optional[ObjectMeta] = None
     ) -> ObjectInfo:
         """Store data from a readable stream."""
-        os = await self.ensure_object_store(bucket_name)
+        os = await self.get_object_store(bucket_name)
         result = await os.put(name, readable, meta=meta)
         info(f"Object stored from stream: {bucket_name}/{name}")
         return result
 
     async def get_object(self, bucket_name: str, name: str) -> Optional[bytes]:
         """Retrieve an object as bytes."""
-        os = await self.ensure_object_store(bucket_name)
+        os = await self.get_object_store(bucket_name)
         try:
             result = await os.get(name)
         except Exception as e:
@@ -739,7 +730,7 @@ class NatsService:
         writeinto: io.BufferedIOBase
     ) -> Optional[ObjectInfo]:
         """Retrieve an object by streaming directly into a writable buffer."""
-        os = await self.ensure_object_store(bucket_name)
+        os = await self.get_object_store(bucket_name)
         try:
             result = await os.get(name, writeinto=writeinto)
         except Exception as e:
@@ -752,7 +743,7 @@ class NatsService:
 
     async def get_object_info(self, bucket_name: str, name: str) -> Optional[ObjectInfo]:
         """Get object metadata."""
-        os = await self.ensure_object_store(bucket_name)
+        os = await self.get_object_store(bucket_name)
         try:
             return await os.info(name)
         except Exception as e:
@@ -762,11 +753,11 @@ class NatsService:
 
     async def delete_object(self, bucket_name: str, name: str) -> None:
         """Delete an object from a bucket."""
-        os = await self.ensure_object_store(bucket_name)
+        os = await self.get_object_store(bucket_name)
         await os.delete(name)
         info(f"Object deleted: {bucket_name}/{name}")
 
     async def list_objects(self, bucket_name: str) -> List[ObjectInfo]:
         """List all objects in a bucket."""
-        os = await self.ensure_object_store(bucket_name)
+        os = await self.get_object_store(bucket_name)
         return await os.list()

--- a/packages/lixpi/nats-service/ts/nats-service.ts
+++ b/packages/lixpi/nats-service/ts/nats-service.ts
@@ -574,23 +574,6 @@ export default class NatsService {
         return objm.open(bucketName)
     }
 
-    // Open a bucket for WRITES, creating it only if it genuinely does not exist.
-    // A transient open failure is rethrown rather than masked by creating an
-    // empty replacement bucket. New buckets are created replicated (R3).
-    async ensureObjectStore(bucketName: string): Promise<ObjectStore> {
-        const objm = this.getObjectStoreManager()
-        try {
-            return await objm.open(bucketName)
-        } catch (e: any) {
-            if (!this.isStreamNotFoundError(e)) {
-                err(`Object Store open failed for ${bucketName} (NOT auto-creating — transient/cluster error):`, e)
-                throw e
-            }
-            warn(`Object Store bucket does not exist, creating (replicas=${this.streamReplicas}): ${bucketName}`)
-            return await objm.create(bucketName, { replicas: this.streamReplicas })
-        }
-    }
-
     async deleteObjectStore(bucketName: string): Promise<boolean> {
         const objm = this.getObjectStoreManager()
         const result = await objm.destroy(bucketName)
@@ -633,7 +616,7 @@ export default class NatsService {
     }
 
     async putObject(bucketName: string, name: string, data: Uint8Array, meta?: Partial<ObjectInfo>): Promise<ObjectInfo> {
-        const os = await this.ensureObjectStore(bucketName)
+        const os = await this.getObjectStore(bucketName)
         const stream = this.readableStreamFrom(data)
         const result = await os.put({ name, ...meta }, stream)
         info(`Object stored: ${bucketName}/${name} (${data.length} bytes)`)
@@ -641,7 +624,7 @@ export default class NatsService {
     }
 
     async putObjectFromReadable(bucketName: string, name: string, readable: ReadableStream<Uint8Array>, meta?: Partial<ObjectInfo>): Promise<ObjectInfo> {
-        const os = await this.ensureObjectStore(bucketName)
+        const os = await this.getObjectStore(bucketName)
         const result = await os.put({ name, ...meta }, readable)
         info(`Object stored from stream: ${bucketName}/${name}`)
         return result

--- a/services/api/src/NATS/subscriptions/workspace-creation-storage.test.ts
+++ b/services/api/src/NATS/subscriptions/workspace-creation-storage.test.ts
@@ -1,0 +1,117 @@
+'use strict'
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { NATS_SUBJECTS } from '@lixpi/constants'
+
+const mocks = vi.hoisted(() => ({
+    natsService: {
+        createObjectStore: vi.fn(),
+        deleteObjectStore: vi.fn(),
+    },
+    workspace: {
+        createWorkspace: vi.fn(),
+        delete: vi.fn(),
+        getBucketName: vi.fn((workspaceId: string) => `workspace-${workspaceId}-files`),
+    },
+    feature: {
+        listPromotedByOriginWorkspaceForCleanup: vi.fn(),
+        listByScope: vi.fn(),
+        deleteFeature: vi.fn(),
+    },
+    mediaLibraryItem: {
+        listWorkspaceItemsForCleanup: vi.fn(),
+        deleteImageItem: vi.fn(),
+        deleteVideoItem: vi.fn(),
+    },
+    aiChatThread: {
+        deleteWorkspaceAiChatThreads: vi.fn(),
+    },
+    extractionRun: {
+        deleteWorkspaceRuns: vi.fn(),
+    },
+    getMediaLibraryWorkspaceBucketName: vi.fn((workspaceId: string) =>
+        `media-library-workspace-${workspaceId}-files`
+    ),
+}))
+
+vi.mock('@lixpi/debug-tools', () => ({ info: vi.fn(), err: vi.fn(), warn: vi.fn() }))
+vi.mock('@lixpi/nats-service', () => ({
+    default: {
+        getInstance: vi.fn(() => mocks.natsService),
+    },
+}))
+vi.mock('../../models/workspace.ts', () => ({ default: mocks.workspace }))
+vi.mock('../../models/document.ts', () => ({ default: {} }))
+vi.mock('../../models/feature.ts', () => ({ default: mocks.feature }))
+vi.mock('../../models/media-library-item.ts', () => ({ default: mocks.mediaLibraryItem }))
+vi.mock('../../models/ai-chat-thread.ts', () => ({ default: mocks.aiChatThread }))
+vi.mock('../../models/extraction-run.ts', () => ({ default: mocks.extractionRun }))
+vi.mock('../../services/media-library-storage.ts', () => ({
+    deleteLibraryImageObject: vi.fn(),
+    deleteLibraryVideoObject: vi.fn(),
+    deleteMediaLibraryWorkspaceBucket: vi.fn(),
+    getMediaLibraryWorkspaceBucketName: mocks.getMediaLibraryWorkspaceBucketName,
+}))
+vi.mock('../../services/feature-sample-storage.ts', () => ({
+    ensureFeatureSamplesForScope: vi.fn(),
+}))
+
+import { workspaceSubjects } from './workspace-subjects.ts'
+
+const getHandler = (subject: string) =>
+    workspaceSubjects.find((subscription) => subscription.subject === subject)!.handler
+
+// =============================================================================
+// WORKSPACE STORAGE PROVISIONING
+// =============================================================================
+
+describe('Workspace creation storage provisioning', () => {
+    beforeEach(() => {
+        vi.clearAllMocks()
+        mocks.workspace.createWorkspace.mockResolvedValue({
+            workspaceId: 'ws-1',
+            name: 'New Workspace',
+        })
+        mocks.workspace.delete.mockResolvedValue({ status: 'deleted', workspaceId: 'ws-1' })
+        mocks.natsService.createObjectStore.mockResolvedValue({})
+        mocks.natsService.deleteObjectStore.mockResolvedValue(true)
+    })
+
+    it('creates both the workspace file bucket and the workspace media-library bucket', async () => {
+        const result = await getHandler(NATS_SUBJECTS.WORKSPACE_SUBJECTS.CREATE_WORKSPACE)({
+            user: { userId: 'user-1' },
+            name: 'New Workspace',
+        })
+
+        expect(mocks.workspace.getBucketName).toHaveBeenCalledWith('ws-1')
+        expect(mocks.getMediaLibraryWorkspaceBucketName).toHaveBeenCalledWith('ws-1')
+        expect(mocks.natsService.createObjectStore).toHaveBeenNthCalledWith(1, 'workspace-ws-1-files', {
+            description: 'Files for workspace ws-1',
+        })
+        expect(mocks.natsService.createObjectStore).toHaveBeenNthCalledWith(2, 'media-library-workspace-ws-1-files', {
+            description: 'Media Library files for workspace ws-1',
+        })
+        expect(mocks.workspace.delete).not.toHaveBeenCalled()
+        expect(result).toEqual(expect.objectContaining({ workspaceId: 'ws-1' }))
+    })
+
+    it('rolls back the database record and both bucket names when media-library bucket creation fails', async () => {
+        mocks.natsService.createObjectStore
+            .mockResolvedValueOnce({})
+            .mockRejectedValueOnce(new Error('stream create failed'))
+
+        const result = await getHandler(NATS_SUBJECTS.WORKSPACE_SUBJECTS.CREATE_WORKSPACE)({
+            user: { userId: 'user-1' },
+            name: 'New Workspace',
+        })
+
+        expect(result).toEqual({ error: 'FAILED_TO_CREATE_BUCKET' })
+        expect(mocks.natsService.deleteObjectStore).toHaveBeenNthCalledWith(1, 'workspace-ws-1-files')
+        expect(mocks.natsService.deleteObjectStore).toHaveBeenNthCalledWith(2, 'media-library-workspace-ws-1-files')
+        expect(mocks.workspace.delete).toHaveBeenCalledWith({
+            userId: 'user-1',
+            workspaceId: 'ws-1',
+        })
+    })
+})

--- a/services/api/src/NATS/subscriptions/workspace-deletion.test.ts
+++ b/services/api/src/NATS/subscriptions/workspace-deletion.test.ts
@@ -37,7 +37,11 @@ vi.mock('../../models/ai-chat-thread.ts', () => ({ default: mocks.aiChatThread }
 vi.mock('../../models/extraction-run.ts', () => ({ default: mocks.extractionRun }))
 vi.mock('../../services/media-library-storage.ts', () => ({
     deleteLibraryImageObject: vi.fn(),
+    deleteLibraryVideoObject: vi.fn(),
     deleteMediaLibraryWorkspaceBucket: vi.fn(),
+    getMediaLibraryWorkspaceBucketName: vi.fn((workspaceId: string) =>
+        `media-library-workspace-${workspaceId}-files`
+    ),
 }))
 vi.mock('../../services/feature-sample-storage.ts', () => ({
     ensureFeatureSamplesForScope: vi.fn(),

--- a/services/api/src/NATS/subscriptions/workspace-subjects.ts
+++ b/services/api/src/NATS/subscriptions/workspace-subjects.ts
@@ -13,6 +13,7 @@ import {
     deleteLibraryImageObject,
     deleteLibraryVideoObject,
     deleteMediaLibraryWorkspaceBucket,
+    getMediaLibraryWorkspaceBucketName,
 } from '../../services/media-library-storage.ts'
 import { ensureFeatureSamplesForScope } from '../../services/feature-sample-storage.ts'
 
@@ -62,6 +63,7 @@ export const workspaceSubjects = [
             if (workspace && 'workspaceId' in workspace) {
                 const natsService = NATS_Service.getInstance()
                 const bucketName = Workspace.getBucketName(workspace.workspaceId)
+                const mediaLibraryBucketName = getMediaLibraryWorkspaceBucketName(workspace.workspaceId)
 
                 if (!natsService) {
                     err(`Failed to create Object Store bucket ${bucketName}: NATS service unavailable`)
@@ -75,8 +77,14 @@ export const workspaceSubjects = [
                         description: `Files for workspace ${workspace.workspaceId}`
                     })
                     info(`Created Object Store bucket: ${bucketName}`)
+                    await natsService.createObjectStore(mediaLibraryBucketName, {
+                        description: `Media Library files for workspace ${workspace.workspaceId}`
+                    })
+                    info(`Created Object Store bucket: ${mediaLibraryBucketName}`)
                 } catch (bucketError: any) {
                     err(`Failed to create Object Store bucket for workspace ${workspace.workspaceId}:`, bucketError)
+                    await natsService.deleteObjectStore(bucketName).catch(() => {})
+                    await natsService.deleteObjectStore(mediaLibraryBucketName).catch(() => {})
                     await Workspace.delete({ userId, workspaceId: workspace.workspaceId })
                     return { error: 'FAILED_TO_CREATE_BUCKET' }
                 }

--- a/services/api/src/models/workspace.test.ts
+++ b/services/api/src/models/workspace.test.ts
@@ -3,7 +3,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import Workspace from './workspace.ts'
-import type { ContentDescriptor } from '@lixpi/constants'
+import type { ContentDescriptor, DocumentFile } from '@lixpi/constants'
 
 const dynamo = {
     getItem: vi.fn(),
@@ -71,6 +71,116 @@ describe('Workspace.patchCanvasNodeDescriptor', () => {
                 updatedAt: 1,
             },
         })).resolves.toBe(false)
+
+        expect(dynamo.updateItem).not.toHaveBeenCalled()
+    })
+})
+
+// =============================================================================
+// WORKSPACE FILE LIST STORAGE
+// =============================================================================
+
+describe('Workspace file list storage', () => {
+    const file: DocumentFile = {
+        id: 'file-1',
+        name: 'image.png',
+        mimeType: 'image/png',
+        size: 100,
+    }
+
+    it('adds files with DynamoDB list_append instead of a read-modify-write overwrite', async () => {
+        await Workspace.addFile({
+            workspaceId: 'workspace-1',
+            file,
+        })
+
+        expect(dynamo.getItem).not.toHaveBeenCalled()
+        expect(dynamo.updateItem).toHaveBeenCalledWith(expect.objectContaining({
+            key: { workspaceId: 'workspace-1' },
+            updateExpression: 'SET #files = list_append(if_not_exists(#files, :empty), :newFiles), #updatedAt = :now',
+            expressionAttributeNames: {
+                '#files': 'files',
+                '#updatedAt': 'updatedAt',
+            },
+            expressionAttributeValues: {
+                ':empty': [],
+                ':newFiles': [file],
+                ':now': expect.any(Number),
+            },
+        }))
+    })
+
+    it('removes a file by guarded list index instead of rewriting the whole files array', async () => {
+        dynamo.getItem.mockResolvedValue({
+            files: [
+                { id: 'keep-1' },
+                { id: 'file-1' },
+                { id: 'keep-2' },
+            ],
+        })
+        dynamo.updateItem.mockResolvedValue(undefined)
+
+        await Workspace.removeFile({
+            workspaceId: 'workspace-1',
+            fileId: 'file-1',
+        })
+
+        expect(dynamo.updateItem).toHaveBeenCalledWith(expect.objectContaining({
+            key: { workspaceId: 'workspace-1' },
+            updateExpression: 'SET #updatedAt = :now REMOVE #files[1]',
+            conditionExpression: '#files[1].#id = :fileId',
+            expressionAttributeNames: {
+                '#files': 'files',
+                '#id': 'id',
+                '#updatedAt': 'updatedAt',
+            },
+            expressionAttributeValues: {
+                ':fileId': 'file-1',
+                ':now': expect.any(Number),
+            },
+        }))
+        expect(dynamo.updateItem.mock.calls[0][0].updates).toBeUndefined()
+    })
+
+    it('re-reads and retries when another writer shifts the file index', async () => {
+        const conditionalFailure = Object.assign(new Error('index changed'), {
+            name: 'ConditionalCheckFailedException',
+        })
+        dynamo.getItem
+            .mockResolvedValueOnce({
+                files: [
+                    { id: 'keep-1' },
+                    { id: 'file-1' },
+                ],
+            })
+            .mockResolvedValueOnce({
+                files: [
+                    { id: 'file-1' },
+                ],
+            })
+        dynamo.updateItem
+            .mockRejectedValueOnce(conditionalFailure)
+            .mockResolvedValueOnce(undefined)
+
+        await Workspace.removeFile({
+            workspaceId: 'workspace-1',
+            fileId: 'file-1',
+        })
+
+        expect(dynamo.getItem).toHaveBeenCalledTimes(2)
+        expect(dynamo.updateItem.mock.calls[0][0].updateExpression).toBe('SET #updatedAt = :now REMOVE #files[1]')
+        expect(dynamo.updateItem.mock.calls[1][0].updateExpression).toBe('SET #updatedAt = :now REMOVE #files[0]')
+    })
+
+    it('does not write when the file is already absent', async () => {
+        dynamo.getItem.mockResolvedValue({
+            files: [{ id: 'keep-1' }],
+        })
+
+        await Workspace.removeFile({
+            workspaceId: 'workspace-1',
+            fileId: 'file-1',
+        })
 
         expect(dynamo.updateItem).not.toHaveBeenCalled()
     })

--- a/services/api/src/models/workspace.ts
+++ b/services/api/src/models/workspace.ts
@@ -12,6 +12,7 @@ import {
     type ContentDescriptor,
     type DocumentFile
 } from '@lixpi/constants'
+import { err } from '@lixpi/debug-tools'
 
 const {
     ORG_NAME,
@@ -149,7 +150,7 @@ export default {
 
             return newWorkspaceData
         } catch (error) {
-            console.error('Failed to create workspace:', error)
+            err('Failed to create workspace:', error)
         }
     },
 
@@ -185,7 +186,7 @@ export default {
                 })
             }
         } catch (error) {
-            console.error('Failed to update workspace:', error)
+            err('Failed to update workspace:', error)
         }
     },
 
@@ -216,7 +217,7 @@ export default {
                 origin: 'updateWorkspaceCanvasState'
             })
         } catch (error) {
-            console.error('Failed to update workspace canvas state:', error)
+            err('Failed to update workspace canvas state:', error)
         }
     },
 
@@ -266,7 +267,7 @@ export default {
 
             return true
         } catch (error) {
-            console.error('Failed to patch workspace canvas node descriptor:', error)
+            err('Failed to patch workspace canvas node descriptor:', error)
             throw error
         }
     },
@@ -327,7 +328,7 @@ export default {
                 origin: 'model::Workspace->addFile()'
             })
         } catch (error) {
-            console.error('Failed to add file to workspace:', error)
+            err('Failed to add file to workspace:', error)
             throw error
         }
     },
@@ -337,8 +338,9 @@ export default {
         fileId
     }: { workspaceId: string; fileId: string }): Promise<void> => {
         const currentDate = new Date().getTime()
+        const maxAttempts = 5
 
-        try {
+        for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
             const workspace = await dynamoDBService.getItem({
                 tableName: getDynamoDbTableStageName('WORKSPACES', ORG_NAME, STAGE),
                 key: { workspaceId },
@@ -346,21 +348,35 @@ export default {
             })
 
             const currentFiles = workspace?.files || []
-            const updatedFiles = currentFiles.filter((file: DocumentFile) => file.id !== fileId)
+            const fileIndex = currentFiles.findIndex((file: DocumentFile) => file.id === fileId)
+            if (fileIndex < 0) return
 
-            await dynamoDBService.updateItem({
-                tableName: getDynamoDbTableStageName('WORKSPACES', ORG_NAME, STAGE),
-                key: { workspaceId },
-                updates: {
-                    files: updatedFiles,
-                    updatedAt: currentDate
-                },
-                origin: 'model::Workspace->removeFile()'
-            })
-        } catch (error) {
-            console.error('Failed to remove file from workspace:', error)
-            throw error
+            try {
+                await dynamoDBService.updateItem({
+                    tableName: getDynamoDbTableStageName('WORKSPACES', ORG_NAME, STAGE),
+                    key: { workspaceId },
+                    updateExpression: `SET #updatedAt = :now REMOVE #files[${fileIndex}]`,
+                    conditionExpression: `#files[${fileIndex}].#id = :fileId`,
+                    expressionAttributeNames: {
+                        '#files': 'files',
+                        '#id': 'id',
+                        '#updatedAt': 'updatedAt'
+                    },
+                    expressionAttributeValues: {
+                        ':fileId': fileId,
+                        ':now': currentDate
+                    },
+                    origin: 'model::Workspace->removeFile()'
+                })
+                return
+            } catch (error: any) {
+                if (error?.name === 'ConditionalCheckFailedException') continue
+                err('Failed to remove file from workspace:', error)
+                throw error
+            }
         }
+
+        throw new Error(`Failed to remove file from workspace after concurrent updates: ${workspaceId}/${fileId}`)
     },
 
     getWorkspaceInternal: async ({
@@ -407,7 +423,7 @@ export default {
                 origin: 'replaceWorkspaceContent:meta'
             })
         } catch (error) {
-            console.error('Failed to replace workspace content:', error)
+            err('Failed to replace workspace content:', error)
             throw error
         }
     },

--- a/services/api/src/routes/workspace-export-routes.ts
+++ b/services/api/src/routes/workspace-export-routes.ts
@@ -326,9 +326,12 @@ router.post(
                 AiChatThread.deleteWorkspaceAiChatThreads({ workspaceId })
             ])
 
-            // ── Restore images ─────────────────────────────────────
+            // ── Restore workspace bucket + images ──────────────────
+            if (natsService) {
+                await natsService.createObjectStore(bucketName)
+            }
+
             if (imageEntries.length > 0 && natsService) {
-                await natsService.ensureObjectStore(bucketName)
                 for (const image of imageEntries) {
                     await natsService.putObject(bucketName, image.fileId, image.data, {
                         name: image.fileId,

--- a/services/api/src/services/dynamodb-service-condition.test.ts
+++ b/services/api/src/services/dynamodb-service-condition.test.ts
@@ -1,0 +1,72 @@
+'use strict'
+
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+
+const workspaceModelSource = (): string =>
+    readFileSync(new URL('../models/workspace.ts', import.meta.url), 'utf8')
+
+function expectSourceToContain(source: string, snippet: string, label = 'source'): void {
+    expect(
+        source.includes(snippet),
+        `${label} should contain:\n${snippet}`
+    ).toBe(true)
+}
+
+function expectSourceNotToContain(source: string, snippet: string, label = 'source'): void {
+    expect(
+        source.includes(snippet),
+        `${label} should not contain:\n${snippet}`
+    ).toBe(false)
+}
+
+// =============================================================================
+// API WORKSPACE FILE UPDATE CONTRACT
+// =============================================================================
+
+describe('Workspace model file update contract', () => {
+    it('appends workspace files atomically instead of using read-modify-write state', () => {
+        const source = workspaceModelSource()
+
+        expectSourceToContain(
+            source,
+            "updateExpression: 'SET #files = list_append(if_not_exists(#files, :empty), :newFiles), #updatedAt = :now'",
+            'Workspace.addFile'
+        )
+        expectSourceNotToContain(
+            source,
+            'const currentFiles = workspace?.files || []\n            const updatedFiles = [...currentFiles, file]',
+            'Workspace.addFile'
+        )
+    })
+
+    it('removes workspace files with a guarded list-index update and conditional retry', () => {
+        const source = workspaceModelSource()
+
+        expectSourceToContain(
+            source,
+            'const maxAttempts = 5',
+            'Workspace.removeFile'
+        )
+        expectSourceToContain(
+            source,
+            'updateExpression: `SET #updatedAt = :now REMOVE #files[${fileIndex}]`',
+            'Workspace.removeFile'
+        )
+        expectSourceToContain(
+            source,
+            'conditionExpression: `#files[${fileIndex}].#id = :fileId`',
+            'Workspace.removeFile'
+        )
+        expectSourceToContain(
+            source,
+            "if (error?.name === 'ConditionalCheckFailedException') continue",
+            'Workspace.removeFile'
+        )
+        expectSourceNotToContain(
+            source,
+            'files: updatedFiles',
+            'Workspace.removeFile'
+        )
+    })
+})

--- a/services/api/src/services/media-library-storage.test.ts
+++ b/services/api/src/services/media-library-storage.test.ts
@@ -2,7 +2,7 @@
 
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-import type { MediaLibraryImageItem } from '@lixpi/constants'
+import type { MediaLibraryImageItem, MediaLibraryVideoItem } from '@lixpi/constants'
 
 const mocks = vi.hoisted(() => ({
     getWorkspaceInternal: vi.fn(),
@@ -12,6 +12,7 @@ const mocks = vi.hoisted(() => ({
     deleteObject: vi.fn(),
     deleteObjectStore: vi.fn(),
     storeWorkspaceImage: vi.fn(),
+    storeWorkspaceVideo: vi.fn(),
 }))
 
 vi.mock('@lixpi/nats-service', () => ({
@@ -37,11 +38,17 @@ vi.mock('./image-storage.ts', () => ({
     storeWorkspaceImage: mocks.storeWorkspaceImage,
 }))
 
+vi.mock('./video-storage.ts', () => ({
+    storeWorkspaceVideo: mocks.storeWorkspaceVideo,
+}))
+
 import {
+    copyWorkspaceVideoToLibrary,
     copyLibraryImageToScope,
     copyWorkspaceImageToLibrary,
     deleteMediaLibraryWorkspaceBucket,
     materializeLibraryImageToWorkspace,
+    materializeLibraryVideoToWorkspace,
 } from './media-library-storage.ts'
 
 const pngBytes = Buffer.from(
@@ -73,6 +80,38 @@ const makeItem = (): MediaLibraryImageItem => ({
     updatedAt: 1,
 })
 
+const makeVideoItem = (): MediaLibraryVideoItem => ({
+    itemId: 'library-video-1',
+    version: 1,
+    kind: 'video',
+    displayName: 'saved.mp4',
+    ownerUserId: 'user-1',
+    originWorkspaceId: 'workspace-1',
+    sourceFileId: 'source-video-1',
+    sourcePosterFileId: 'source-poster-1',
+    scope: 'workspace',
+    scopeOwnerId: 'workspace-1',
+    scopeAndOwner: 'workspace#workspace-1',
+    status: 'active',
+    asset: {
+        bucketName: 'media-library-workspace-workspace-1-files',
+        objectKey: 'library-video-1',
+        mimeType: 'video/mp4',
+        byteSize: pngBytes.length,
+        originalName: 'saved.mp4',
+    },
+    poster: {
+        bucketName: 'media-library-workspace-workspace-1-files',
+        objectKey: 'library-video-1-poster',
+        mimeType: 'image/png',
+        byteSize: pngBytes.length,
+        originalName: 'saved-poster.png',
+    },
+    video: { durationSeconds: 4, aspectRatio: 1, hasAudio: false },
+    createdAt: 1,
+    updatedAt: 1,
+})
+
 describe('Media Library storage ownership', () => {
     beforeEach(() => {
         vi.clearAllMocks()
@@ -80,6 +119,16 @@ describe('Media Library storage ownership', () => {
             files: [{
                 id: 'source-file-1',
                 name: 'saved.png',
+                mimeType: 'image/png',
+                size: pngBytes.length,
+            }, {
+                id: 'source-video-1',
+                name: 'saved.mp4',
+                mimeType: 'video/mp4',
+                size: pngBytes.length,
+            }, {
+                id: 'source-poster-1',
+                name: 'saved-poster.png',
                 mimeType: 'image/png',
                 size: pngBytes.length,
             }],
@@ -93,6 +142,13 @@ describe('Media Library storage ownership', () => {
             isDuplicate: false,
             size: pngBytes.length,
             mimeType: 'image/png',
+        })
+        mocks.storeWorkspaceVideo.mockResolvedValue({
+            fileId: 'restored-video-1',
+            url: '/api/videos/workspace-2/restored-video-1',
+            isDuplicate: false,
+            size: pngBytes.length,
+            mimeType: 'video/mp4',
         })
     })
 
@@ -146,5 +202,57 @@ describe('Media Library storage ownership', () => {
 
         await deleteMediaLibraryWorkspaceBucket('workspace-1')
         expect(mocks.deleteObjectStore).toHaveBeenCalledWith('media-library-workspace-workspace-1-files')
+    })
+
+    it('saves a canvas video and its poster into independent workspace-scoped library objects', async () => {
+        const copied = await copyWorkspaceVideoToLibrary({
+            workspaceId: 'workspace-1',
+            fileId: 'source-video-1',
+            posterFileId: 'source-poster-1',
+            durationSeconds: 4,
+            aspectRatio: 1,
+            hasAudio: false,
+            scope: 'workspace',
+            scopeOwnerId: 'workspace-1',
+        })
+
+        expect(copied.itemId).not.toBe('source-video-1')
+        expect(copied.asset.bucketName).toBe('media-library-workspace-workspace-1-files')
+        expect(copied.asset.objectKey).toBe(copied.itemId)
+        expect(copied.poster).toEqual(expect.objectContaining({
+            bucketName: 'media-library-workspace-workspace-1-files',
+            objectKey: `${copied.itemId}-poster`,
+            originalName: 'saved-poster.png',
+        }))
+        expect(mocks.putObjectFromReadable).toHaveBeenCalledWith(
+            'media-library-workspace-workspace-1-files',
+            copied.itemId,
+            { readable: true },
+            { name: copied.itemId, description: 'saved.mp4' }
+        )
+        expect(mocks.putObjectFromReadable).toHaveBeenCalledWith(
+            'media-library-workspace-workspace-1-files',
+            `${copied.itemId}-poster`,
+            { readable: true },
+            { name: `${copied.itemId}-poster`, description: 'saved-poster.png' }
+        )
+    })
+
+    it('restores a saved video through the existing workspace video and poster storage paths', async () => {
+        const item = makeVideoItem()
+        await materializeLibraryVideoToWorkspace({ item, workspaceId: 'workspace-2' })
+
+        expect(mocks.storeWorkspaceVideo).toHaveBeenCalledWith({
+            workspaceId: 'workspace-2',
+            buffer: pngBytes,
+            originalName: 'saved.mp4',
+            mimeType: 'video/mp4',
+        })
+        expect(mocks.storeWorkspaceImage).toHaveBeenCalledWith({
+            workspaceId: 'workspace-2',
+            buffer: pngBytes,
+            originalName: 'saved-poster.png',
+            mimeType: 'image/png',
+        })
     })
 })

--- a/services/api/src/services/media-library-storage.ts
+++ b/services/api/src/services/media-library-storage.ts
@@ -24,6 +24,9 @@ const getMediaLibraryBucketName = (scope: MediaLibraryScope, scopeOwnerId: strin
         ? 'media-library-public-files'
         : `media-library-${scope}-${scopeOwnerId}-files`
 
+export const getMediaLibraryWorkspaceBucketName = (workspaceId: string): string =>
+    getMediaLibraryBucketName(MEDIA_LIBRARY_SCOPE.WORKSPACE, workspaceId)
+
 const getStorageService = (): NATS_Service => {
     const natsService = NATS_Service.getInstance()
     if (!natsService) {
@@ -152,7 +155,7 @@ export const deleteLibraryImageObject = async (item: MediaLibraryImageItem): Pro
 }
 
 export const deleteMediaLibraryWorkspaceBucket = async (workspaceId: string): Promise<void> => {
-    await getStorageService().deleteObjectStore(getMediaLibraryBucketName(MEDIA_LIBRARY_SCOPE.WORKSPACE, workspaceId))
+    await getStorageService().deleteObjectStore(getMediaLibraryWorkspaceBucketName(workspaceId))
 }
 
 // =============================================================================

--- a/services/api/src/services/nats-object-store-contract.test.ts
+++ b/services/api/src/services/nats-object-store-contract.test.ts
@@ -1,0 +1,85 @@
+'use strict'
+
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+
+const readSource = (relativeUrl: string): string =>
+    readFileSync(new URL(relativeUrl, import.meta.url), 'utf8')
+
+function expectSourceToContain(source: string, snippet: string, label = 'source'): void {
+    expect(
+        source.includes(snippet),
+        `${label} should contain:\n${snippet}`
+    ).toBe(true)
+}
+
+function expectSourceNotToContain(source: string, snippet: string, label = 'source'): void {
+    expect(
+        source.includes(snippet),
+        `${label} should not contain:\n${snippet}`
+    ).toBe(false)
+}
+
+// =============================================================================
+// API STORAGE BUCKET CONTRACT
+// =============================================================================
+
+describe('API storage bucket contract', () => {
+    it('workspace import explicitly recreates the wiped workspace bucket before image writes', () => {
+        const source = readSource('../routes/workspace-export-routes.ts')
+
+        expectSourceNotToContain(source, 'ensureObjectStore', 'workspace export/import route')
+        const createBucketIndex = source.indexOf('await natsService.createObjectStore(bucketName)')
+        const putImageIndex = source.indexOf('await natsService.putObject(bucketName, image.fileId')
+
+        expect(createBucketIndex, 'workspace import should create the bucket explicitly').toBeGreaterThan(-1)
+        expect(putImageIndex, 'workspace import should write image objects').toBeGreaterThan(-1)
+        expect(createBucketIndex, 'workspace import should create the bucket before writing images')
+            .toBeLessThan(putImageIndex)
+    })
+
+    it('workspace creation provisions both primary and media-library buckets and rolls back both on failure', () => {
+        const source = readSource('../NATS/subscriptions/workspace-subjects.ts')
+
+        expectSourceToContain(
+            source,
+            'const mediaLibraryBucketName = getMediaLibraryWorkspaceBucketName(workspace.workspaceId)',
+            'workspace create handler'
+        )
+        expectSourceToContain(
+            source,
+            'await natsService.createObjectStore(bucketName',
+            'workspace create handler'
+        )
+        expectSourceToContain(
+            source,
+            'await natsService.createObjectStore(mediaLibraryBucketName',
+            'workspace create handler'
+        )
+        expectSourceToContain(
+            source,
+            'await natsService.deleteObjectStore(bucketName).catch(() => {})',
+            'workspace create rollback'
+        )
+        expectSourceToContain(
+            source,
+            'await natsService.deleteObjectStore(mediaLibraryBucketName).catch(() => {})',
+            'workspace create rollback'
+        )
+    })
+
+    it('media-library workspace bucket naming is centralized for create and delete paths', () => {
+        const source = readSource('./media-library-storage.ts')
+
+        expectSourceToContain(
+            source,
+            'export const getMediaLibraryWorkspaceBucketName = (workspaceId: string): string =>',
+            'media-library storage'
+        )
+        expectSourceToContain(
+            source,
+            'deleteObjectStore(getMediaLibraryWorkspaceBucketName(workspaceId))',
+            'media-library workspace bucket delete'
+        )
+    })
+})

--- a/services/web-ui/src/components/WorkspaceCanvas.svelte
+++ b/services/web-ui/src/components/WorkspaceCanvas.svelte
@@ -37,10 +37,12 @@
     }
 
     let workspaceId = $derived($routerStore.data.currentRoute.routeParams.workspaceId as string)
-    let canvasState = $derived($workspaceStore.data.canvasState)
-    let isAiChatPanelOpen = $derived(Boolean(canvasState?.aiChatPanel?.isOpen ?? canvasState?.lastActiveAiChatThreadId))
-    let documents = $derived($documentsStore.data)
-    let aiChatThreads = $derived(Array.from($aiChatThreadsStore.data.values()))
+    let loadedWorkspaceId = $derived($workspaceStore.data.workspaceId)
+    let isRouteWorkspaceLoaded = $derived(Boolean(workspaceId && loadedWorkspaceId === workspaceId))
+    let canvasState = $derived(isRouteWorkspaceLoaded ? $workspaceStore.data.canvasState : null)
+    let isAiChatPanelOpen = $derived(Boolean(isRouteWorkspaceLoaded && (canvasState?.aiChatPanel?.isOpen ?? canvasState?.lastActiveAiChatThreadId)))
+    let documents = $derived(isRouteWorkspaceLoaded ? $documentsStore.data.filter((document: any) => document.workspaceId === workspaceId) : [])
+    let aiChatThreads = $derived(isRouteWorkspaceLoaded ? Array.from($aiChatThreadsStore.data.values()).filter((thread: any) => thread.workspaceId === workspaceId) : [])
 
     let viewport: Viewport = $state({ x: 0, y: 0, zoom: 1 })
     let imageSubmenuOpen = $state(false)
@@ -60,6 +62,8 @@
     }
 
     function persistCanvasState(newCanvasState: CanvasState) {
+        if (!workspaceId || loadedWorkspaceId !== workspaceId) return
+
         const stateToPersist = {
             ...newCanvasState,
             viewport,
@@ -79,6 +83,7 @@
 
         if (saveDebounceTimer) clearTimeout(saveDebounceTimer)
         const scheduledViewport = newViewport
+        const scheduledWorkspaceId = workspaceId
         saveDebounceTimer = setTimeout(() => {
             if (
                 viewport.x !== scheduledViewport.x ||
@@ -86,7 +91,7 @@
                 viewport.zoom !== scheduledViewport.zoom
             ) return
 
-            if (workspaceId && canvasState) {
+            if (scheduledWorkspaceId && loadedWorkspaceId === scheduledWorkspaceId && workspaceId === scheduledWorkspaceId && canvasState) {
                 const newCanvasState: CanvasState = {
                     ...canvasState,
                     viewport: scheduledViewport
@@ -97,7 +102,8 @@
     }
 
     async function handleCreateDocument() {
-        if (!workspaceId) {
+        const targetWorkspaceId = workspaceId
+        if (!targetWorkspaceId || loadedWorkspaceId !== targetWorkspaceId) {
             console.error('No workspaceId available!')
             return
         }
@@ -119,10 +125,12 @@
             }
 
             const doc = await servicesStore.getData('documentService').createDocument({
-                workspaceId,
+                workspaceId: targetWorkspaceId,
                 title: 'New Document',
                 content: initialContent
             })
+
+            if (workspaceId !== targetWorkspaceId || loadedWorkspaceId !== targetWorkspaceId) return
 
             if (doc) {
                 const dimensions = { ...DEFAULT_DOCUMENT_NODE_DIMENSIONS }
@@ -169,13 +177,14 @@
 
     async function handleImageUrlInsert() {
         const url = imageUrlValue.trim()
-        if (!url || !workspaceId) return
+        const targetWorkspaceId = workspaceId
+        if (!url || !targetWorkspaceId || loadedWorkspaceId !== targetWorkspaceId) return
 
         try {
             const token = await AuthService.getTokenSilently()
             if (!token) return
 
-            const response = await fetch(`${API_BASE_URL}/api/images/${workspaceId}/import-url`, {
+            const response = await fetch(`${API_BASE_URL}/api/images/${targetWorkspaceId}/import-url`, {
                 method: 'POST',
                 headers: {
                     'Authorization': `Bearer ${token}`,
@@ -187,8 +196,10 @@
 
             const data = await response.json()
             const imageUrl = `${API_BASE_URL}${data.url}?token=${encodeURIComponent(token)}`
+            if (workspaceId !== targetWorkspaceId || loadedWorkspaceId !== targetWorkspaceId) return
+
             closeImageSubmenu()
-            addImageToCanvas({ fileId: data.fileId, src: imageUrl })
+            addImageToCanvas({ fileId: data.fileId, src: imageUrl, targetWorkspaceId })
         } catch (error) {
             console.error('Image URL import failed:', error)
         }
@@ -197,7 +208,8 @@
     async function uploadAndAddImage(file: File) {
         if (!file.type.startsWith('image/')) return
         if (file.size > MAX_IMAGE_FILE_SIZE) return
-        if (!workspaceId) return
+        const targetWorkspaceId = workspaceId
+        if (!targetWorkspaceId || loadedWorkspaceId !== targetWorkspaceId) return
 
         try {
             const token = await AuthService.getTokenSilently()
@@ -206,7 +218,7 @@
             const formData = new FormData()
             formData.append('file', file)
 
-            const response = await fetch(`${API_BASE_URL}/api/images/${workspaceId}`, {
+            const response = await fetch(`${API_BASE_URL}/api/images/${targetWorkspaceId}`, {
                 method: 'POST',
                 headers: { 'Authorization': `Bearer ${token}` },
                 body: formData
@@ -216,18 +228,21 @@
 
             const data = await response.json()
             const imageUrl = `${API_BASE_URL}${data.url}?token=${encodeURIComponent(token)}`
+            if (workspaceId !== targetWorkspaceId || loadedWorkspaceId !== targetWorkspaceId) return
 
-            addImageToCanvas({ fileId: data.fileId, src: imageUrl })
+            addImageToCanvas({ fileId: data.fileId, src: imageUrl, targetWorkspaceId })
         } catch (error) {
             console.error('Image upload failed:', error)
         }
     }
 
-    function addImageToCanvas({ fileId, src }: { fileId: string, src: string }) {
-        if (!workspaceId) return
+    function addImageToCanvas({ fileId, src, targetWorkspaceId }: { fileId: string, src: string, targetWorkspaceId: string }) {
+        if (!targetWorkspaceId || workspaceId !== targetWorkspaceId || loadedWorkspaceId !== targetWorkspaceId) return
 
         const img = new Image()
         img.onload = () => {
+            if (workspaceId !== targetWorkspaceId || loadedWorkspaceId !== targetWorkspaceId) return
+
             const aspectRatio = img.naturalWidth > 0 && img.naturalHeight > 0
                 ? img.naturalWidth / img.naturalHeight
                 : 1
@@ -237,7 +252,7 @@
                 nodeId: `node-${fileId}`,
                 type: 'image',
                 fileId,
-                workspaceId,
+                workspaceId: targetWorkspaceId,
                 src,
                 aspectRatio,
                 dimensions,
@@ -247,13 +262,15 @@
         }
 
         img.onerror = () => {
+            if (workspaceId !== targetWorkspaceId || loadedWorkspaceId !== targetWorkspaceId) return
+
             console.error('Failed to load image for dimension calculation')
             const dimensions = getImageInsertionDimensions(1)
             const imageNode: Omit<ImageCanvasNode, 'position'> = {
                 nodeId: `node-${fileId}`,
                 type: 'image',
                 fileId,
-                workspaceId,
+                workspaceId: targetWorkspaceId,
                 src,
                 aspectRatio: 1,
                 dimensions,
@@ -278,7 +295,7 @@
             onViewportChange: handleViewportChange,
             onCanvasStateChange: persistCanvasState,
             onDocumentContentChange: ({ documentId, title, prevRevision, content }) => {
-                if (!workspaceId) return
+                if (!workspaceId || loadedWorkspaceId !== workspaceId) return
                 documentService.updateDocument({
                     workspaceId,
                     documentId,
@@ -288,8 +305,8 @@
                 })
             },
             onDocumentTitleChange: ({ documentId, title }) => {
+                if (!workspaceId || loadedWorkspaceId !== workspaceId) return
                 documentsStore.updateDocument(documentId, { title })
-                if (!workspaceId) return
                 documentService.updateDocument({
                     workspaceId,
                     documentId,

--- a/services/web-ui/src/infographics/workspace/README.md
+++ b/services/web-ui/src/infographics/workspace/README.md
@@ -139,7 +139,7 @@ flowchart TB
         TN[AI Chat Thread Nodes]
         PM[ProseMirror Editors]
         AIS[AiInteractionService]
-        IL[Canvas Image Lifecycle]
+        IL[Canvas Media Node Lifecycle]
     end
 
     subgraph Services["Services Layer"]
@@ -268,9 +268,13 @@ When an AI-generated image is being created, the canvas provides visual feedback
 5. **Prompt handoff** — `IMAGE_GENERATION_TRACE` / `VIDEO_GENERATION_TRACE` marks the handoff from reasoning model to media model and clears the reference outlines. Later image partials replace only the generated node.
 6. **Completion** — `onImageCompleteToCanvas` clears the tracker only after the final image arrives, which removes the generated-node PIXI progress outline. `IMAGE_ERROR` removes the matching partial node immediately, keyed by `mediaRunId` when present.
 
-### Image Lifecycle
+### Media Node Lifecycle
 
-When an image node is removed from the canvas, the `canvasImageLifecycle` tracker detects the change and triggers deletion from NATS Object Store via the `WORKSPACE_SUBJECTS.IMAGE_SUBJECTS.DELETE_IMAGE` NATS subject.
+When a tracked media node is removed from the canvas, the `canvasMediaNodeLifecycle` tracker detects the change and triggers the configured deletion path. Image nodes route through `WORKSPACE_SUBJECTS.IMAGE_SUBJECTS.DELETE_IMAGE`; video nodes route through `WORKSPACE_SUBJECTS.VIDEO_SUBJECTS.DELETE_VIDEO` and best-effort poster cleanup.
+
+Workspace navigation and first non-empty workspace load reinitialize the media lifecycle tracker from the opened workspace's canvas state before local commits can run. The tracker must never compare media from one workspace against another workspace's node set, because a cross-workspace diff would turn a navigation render into destructive storage deletion.
+
+Generated media stream callbacks also verify that the event's thread still belongs to the currently rendered workspace before they mutate canvas state. Late image/video events from a previously opened workspace must be ignored instead of inserted into the new workspace.
 
 ### Drag and Resize
 
@@ -461,7 +465,7 @@ Menu items are defined in `canvasBubbleMenuItems.ts`. The core `BubbleMenu` clas
 | `rendering/mediaNodeRegistry.ts` | Dispatches non-image media nodes to specialized handlers. Image nodes are handled directly by `pixiMediaLayer`; video nodes route to `videoNodeHandler.ts` |
 | `rendering/videoNodeHandler.ts` | Video renderer that owns PIXI poster/placeholder sprites and the authenticated `HTMLVideoElement` moved into DOM video chrome |
 | `workspace-canvas.scss` | All styles for canvas, DOM interaction nodes, handles, edges, editors, and media chrome |
-| `canvasImageLifecycle.ts` | Tracks image nodes and deletes orphaned images from storage |
+| `canvasMediaNodeLifecycle.ts` | Tracks configured media-node types and deletes orphaned workspace media from storage |
 | `canvasBubbleMenuItems.ts` | Bubble menu item definitions for canvas elements (image and edge actions) |
 | `imagePositioning.ts` | Computes viewport-normalized insertion dimensions and generated image placement positions next to source threads |
 | `nodeLayering.ts` | Z-index management for bringing nodes to front |

--- a/services/web-ui/src/infographics/workspace/WorkspaceCanvas.ts
+++ b/services/web-ui/src/infographics/workspace/WorkspaceCanvas.ts
@@ -58,8 +58,8 @@ import {
 import AiInteractionService from '$src/services/ai-interaction-service.ts'
 import { imageResizeCornerIcon, aiChatThreadRailBoundaryCircle, infoCircleFilledIcon, trashBinIcon, aiChatPanelToggleHistoryIcon, xCircleIcon, branchMidIcon, branchForkfIcon } from '$src/svgIcons/index.ts'
 import { type Document } from '$src/stores/documentStore.ts'
-import { createCanvasImageLifecycleTracker } from '$src/infographics/workspace/canvasImageLifecycle.ts'
-import { createCanvasVideoLifecycleTracker } from '$src/infographics/workspace/canvasVideoLifecycle.ts'
+import { createCanvasMediaNodeLifecycleTracker } from '$src/infographics/workspace/canvasMediaNodeLifecycle.ts'
+import { shouldAcceptGeneratedMediaEvent as shouldAcceptGeneratedMediaEventForState } from '$src/infographics/workspace/generatedMediaEventWorkspaceGuard.ts'
 import { createVideoNodeHandler, type VideoNodeHandlerControl } from '$src/infographics/workspace/rendering/videoNodeHandler.ts'
 import { createLoadingPlaceholder, createErrorPlaceholder } from '$src/components/proseMirror/plugins/primitives/loadingPlaceholder/index.ts'
 import { WorkspaceConnectionManager } from '$src/infographics/workspace/WorkspaceConnectionManager.ts'
@@ -427,15 +427,8 @@ export function createWorkspaceCanvas(options: WorkspaceCanvasOptions) {
     const loadedNodeIds: Set<string> = new Set()
     let paneRect: DOMRect | null = null
 
-    // Image lifecycle tracker - handles deletion of orphaned images
-    const canvasImageLifecycle = createCanvasImageLifecycleTracker()
-    canvasImageLifecycle.initializeFromCanvasState(currentCanvasState)
-
-    // Video lifecycle tracker (sibling of canvasImageLifecycle) — deletes the
-    // MP4 + poster from the workspace Object Store when a VideoCanvasNode is
-    // removed from canvas state.
-    const canvasVideoLifecycle = createCanvasVideoLifecycleTracker()
-    canvasVideoLifecycle.initializeFromCanvasState(currentCanvasState)
+    const canvasMediaNodeLifecycle = createCanvasMediaNodeLifecycleTracker()
+    canvasMediaNodeLifecycle.initializeFromCanvasState(currentCanvasState)
 
     // Pending video-generation tracker: mirrors partialImageTracker. VEO has no
     // partial frames, so the sequence is VIDEO_PENDING (create placeholder +
@@ -5636,6 +5629,16 @@ export function createWorkspaceCanvas(options: WorkspaceCanvasOptions) {
         onCanvasStateChange?.(nextState)
     }
 
+    function shouldAcceptGeneratedMediaEvent(threadId: string, eventWorkspaceId?: string): boolean {
+        return shouldAcceptGeneratedMediaEventForState({
+            threadId,
+            eventWorkspaceId,
+            workspaceId,
+            currentCanvasState,
+            currentAiChatThreads,
+        })
+    }
+
     setAiGeneratedImageCallbacks({
         onAddToCanvas: async (data) => {
             const { imageUrl, fileId, responseId, revisedPrompt, aiModel } = data
@@ -5701,6 +5704,8 @@ export function createWorkspaceCanvas(options: WorkspaceCanvasOptions) {
         },
 
         onImageBranchResolvedToCanvas: ({ threadId, resolution, generationRun }) => {
+            if (!shouldAcceptGeneratedMediaEvent(threadId)) return
+
             const placement = getPendingGeneratedMediaPlacement(threadId, generationRun)
             if (!placement) return
 
@@ -5728,25 +5733,35 @@ export function createWorkspaceCanvas(options: WorkspaceCanvasOptions) {
         },
 
         onMediaLineagePlannedToCanvas: ({ threadId, lineagePlan, generationRun }) => {
+            if (!shouldAcceptGeneratedMediaEvent(threadId)) return
+
             applyMediaBranchLineagePlan(threadId, lineagePlan, generationRun)
         },
 
         onWorkspaceContextResolvedToCanvas: ({ threadId, resolution, generationRun }) => {
+            if (!shouldAcceptGeneratedMediaEvent(threadId)) return
+
             handleWorkspaceContextResolution(threadId, resolution, generationRun)
         },
 
         onImageBranchResolutionErrorToCanvas: ({ threadId, generationRun }) => {
+            if (!shouldAcceptGeneratedMediaEvent(threadId)) return
+
             const placementKey = getGeneratedMediaPlacementKey(threadId, generationRun)
             pendingGeneratedImagePlacements.delete(placementKey)
             clearGeneratingReferenceNodeIds(placementKey)
         },
 
         onImageGenerationTraceToCanvas: ({ threadId, generationRun }) => {
+            if (!shouldAcceptGeneratedMediaEvent(threadId)) return
+
             registerGeneratedMediaRun(threadId, generationRun)
             clearGeneratingReferencesAfterPromptHandoff(threadId, generationRun)
         },
 
         onImageErrorToCanvas: ({ threadId, generationRun }) => {
+            if (!shouldAcceptGeneratedMediaEvent(threadId)) return
+
             const runKey = getGeneratedMediaRunKey(threadId, generationRun)
             const existing = partialImageTracker.get(runKey)
             if (!existing || !currentCanvasState) {
@@ -5778,6 +5793,8 @@ export function createWorkspaceCanvas(options: WorkspaceCanvasOptions) {
 
         onImagePartialToCanvas: (data) => {
             const { threadId, imageUrl, fileId, workspaceId: imgWorkspaceId, generationRun } = data
+            if (!shouldAcceptGeneratedMediaEvent(threadId, imgWorkspaceId)) return
+
             const runKey = getGeneratedMediaRunKey(threadId, generationRun)
             const placementKey = getGeneratedMediaPlacementKey(threadId, generationRun)
             registerGeneratedMediaRun(threadId, generationRun)
@@ -5879,6 +5896,8 @@ export function createWorkspaceCanvas(options: WorkspaceCanvasOptions) {
 
         onImageCompleteToCanvas: (data) => {
             const { threadId, imageUrl, fileId, workspaceId: imgWorkspaceId, responseId, revisedPrompt, aiModel, imageModelProvider, imageModelId, responseMessageId, generationRun } = data
+            if (!shouldAcceptGeneratedMediaEvent(threadId, imgWorkspaceId)) return
+
             const runKey = getGeneratedMediaRunKey(threadId, generationRun)
             registerGeneratedMediaRun(threadId, generationRun)
             const completionMediaModelId = generationRun?.mediaModelId ?? buildAiModelId(imageModelProvider, imageModelId ?? '')
@@ -6148,6 +6167,8 @@ export function createWorkspaceCanvas(options: WorkspaceCanvasOptions) {
     setAiGeneratedVideoCallbacks({
         onVideoPendingToCanvas: (data) => {
             const { threadId, generationRun } = data
+            if (!shouldAcceptGeneratedMediaEvent(threadId)) return
+
             const runKey = getGeneratedMediaRunKey(threadId, generationRun)
             const placementKey = getGeneratedMediaPlacementKey(threadId, generationRun)
             registerGeneratedMediaRun(threadId, generationRun)
@@ -6227,7 +6248,9 @@ export function createWorkspaceCanvas(options: WorkspaceCanvasOptions) {
             appendVideoNodeToDOM(placedVideoNode)
         },
 
-        onVideoGeneratingToCanvas: (_data) => {
+        onVideoGeneratingToCanvas: ({ threadId }) => {
+            if (!shouldAcceptGeneratedMediaEvent(threadId)) return
+
             // VEO keepalive heartbeat. The PIXI traveling outline is already
             // running on the placeholder via pixiMediaLayer's generating-image
             // tracker, so no canvas state mutation is required here. Phase 6
@@ -6235,6 +6258,8 @@ export function createWorkspaceCanvas(options: WorkspaceCanvasOptions) {
         },
 
         onVideoGenerationTraceToCanvas: ({ threadId, generationRun }) => {
+            if (!shouldAcceptGeneratedMediaEvent(threadId)) return
+
             registerGeneratedMediaRun(threadId, generationRun)
             clearGeneratingReferencesAfterPromptHandoff(threadId, generationRun)
         },
@@ -6258,6 +6283,8 @@ export function createWorkspaceCanvas(options: WorkspaceCanvasOptions) {
                 responseMessageId,
                 generationRun,
             } = data
+            if (!shouldAcceptGeneratedMediaEvent(threadId, videoWorkspaceId)) return
+
             const runKey = getGeneratedMediaRunKey(threadId, generationRun)
             registerGeneratedMediaRun(threadId, generationRun)
 
@@ -6582,12 +6609,7 @@ export function createWorkspaceCanvas(options: WorkspaceCanvasOptions) {
     }
 
     function commitCanvasState(nextState: CanvasState) {
-        // Track image changes and delete orphaned images from storage
-        canvasImageLifecycle.trackCanvasState(nextState)
-        // Same lifecycle treatment for VideoCanvasNode entries: when a node
-        // leaves canvasState, the tracker fires the workspace.video.delete
-        // NATS subject to remove both the MP4 and its companion poster image.
-        canvasVideoLifecycle.trackCanvasState(nextState)
+        canvasMediaNodeLifecycle.trackCanvasState(nextState)
         currentCanvasState = nextState
         pendingLocalCanvasVisualCommit = createPendingCanvasVisualCommit(nextState)
         onCanvasStateChange?.(nextState)
@@ -7960,11 +7982,16 @@ export function createWorkspaceCanvas(options: WorkspaceCanvasOptions) {
                 workspaceChanged,
             })
 
+            const shouldResetMediaLifecycle = workspaceChanged || (!currentCanvasState && Boolean(effectiveCanvasState))
+
             currentCanvasState = shouldPreserveLiveViewport && effectiveCanvasState
                 ? { ...effectiveCanvasState, viewport: liveViewport }
                 : effectiveCanvasState
             currentDocuments = newDocuments
             currentAiChatThreads = newAiChatThreads
+            if (shouldResetMediaLifecycle) {
+                canvasMediaNodeLifecycle.initializeFromCanvasState(currentCanvasState)
+            }
             syncActiveAiChatPanelFromState()
 
             // 1. Rebuild DOM first so image nodes exist when PIXI syncs DOM ownership.
@@ -8093,8 +8120,7 @@ export function createWorkspaceCanvas(options: WorkspaceCanvasOptions) {
                 promptInputController.unregisterThreadEditor(threadId)
             }
             threadEditors.clear()
-            canvasImageLifecycle.destroy()
-            canvasVideoLifecycle.destroy()
+            canvasMediaNodeLifecycle.destroy()
             videoNodeHandler?.destroy()
             videoNodeHandler = null
             videoGenerationTracker.clear()

--- a/services/web-ui/src/infographics/workspace/canvasImageLifecycle.ts
+++ b/services/web-ui/src/infographics/workspace/canvasImageLifecycle.ts
@@ -1,63 +1,8 @@
-import type { CanvasState, ImageCanvasNode } from '@lixpi/constants'
-import { deleteImage } from '$src/utils/imageUtils.ts'
-
-type TrackedCanvasImage = {
-    fileId: string
-    workspaceId: string
-}
+import {
+    createCanvasMediaNodeLifecycleTracker,
+    imageCanvasMediaNodeLifecycleConfig,
+} from '$src/infographics/workspace/canvasMediaNodeLifecycle.ts'
 
 export function createCanvasImageLifecycleTracker() {
-    let previousImages = new Map<string, TrackedCanvasImage>()
-
-    function extractImagesFromCanvasState(canvasState: CanvasState | null): Map<string, TrackedCanvasImage> {
-        const images = new Map<string, TrackedCanvasImage>()
-
-        if (!canvasState) return images
-
-        for (const node of canvasState.nodes) {
-            if (node.type === 'image') {
-                const imageNode = node as ImageCanvasNode
-                if (!imageNode.fileId) continue // skip placeholder nodes that have no uploaded file yet
-                images.set(imageNode.fileId, {
-                    fileId: imageNode.fileId,
-                    workspaceId: imageNode.workspaceId,
-                })
-            }
-        }
-
-        return images
-    }
-
-    function trackCanvasState(canvasState: CanvasState | null): void {
-        const currentImages = extractImagesFromCanvasState(canvasState)
-
-        // Find images that were removed (present in previous but not in current)
-        for (const [fileId, trackedImage] of previousImages) {
-            if (!currentImages.has(fileId)) {
-                // Image was removed from canvas, schedule deletion
-                // Use setTimeout to avoid blocking the current operation
-                setTimeout(() => {
-                    deleteImage(fileId, trackedImage.workspaceId)
-                }, 0)
-            }
-        }
-
-        previousImages = currentImages
-    }
-
-    function initializeFromCanvasState(canvasState: CanvasState | null): void {
-        // Initialize tracking without triggering deletions
-        // Used when first loading a workspace
-        previousImages = extractImagesFromCanvasState(canvasState)
-    }
-
-    function destroy(): void {
-        previousImages.clear()
-    }
-
-    return {
-        trackCanvasState,
-        initializeFromCanvasState,
-        destroy,
-    }
+    return createCanvasMediaNodeLifecycleTracker([imageCanvasMediaNodeLifecycleConfig])
 }

--- a/services/web-ui/src/infographics/workspace/canvasMediaNodeLifecycle.test.ts
+++ b/services/web-ui/src/infographics/workspace/canvasMediaNodeLifecycle.test.ts
@@ -1,0 +1,134 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { CanvasState } from '@lixpi/constants'
+import {
+    createCanvasMediaNodeLifecycleTracker,
+    type CanvasMediaNodeLifecycleConfig,
+} from './canvasMediaNodeLifecycle.ts'
+
+const mocks = vi.hoisted(() => ({
+    deleteImage: vi.fn(),
+    deleteVideo: vi.fn(),
+}))
+
+vi.mock('$src/utils/imageUtils.ts', () => ({
+    deleteImage: mocks.deleteImage,
+}))
+
+vi.mock('$src/utils/videoUtils.ts', () => ({
+    deleteVideo: mocks.deleteVideo,
+}))
+
+function makeCanvasState(nodes: any[] = []): CanvasState {
+    return {
+        viewport: { x: 0, y: 0, zoom: 1 },
+        nodes,
+        edges: [],
+    } as CanvasState
+}
+
+function makeImageNode(fileId: string, workspaceId = 'workspace-1'): any {
+    return {
+        nodeId: `node-${fileId}`,
+        type: 'image',
+        fileId,
+        workspaceId,
+        src: `/api/images/${workspaceId}/${fileId}`,
+        aspectRatio: 1,
+        position: { x: 0, y: 0 },
+        dimensions: { width: 100, height: 100 },
+    }
+}
+
+function makeVideoNode(fileId: string, posterFileId = 'poster-1', workspaceId = 'workspace-1'): any {
+    return {
+        nodeId: `node-${fileId}`,
+        type: 'video',
+        fileId,
+        posterFileId,
+        workspaceId,
+        src: `/api/videos/${workspaceId}/${fileId}`,
+        posterSrc: `/api/images/${workspaceId}/${posterFileId}`,
+        aspectRatio: 1,
+        durationSeconds: 4,
+        hasAudio: false,
+        position: { x: 0, y: 0 },
+        dimensions: { width: 100, height: 100 },
+    }
+}
+
+// =============================================================================
+// CANVAS MEDIA NODE LIFECYCLE
+// =============================================================================
+
+describe('canvasMediaNodeLifecycle', () => {
+    beforeEach(() => {
+        vi.useFakeTimers()
+        mocks.deleteImage.mockReset()
+        mocks.deleteVideo.mockReset()
+    })
+
+    afterEach(() => {
+        vi.useRealTimers()
+    })
+
+    it('deletes removed image and video nodes through their configured deletion paths', async () => {
+        const tracker = createCanvasMediaNodeLifecycleTracker()
+        tracker.initializeFromCanvasState(makeCanvasState([
+            makeImageNode('image-1'),
+            makeVideoNode('video-1', 'poster-1'),
+        ]))
+
+        tracker.trackCanvasState(makeCanvasState([]))
+        await vi.runAllTimersAsync()
+
+        expect(mocks.deleteImage).toHaveBeenCalledWith('image-1', 'workspace-1')
+        expect(mocks.deleteVideo).toHaveBeenCalledWith('video-1', 'workspace-1', 'poster-1')
+    })
+
+    it('does not delete nodes during initial snapshot or when the tracked media still exists', async () => {
+        const tracker = createCanvasMediaNodeLifecycleTracker()
+        tracker.initializeFromCanvasState(makeCanvasState([makeImageNode('image-1')]))
+
+        tracker.trackCanvasState(makeCanvasState([makeImageNode('image-1')]))
+        await vi.runAllTimersAsync()
+
+        expect(mocks.deleteImage).not.toHaveBeenCalled()
+        expect(mocks.deleteVideo).not.toHaveBeenCalled()
+    })
+
+    it('supports adding future media node types by config instead of duplicating lifecycle code', async () => {
+        const deleteAudio = vi.fn()
+        const audioConfig: CanvasMediaNodeLifecycleConfig = {
+            nodeType: 'audio' as any,
+            trackNode: (node) => {
+                const audioNode = node as any
+                if (audioNode.type !== 'audio') return null
+                if (!audioNode.fileId) return null
+
+                return {
+                    key: `audio:${audioNode.fileId}`,
+                    fileId: audioNode.fileId,
+                    workspaceId: audioNode.workspaceId,
+                    nodeType: 'audio' as any,
+                }
+            },
+            deleteTrackedNode: deleteAudio,
+        }
+        const tracker = createCanvasMediaNodeLifecycleTracker([audioConfig])
+        tracker.initializeFromCanvasState(makeCanvasState([{
+            type: 'audio',
+            fileId: 'audio-1',
+            workspaceId: 'workspace-1',
+        }]))
+
+        tracker.trackCanvasState(makeCanvasState([]))
+        await vi.runAllTimersAsync()
+
+        expect(deleteAudio).toHaveBeenCalledWith({
+            key: 'audio:audio-1',
+            fileId: 'audio-1',
+            workspaceId: 'workspace-1',
+            nodeType: 'audio',
+        })
+    })
+})

--- a/services/web-ui/src/infographics/workspace/canvasMediaNodeLifecycle.ts
+++ b/services/web-ui/src/infographics/workspace/canvasMediaNodeLifecycle.ts
@@ -1,0 +1,135 @@
+import type {
+    CanvasNode,
+    CanvasNodeType,
+    CanvasState,
+    ImageCanvasNode,
+    VideoCanvasNode,
+} from '@lixpi/constants'
+import { deleteImage } from '$src/utils/imageUtils.ts'
+import { deleteVideo } from '$src/utils/videoUtils.ts'
+
+export type TrackedCanvasMediaNode = {
+    key: string
+    fileId: string
+    workspaceId: string
+    nodeType: CanvasNodeType
+    posterFileId?: string
+}
+
+export type CanvasMediaNodeLifecycleConfig = {
+    nodeType: CanvasNodeType
+    trackNode: (node: CanvasNode) => TrackedCanvasMediaNode | null
+    deleteTrackedNode: (trackedNode: TrackedCanvasMediaNode) => void | Promise<void>
+}
+
+export type CanvasMediaNodeLifecycleTrackerInstance = {
+    trackCanvasState: (canvasState: CanvasState | null) => void
+    initializeFromCanvasState: (canvasState: CanvasState | null) => void
+    destroy: () => void
+}
+
+export const imageCanvasMediaNodeLifecycleConfig: CanvasMediaNodeLifecycleConfig = {
+    nodeType: 'image',
+    trackNode: (node) => {
+        if (node.type !== 'image') return null
+
+        const imageNode = node as ImageCanvasNode
+        if (!imageNode.fileId) return null
+
+        return {
+            key: `image:${imageNode.fileId}`,
+            fileId: imageNode.fileId,
+            workspaceId: imageNode.workspaceId,
+            nodeType: 'image',
+        }
+    },
+    deleteTrackedNode: (trackedNode) => {
+        return deleteImage(trackedNode.fileId, trackedNode.workspaceId)
+    },
+}
+
+export const videoCanvasMediaNodeLifecycleConfig: CanvasMediaNodeLifecycleConfig = {
+    nodeType: 'video',
+    trackNode: (node) => {
+        if (node.type !== 'video') return null
+
+        const videoNode = node as VideoCanvasNode
+        if (!videoNode.fileId) return null
+
+        return {
+            key: `video:${videoNode.fileId}`,
+            fileId: videoNode.fileId,
+            posterFileId: videoNode.posterFileId || undefined,
+            workspaceId: videoNode.workspaceId,
+            nodeType: 'video',
+        }
+    },
+    deleteTrackedNode: (trackedNode) => {
+        return deleteVideo(trackedNode.fileId, trackedNode.workspaceId, trackedNode.posterFileId)
+    },
+}
+
+class CanvasMediaNodeLifecycleTracker implements CanvasMediaNodeLifecycleTrackerInstance {
+    private previousMediaNodes = new Map<string, TrackedCanvasMediaNode>()
+    private readonly configsByNodeType: Map<CanvasNodeType, CanvasMediaNodeLifecycleConfig>
+
+    constructor(configs: CanvasMediaNodeLifecycleConfig[]) {
+        this.configsByNodeType = new Map()
+        for (const config of configs) {
+            this.configsByNodeType.set(config.nodeType, config)
+        }
+    }
+
+    trackCanvasState(canvasState: CanvasState | null): void {
+        const currentMediaNodes = this.extractMediaNodesFromCanvasState(canvasState)
+
+        for (const [key, trackedNode] of this.previousMediaNodes) {
+            if (currentMediaNodes.has(key)) continue
+            this.scheduleDeletion(trackedNode)
+        }
+
+        this.previousMediaNodes = currentMediaNodes
+    }
+
+    initializeFromCanvasState(canvasState: CanvasState | null): void {
+        this.previousMediaNodes = this.extractMediaNodesFromCanvasState(canvasState)
+    }
+
+    destroy(): void {
+        this.previousMediaNodes.clear()
+    }
+
+    private extractMediaNodesFromCanvasState(canvasState: CanvasState | null): Map<string, TrackedCanvasMediaNode> {
+        const mediaNodes = new Map<string, TrackedCanvasMediaNode>()
+
+        if (!canvasState) return mediaNodes
+
+        for (const node of canvasState.nodes) {
+            const config = this.configsByNodeType.get(node.type)
+            const trackedNode = config?.trackNode(node)
+            if (!trackedNode) continue
+
+            mediaNodes.set(trackedNode.key, trackedNode)
+        }
+
+        return mediaNodes
+    }
+
+    private scheduleDeletion(trackedNode: TrackedCanvasMediaNode): void {
+        const config = this.configsByNodeType.get(trackedNode.nodeType)
+        if (!config) return
+
+        setTimeout(() => {
+            void config.deleteTrackedNode(trackedNode)
+        }, 0)
+    }
+}
+
+export function createCanvasMediaNodeLifecycleTracker(
+    configs: CanvasMediaNodeLifecycleConfig[] = [
+        imageCanvasMediaNodeLifecycleConfig,
+        videoCanvasMediaNodeLifecycleConfig,
+    ]
+): CanvasMediaNodeLifecycleTrackerInstance {
+    return new CanvasMediaNodeLifecycleTracker(configs)
+}

--- a/services/web-ui/src/infographics/workspace/canvasVideoLifecycle.ts
+++ b/services/web-ui/src/infographics/workspace/canvasVideoLifecycle.ts
@@ -1,67 +1,8 @@
-import type { CanvasState, VideoCanvasNode } from '@lixpi/constants'
-import { deleteVideo } from '$src/utils/videoUtils.ts'
-
-// Sibling of canvasImageLifecycle.ts. Watches VideoCanvasNode entries across
-// canvas state commits and, when a video node disappears, fires the workspace
-// video delete (MP4 + poster) so orphan media doesn't accumulate in the Object
-// Store. Initialization (initializeFromCanvasState) snapshots the current set
-// without scheduling any deletions, matching how the image tracker behaves on
-// first workspace load.
-
-type TrackedCanvasVideo = {
-    fileId: string
-    posterFileId?: string
-    workspaceId: string
-}
+import {
+    createCanvasMediaNodeLifecycleTracker,
+    videoCanvasMediaNodeLifecycleConfig,
+} from '$src/infographics/workspace/canvasMediaNodeLifecycle.ts'
 
 export function createCanvasVideoLifecycleTracker() {
-    let previousVideos = new Map<string, TrackedCanvasVideo>()
-
-    function extractVideosFromCanvasState(canvasState: CanvasState | null): Map<string, TrackedCanvasVideo> {
-        const videos = new Map<string, TrackedCanvasVideo>()
-
-        if (!canvasState) return videos
-
-        for (const node of canvasState.nodes) {
-            if (node.type === 'video') {
-                const videoNode = node as VideoCanvasNode
-                if (!videoNode.fileId) continue // skip placeholder nodes that have no stored MP4 yet
-                videos.set(videoNode.fileId, {
-                    fileId: videoNode.fileId,
-                    posterFileId: videoNode.posterFileId || undefined,
-                    workspaceId: videoNode.workspaceId,
-                })
-            }
-        }
-
-        return videos
-    }
-
-    function trackCanvasState(canvasState: CanvasState | null): void {
-        const currentVideos = extractVideosFromCanvasState(canvasState)
-
-        for (const [fileId, tracked] of previousVideos) {
-            if (!currentVideos.has(fileId)) {
-                setTimeout(() => {
-                    deleteVideo(fileId, tracked.workspaceId, tracked.posterFileId)
-                }, 0)
-            }
-        }
-
-        previousVideos = currentVideos
-    }
-
-    function initializeFromCanvasState(canvasState: CanvasState | null): void {
-        previousVideos = extractVideosFromCanvasState(canvasState)
-    }
-
-    function destroy(): void {
-        previousVideos.clear()
-    }
-
-    return {
-        trackCanvasState,
-        initializeFromCanvasState,
-        destroy,
-    }
+    return createCanvasMediaNodeLifecycleTracker([videoCanvasMediaNodeLifecycleConfig])
 }

--- a/services/web-ui/src/infographics/workspace/generatedMediaEventWorkspaceGuard.test.ts
+++ b/services/web-ui/src/infographics/workspace/generatedMediaEventWorkspaceGuard.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from 'vitest'
+import type { AiChatThread, CanvasState } from '@lixpi/constants'
+import {
+    hasCurrentWorkspaceThread,
+    shouldAcceptGeneratedMediaEvent,
+} from './generatedMediaEventWorkspaceGuard.ts'
+
+function makeCanvasState(overrides: Partial<CanvasState> = {}): CanvasState {
+    return {
+        viewport: { x: 0, y: 0, zoom: 1 },
+        nodes: [],
+        edges: [],
+        ...overrides,
+    } as CanvasState
+}
+
+function makeThread(threadId: string): Pick<AiChatThread, 'threadId'> {
+    return { threadId }
+}
+
+// =============================================================================
+// GENERATED MEDIA EVENT WORKSPACE GUARD
+// =============================================================================
+
+describe('generated media event workspace guard', () => {
+    it('accepts a thread loaded in the current workspace thread list', () => {
+        expect(hasCurrentWorkspaceThread({
+            threadId: 'thread-current',
+            currentCanvasState: makeCanvasState(),
+            currentAiChatThreads: [makeThread('thread-current')],
+            workspaceId: 'workspace-1',
+        })).toBe(true)
+    })
+
+    it('accepts a thread opened in the persisted AI chat panel tabs', () => {
+        expect(hasCurrentWorkspaceThread({
+            threadId: 'thread-tab',
+            currentCanvasState: makeCanvasState({
+                aiChatPanel: {
+                    isOpen: true,
+                    isSessionHistoryOpen: false,
+                    tabs: [{ tabId: 'tab-1', type: 'thread', refId: 'thread-tab', title: 'Thread' }],
+                    contextChips: [],
+                },
+            }),
+            currentAiChatThreads: [],
+            workspaceId: 'workspace-1',
+        })).toBe(true)
+    })
+
+    it('accepts legacy canvas thread nodes', () => {
+        expect(hasCurrentWorkspaceThread({
+            threadId: 'legacy-thread',
+            currentCanvasState: makeCanvasState({
+                nodes: [{
+                    nodeId: 'node-legacy-thread',
+                    type: 'aiChatThread',
+                    referenceId: 'legacy-thread',
+                    position: { x: 0, y: 0 },
+                    dimensions: { width: 300, height: 200 },
+                } as any],
+            }),
+            currentAiChatThreads: [],
+            workspaceId: 'workspace-1',
+        })).toBe(true)
+    })
+
+    it('rejects an event from another workspace even when the thread id is known locally', () => {
+        expect(shouldAcceptGeneratedMediaEvent({
+            threadId: 'thread-current',
+            eventWorkspaceId: 'workspace-2',
+            workspaceId: 'workspace-1',
+            currentCanvasState: makeCanvasState(),
+            currentAiChatThreads: [makeThread('thread-current')],
+        })).toBe(false)
+    })
+
+    it('rejects a matching workspace event when the thread is not part of the current workspace', () => {
+        expect(shouldAcceptGeneratedMediaEvent({
+            threadId: 'thread-stale',
+            eventWorkspaceId: 'workspace-1',
+            workspaceId: 'workspace-1',
+            currentCanvasState: makeCanvasState(),
+            currentAiChatThreads: [makeThread('thread-current')],
+        })).toBe(false)
+    })
+
+    it('accepts events without an explicit workspace id only for current workspace threads', () => {
+        expect(shouldAcceptGeneratedMediaEvent({
+            threadId: 'thread-current',
+            workspaceId: 'workspace-1',
+            currentCanvasState: makeCanvasState(),
+            currentAiChatThreads: [makeThread('thread-current')],
+        })).toBe(true)
+    })
+})

--- a/services/web-ui/src/infographics/workspace/generatedMediaEventWorkspaceGuard.ts
+++ b/services/web-ui/src/infographics/workspace/generatedMediaEventWorkspaceGuard.ts
@@ -1,0 +1,42 @@
+import type {
+    AiChatThread,
+    AiChatThreadCanvasNode,
+    CanvasNode,
+    CanvasState,
+} from '@lixpi/constants'
+
+export type GeneratedMediaEventWorkspaceGuardState = {
+    workspaceId: string
+    currentCanvasState: Pick<CanvasState, 'nodes' | 'aiChatPanel'> | null
+    currentAiChatThreads: Pick<AiChatThread, 'threadId'>[]
+}
+
+export type GeneratedMediaEventWorkspaceGuardInput = GeneratedMediaEventWorkspaceGuardState & {
+    threadId: string
+    eventWorkspaceId?: string
+}
+
+export function hasCurrentWorkspaceThread({
+    threadId,
+    currentCanvasState,
+    currentAiChatThreads,
+}: GeneratedMediaEventWorkspaceGuardState & { threadId: string }): boolean {
+    if (currentAiChatThreads.some((thread) => thread.threadId === threadId)) return true
+
+    return Boolean(currentCanvasState?.aiChatPanel?.tabs?.some((tab) =>
+        tab.type === 'thread' && tab.refId === threadId
+    ) || currentCanvasState?.nodes.some((node: CanvasNode) =>
+        node.type === 'aiChatThread' && (node as AiChatThreadCanvasNode).referenceId === threadId
+    ))
+}
+
+export function shouldAcceptGeneratedMediaEvent({
+    threadId,
+    eventWorkspaceId,
+    workspaceId,
+    currentCanvasState,
+    currentAiChatThreads,
+}: GeneratedMediaEventWorkspaceGuardInput): boolean {
+    if (eventWorkspaceId && eventWorkspaceId !== workspaceId) return false
+    return hasCurrentWorkspaceThread({ threadId, currentCanvasState, currentAiChatThreads, workspaceId })
+}

--- a/services/web-ui/src/services/ai-chat-thread-service.ts
+++ b/services/web-ui/src/services/ai-chat-thread-service.ts
@@ -13,6 +13,7 @@ import type {
 const { AI_CHAT_THREAD_SUBJECTS } = NATS_SUBJECTS.WORKSPACE_SUBJECTS
 
 import AuthService from '$src/services/auth-service.ts'
+import RouterService from '$src/services/router-service.ts'
 
 import { servicesStore } from '$src/stores/servicesStore.ts'
 import { aiChatThreadStore } from '$src/stores/aiChatThreadStore.ts'
@@ -230,9 +231,13 @@ class AiChatThreadService {
                 workspaceId
             })
 
+            if (RouterService.getRouteParams().workspaceId !== workspaceId) return
+
             aiChatThreadsStore.setThreads(Array.isArray(threads) ? threads : [])
             aiChatThreadsStore.setMetaValues({ loadingStatus: LoadingStatus.success })
         } catch (error) {
+            if (RouterService.getRouteParams().workspaceId !== workspaceId) return
+
             console.error('Failed to load workspace AI chat threads:', error)
             aiChatThreadsStore.setMetaValues({ loadingStatus: LoadingStatus.error })
         }

--- a/services/web-ui/src/services/document-service.ts
+++ b/services/web-ui/src/services/document-service.ts
@@ -6,6 +6,7 @@ const { WORKSPACE_SUBJECTS } = NATS_SUBJECTS
 const { DOCUMENT_SUBJECTS } = WORKSPACE_SUBJECTS
 
 import AuthService from '$src/services/auth-service.ts'
+import RouterService from '$src/services/router-service.ts'
 
 import { servicesStore } from '$src/stores/servicesStore.ts'
 import { documentsStore } from '$src/stores/documentsStore.ts'
@@ -49,9 +50,14 @@ class DocumentService {
 				token: await AuthService.getTokenSilently(),
 				workspaceId
 			})
+
+			if (RouterService.getRouteParams().workspaceId !== workspaceId) return
+
 			documentsStore.setDocuments(Array.isArray(documents) ? documents : [])
 			documentsStore.setMetaValues({ loadingStatus: LoadingStatus.success })
 		} catch (error) {
+			if (RouterService.getRouteParams().workspaceId !== workspaceId) return
+
 			console.error('Failed to load workspace documents:', error)
 			documentsStore.setMetaValues({ loadingStatus: LoadingStatus.error })
 		}

--- a/services/web-ui/src/services/workspace-service.ts
+++ b/services/web-ui/src/services/workspace-service.ts
@@ -27,6 +27,8 @@ class WorkspaceService {
                 workspaceId
             })
 
+            if (RouterService.getRouteParams().workspaceId !== workspaceId) return
+
             if (workspace.error) {
                 workspaceStore.setMetaValues({ loadingStatus: LoadingStatus.error })
                 workspaceStore.setDataValues({ error: workspace.error })
@@ -45,6 +47,8 @@ class WorkspaceService {
             workspaceStore.setMetaValues({ loadingStatus: LoadingStatus.success })
 
         } catch (error) {
+            if (RouterService.getRouteParams().workspaceId !== workspaceId) return
+
             console.error('Failed to load workspace:', error)
             workspaceStore.setMetaValues({ loadingStatus: LoadingStatus.error })
             workspaceStore.setDataValues({ error: error })


### PR DESCRIPTION
## Summary

- Removes write-time NATS object-store bucket recreation from storage paths so transient storage failures cannot be masked by empty replacement buckets.
- Creates both workspace and workspace media-library buckets explicitly during workspace creation, with rollback if either bucket cannot be created.
- Makes workspace file metadata updates atomic: append uses DynamoDB list_append and removal uses conditional indexed updates with retry.
- Guards generated media events against stale workspace/chat context and consolidates image/video canvas media lifecycle cleanup into one configurable tracker.
- Adds targeted API and web-ui regression coverage around the storage and workspace switching failure surfaces.

Closes #250

## Validation

- docker exec lixpi-api pnpm exec vitest run src/models/workspace.test.ts src/NATS/subscriptions/workspace-creation-storage.test.ts src/NATS/subscriptions/workspace-deletion.test.ts src/services/media-library-storage.test.ts src/services/nats-object-store-contract.test.ts src/services/dynamodb-service-condition.test.ts
- docker exec lixpi-web-ui pnpm exec vitest run src/infographics/workspace/generatedMediaEventWorkspaceGuard.test.ts src/infographics/workspace/canvasMediaNodeLifecycle.test.ts
- git diff --check
