### PR TITLE
Restore GPT-5 OpenAI fix + migrate VLM path to modern Responses API

### DIFF
--- a/services/api/src/llm/extraction/vlm-client.test.ts
+++ b/services/api/src/llm/extraction/vlm-client.test.ts
@@ -11,7 +11,7 @@ const googleGenerateContentStream = vi.fn()
 
 vi.mock('openai', () => ({
     default: class {
-        public chat = { completions: { create: openAiCreate } }
+        public responses = { create: openAiCreate }
     },
 }))
 
@@ -63,9 +63,15 @@ const makeAnthropicStream = (events: any[], finalMessage: any) => ({
     },
 })
 
-const makeOpenAiToolCallChunk = (argument: string, model?: string) => ({
-    ...(model ? { model } : {}),
-    choices: [{ delta: { tool_calls: [{ function: { arguments: argument } }] } }],
+// Responses-API streaming events: structured output arrives as output_text
+// deltas; the terminal event carries the authoritative output_text + usage.
+const makeOpenAiTextDelta = (delta: string) => ({
+    type: 'response.output_text.delta',
+    delta,
+})
+const makeOpenAiCompleted = (outputText: string, model: string, usage?: { input_tokens: number; output_tokens: number }) => ({
+    type: 'response.completed',
+    response: { model, output_text: outputText, ...(usage ? { usage } : {}) },
 })
 
 describe('callStructuredVlm', () => {
@@ -76,16 +82,11 @@ describe('callStructuredVlm', () => {
         vi.clearAllMocks()
     })
 
-    it('dispatches to OpenAI and parses streamed function arguments', async () => {
+    it('dispatches to OpenAI and parses streamed structured output', async () => {
         openAiCreate.mockResolvedValueOnce(makeAsyncStream([
-            {
-                ...makeOpenAiToolCallChunk('{"status":"'),
-                usage: { prompt_tokens: 10, completion_tokens: 4 },
-            },
-            {
-                ...makeOpenAiToolCallChunk('ok"}'),
-                usage: { prompt_tokens: 11, completion_tokens: 8 },
-            },
+            makeOpenAiTextDelta('{"status":"'),
+            makeOpenAiTextDelta('ok"}'),
+            makeOpenAiCompleted('{"status":"ok"}', 'gpt-4.1', { input_tokens: 11, output_tokens: 8 }),
         ]))
 
         const result = await callStructuredVlm({
@@ -103,7 +104,8 @@ describe('callStructuredVlm', () => {
         expect(result.completionTokens).toBe(8)
         const createRequest = openAiCreate.mock.calls[0]?.[0]
         expect(createRequest?.model).toBe('gpt-4.1')
-        expect(createRequest?.tool_choice).toMatchObject({ type: 'function', function: { name: 'extract' } })
+        expect(createRequest?.instructions).toBe('You are helping.')
+        expect(createRequest?.text?.format).toMatchObject({ type: 'json_schema', name: 'extract', strict: true })
     })
 
     it('retries and succeeds when OpenAI throws a transient error once', async () => {
@@ -113,10 +115,9 @@ describe('callStructuredVlm', () => {
         openAiCreate
             .mockRejectedValueOnce(transientError)
             .mockResolvedValueOnce(makeAsyncStream([
-                {
-                    ...makeOpenAiToolCallChunk('{"status":"'),
-                },
-                makeOpenAiToolCallChunk('ok"}'),
+                makeOpenAiTextDelta('{"status":"'),
+                makeOpenAiTextDelta('ok"}'),
+                makeOpenAiCompleted('{"status":"ok"}', 'gpt-4.1'),
             ]))
 
         const result = await callStructuredVlm({
@@ -165,10 +166,9 @@ describe('callStructuredVlm', () => {
         openAiCreate
             .mockRejectedValueOnce(transientError)
             .mockResolvedValueOnce(makeAsyncStream([
-                {
-                    ...makeOpenAiToolCallChunk('{"status":"'),
-                },
-                makeOpenAiToolCallChunk('ok"}'),
+                makeOpenAiTextDelta('{"status":"'),
+                makeOpenAiTextDelta('ok"}'),
+                makeOpenAiCompleted('{"status":"ok"}', 'gpt-4.1'),
             ]))
 
         const result = await callStructuredVlm({

--- a/services/api/src/llm/extraction/vlm-client.ts
+++ b/services/api/src/llm/extraction/vlm-client.ts
@@ -219,59 +219,78 @@ const callAnthropic = async <T>(args: VlmCallArgs): Promise<VlmCallResult<T>> =>
 const callOpenAi = async <T>(args: VlmCallArgs): Promise<VlmCallResult<T>> => {
     const caps = detectCapabilities(args.provider, args.modelVersion)
     const client = getOpenAi()
-    const formatted = await resolveAndConvert(args.userMessages, args.natsService, 'OPENAI')
-    const messages: Array<Record<string, any>> = [
-        { role: 'system', content: args.systemPrompt },
-        ...formatted,
-    ]
+    // 'OPENAI' format yields the Responses-API content shape (input_text /
+    // input_image). The system prompt rides on `instructions`, the modern
+    // top-level field, rather than a synthetic system message in the input.
+    const input = await resolveAndConvert(args.userMessages, args.natsService, 'OPENAI')
 
     const requestArgs: Record<string, any> = {
         model: args.modelVersion,
-        messages,
+        instructions: args.systemPrompt,
+        input,
         stream: true,
-        stream_options: { include_usage: true },
-        tools: [{
-            type: 'function',
-            function: {
+        store: false,
+        // Structured Outputs on the Responses API: the model is constrained to
+        // the JSON schema and emits the object as output_text — no tool-call
+        // round-trip needed.
+        text: {
+            format: {
+                type: 'json_schema',
                 name: args.schema.name,
                 description: args.schema.description,
-                parameters: args.schema.schema,
+                schema: args.schema.schema,
                 strict: true,
             },
-        }],
-        tool_choice: { type: 'function', function: { name: args.schema.name } },
+        },
     }
     if (args.temperature !== undefined && caps.supportsTemperature) requestArgs.temperature = args.temperature
-    if (args.maxTokens) requestArgs.max_tokens = args.maxTokens
+    if (args.maxTokens) requestArgs.max_output_tokens = args.maxTokens
 
-    const stream = await client.chat.completions.create(requestArgs as any, { signal: args.abortSignal })
+    const stream = await client.responses.create(requestArgs as any, { signal: args.abortSignal })
 
-    let toolCallArgs = ''
+    let rawText = ''
+    let finalText = ''
     let modelName = args.modelVersion
     let promptTokens = 0
     let completionTokens = 0
 
-    for await (const chunk of stream as any) {
-        if (chunk?.model) modelName = chunk.model
-        const delta = chunk?.choices?.[0]?.delta
-        if (delta?.content && args.onTextChunk) args.onTextChunk(String(delta.content))
-        if (delta?.tool_calls) {
-            for (const tc of delta.tool_calls) {
-                if (tc?.function?.arguments) toolCallArgs += tc.function.arguments
+    for await (const event of stream as any) {
+        switch (event?.type) {
+            case 'response.output_text.delta': {
+                const delta: string = event.delta ?? ''
+                if (delta) {
+                    rawText += delta
+                    if (args.onTextChunk) args.onTextChunk(delta)
+                }
+                break
             }
-        }
-        if (chunk?.usage) {
-            promptTokens = chunk.usage.prompt_tokens ?? promptTokens
-            completionTokens = chunk.usage.completion_tokens ?? completionTokens
+            case 'response.completed':
+            case 'response.incomplete': {
+                const response = event.response
+                if (response?.model) modelName = response.model
+                if (typeof response?.output_text === 'string' && response.output_text) {
+                    finalText = response.output_text
+                }
+                if (response?.usage) {
+                    promptTokens = response.usage.input_tokens ?? promptTokens
+                    completionTokens = response.usage.output_tokens ?? completionTokens
+                }
+                break
+            }
+            case 'response.failed': {
+                const message = event.response?.error?.message ?? 'unknown error'
+                throw new Error(`OpenAI ${args.modelVersion} response failed: ${message}`)
+            }
         }
     }
 
-    if (!toolCallArgs) throw new Error(`OpenAI ${args.modelVersion} did not call tool "${args.schema.name}"`)
+    const outputText = finalText || rawText
+    if (!outputText) throw new Error(`OpenAI ${args.modelVersion} returned empty structured output for schema=${args.schema.name}`)
     let parsed: T
-    try { parsed = JSON.parse(toolCallArgs) as T }
-    catch (e: any) { throw new Error(`OpenAI returned non-JSON tool args: ${e?.message}`) }
+    try { parsed = JSON.parse(outputText) as T }
+    catch (e: any) { throw new Error(`OpenAI returned non-JSON structured output: ${e?.message}`) }
 
-    return { parsed, rawText: toolCallArgs, modelName, promptTokens, completionTokens }
+    return { parsed, rawText: outputText, modelName, promptTokens, completionTokens }
 }
 
 // ─── Google ───────────────────────────────────────────────────────────────────

--- a/services/api/src/llm/providers/openai-provider.ts
+++ b/services/api/src/llm/providers/openai-provider.ts
@@ -9,6 +9,7 @@ import { BaseProvider, type BaseProviderDeps } from './base-provider.ts'
 import type { ProviderName } from '@lixpi/constants'
 import type { ProviderState } from '../graph/state.ts'
 import { getSystemPrompt } from '../prompts/load-prompts.ts'
+import { detectCapabilities } from '../extraction/capabilities.ts'
 import {
     convertAttachmentsForProvider,
     parseDataUrl,
@@ -158,14 +159,16 @@ export class OpenAIProvider extends BaseProvider {
         aiChatThreadId: string
     }): Promise<Partial<ProviderState>> {
         const update: Partial<ProviderState> = {}
+        // GPT-5 / o-series accept only the default temperature — omit it for them.
+        const caps = detectCapabilities('OpenAI', args.modelVersion)
         const requestKwargs: Record<string, any> = {
             model: args.modelVersion,
             input: args.inputMessages,
             instructions: args.instructions,
-            temperature: args.temperature,
             stream: true,
             store: false,
         }
+        if (caps.supportsTemperature) requestKwargs.temperature = args.temperature
         if (args.maxTokens && args.maxTokens > 0) {
             requestKwargs.max_output_tokens = args.maxTokens
         }
@@ -485,11 +488,13 @@ export class OpenAIProvider extends BaseProvider {
         prompt: string,
         maxChars: number,
     ): Promise<string | undefined> {
+        const caps = detectCapabilities('OpenAI', state.modelVersion)
         const response = await this.client.responses.create({
             model: state.modelVersion,
             input: [{ role: 'user', content: `Original image prompt:\n${prompt}` }],
             instructions: buildImagePromptRewriteInstruction(maxChars),
-            temperature: 0.2,
+            // GPT-5 / o-series accept only the default temperature — omit it for them.
+            ...(caps.supportsTemperature ? { temperature: 0.2 } : {}),
             max_output_tokens: Math.max(256, Math.ceil((maxChars + 3) / 4) + 128),
             store: false,
         } as any)


### PR DESCRIPTION
## Why

PR #257 (Billing local integration) was reverted via #258, which also threw away two unrelated OpenAI fixes that were bundled into it. This PR restores the legitimate OpenAI fix and replaces the legacy compatibility shim that #257 introduced with the modern API.

## What

**1. Restore the GPT-5 / o-series capability fix** (`services/api/src/llm/providers/openai-provider.ts`)

Cherry-picked from #257 (commit `96a9cd1`, authored by Aleksei Romanovskii — authorship preserved). GPT-5 / o-series models accept only the default temperature and 400 otherwise. The provider now detects capabilities and omits the `temperature` field for those models in both the Responses-API chat path and the image-prompt rewrite. The unrelated Dockerfile/pnpm changes from that commit were intentionally left out.

**2. Migrate the structured-VLM OpenAI path to the modern Responses API** (`services/api/src/llm/extraction/vlm-client.ts`)

The structured-VLM OpenAI client was still calling the **legacy `chat.completions`** endpoint, using a forced function tool call to coax JSON out of the model. PR #257 worked around that by adding an `OPENAI_CHAT` attachment format (legacy `text` / `image_url` content shape) — legacy compatibility we don't want.

Instead of restoring that shim, the VLM call now uses `responses.create` with native **Structured Outputs** (`text.format` `json_schema`, `strict: true`) — the same modern API the main OpenAI provider already uses. This reuses the existing `OPENAI` attachment format (`input_text` / `input_image`), so the `OPENAI_CHAT` legacy format is **not needed at all** and is not reintroduced. The system prompt rides on the top-level `instructions` field; structured JSON arrives as `output_text` deltas; usage/model come from the `response.completed` event.

## Testing

`docker exec lixpi-api pnpm vitest run` for `vlm-client.test.ts` (updated to the Responses event/mocks), plus the resolver and media-descriptor suites that consume the VLM client — all green (54 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)