### PR TITLE
LIX-266 # Collapse feature scopes to org-wide and add delete from feature details

### DIFF
--- a/packages/lixpi/constants/nats-subjects.json
+++ b/packages/lixpi/constants/nats-subjects.json
@@ -57,8 +57,6 @@
 			"LIST_BY_SCOPE": "workspace.feature.listByScope",
 			"UPDATE": "workspace.feature.update",
 			"DELETE": "workspace.feature.delete",
-			"CHANGE_SCOPE": "workspace.feature.changeScope",
-			"REPORT_ABUSE": "workspace.feature.reportAbuse",
 			"GET_SAMPLE_URL": "workspace.feature.getSampleUrl",
 			"EVENTS": {
 				"CREATED": "workspace.feature.events.created",

--- a/packages/lixpi/constants/ts/types.ts
+++ b/packages/lixpi/constants/ts/types.ts
@@ -819,8 +819,18 @@ export type WorkspaceEdge = {
     pathType?: WorkspaceEdgePathType
 }
 
-export type FeatureScope = 'workspace' | 'user' | 'organization' | 'public'
+// Feature library access scopes. Intentionally distinct from MEDIA_LIBRARY_SCOPE:
+// features are org-wide (accessible across every workspace in the organization).
+// 'shared' (external/cross-org sharing) is reserved for a future release and has
+// no UI or code path yet.
+export type FeatureScope = 'organization' | 'shared'
 export type FeatureStatus = 'active' | 'reported' | 'removed'
+
+export const FEATURE_SCOPE = {
+    ORGANIZATION: 'organization',
+    SHARED: 'shared',
+} as const
+export type FeatureScopeValue = typeof FEATURE_SCOPE[keyof typeof FEATURE_SCOPE]
 
 export type FeatureSampleKind = 'source-crop' | 'texture-specimen' | 'applied-medium-probe' | 'palette-board'
 

--- a/services/api/src/NATS/subscriptions/extraction-subjects.test.ts
+++ b/services/api/src/NATS/subscriptions/extraction-subjects.test.ts
@@ -10,6 +10,9 @@ const mocks = vi.hoisted(() => ({
     workspace: {
         getWorkspace: vi.fn(),
     },
+    organization: {
+        getUserOrganizations: vi.fn(),
+    },
     extractionRun: {
         createRun: vi.fn(),
         updateStatus: vi.fn(),
@@ -29,6 +32,7 @@ const mocks = vi.hoisted(() => ({
 vi.mock('@lixpi/debug-tools', () => ({ info: vi.fn(), err: vi.fn() }))
 vi.mock('@lixpi/nats-service', () => ({ default: { getInstance: vi.fn(() => ({ publish })) } }))
 vi.mock('../../models/workspace.ts', () => ({ default: mocks.workspace }))
+vi.mock('../../models/organization.ts', () => ({ default: mocks.organization }))
 vi.mock('../../models/extraction-run.ts', () => ({ default: mocks.extractionRun }))
 vi.mock('../../models/ai-model.ts', () => ({ default: mocks.aiModel }))
 
@@ -42,6 +46,7 @@ const getHandler = (subject: string) =>
 beforeEach(() => {
     vi.clearAllMocks()
     mocks.workspace.getWorkspace.mockResolvedValue({ workspaceId: 'workspace-1' })
+    mocks.organization.getUserOrganizations.mockResolvedValue([{ organizationId: 'org-1' }])
     setExtractionLlmModule(mocks.llmModule as any)
 })
 
@@ -53,7 +58,6 @@ describe('Feature extraction START', () => {
     const baseData = {
         user: { userId: 'user-1' },
         workspaceId: 'workspace-1',
-        organizationId: 'org-1',
         extractionRunId: 'run-1',
         messages: [{ role: 'user', content: 'extract the palette' }],
         aiModel: 'openai:gpt-test',
@@ -76,8 +80,31 @@ describe('Feature extraction START', () => {
         expect(mocks.llmModule.processExtraction).toHaveBeenCalledWith(expect.objectContaining({
             extractionRunId: 'run-1',
             workspaceId: 'workspace-1',
+            // organizationId is resolved server-side from the user, not taken from the client.
+            organizationId: 'org-1',
             intent: 'extract the palette',
         }))
+    })
+
+    it('ignores any client-supplied organizationId and resolves it server-side', async () => {
+        mocks.aiModel.getAiModel.mockResolvedValue({ model: 'gpt-test' })
+        mocks.llmModule.processExtraction.mockResolvedValue({ success: true })
+
+        // A client trying to inject another org has no effect — resolution is server-side.
+        await getHandler(SUBJECTS.START)({ ...baseData, organizationId: 'attacker-org' })
+
+        expect(mocks.llmModule.processExtraction).toHaveBeenCalledWith(expect.objectContaining({
+            organizationId: 'org-1',
+        }))
+    })
+
+    it('fails the run when the user has no associated organization', async () => {
+        mocks.organization.getUserOrganizations.mockResolvedValueOnce([])
+
+        await getHandler(SUBJECTS.START)(baseData)
+
+        expect(mocks.extractionRun.markFailed).toHaveBeenCalledWith(expect.objectContaining({ extractionRunId: 'run-1' }))
+        expect(mocks.llmModule.processExtraction).not.toHaveBeenCalled()
     })
 
     it('fails the run and publishes an error when the analysis model is unknown', async () => {

--- a/services/api/src/NATS/subscriptions/extraction-subjects.ts
+++ b/services/api/src/NATS/subscriptions/extraction-subjects.ts
@@ -5,6 +5,7 @@ import NATS_Service from '@lixpi/nats-service'
 import { NATS_SUBJECTS, type ProviderName } from '@lixpi/constants'
 import ExtractionRun from '../../models/extraction-run.ts'
 import Workspace from '../../models/workspace.ts'
+import Organization from '../../models/organization.ts'
 import AiModel from '../../models/ai-model.ts'
 import type { LlmModule } from '../../llm/index.ts'
 
@@ -39,7 +40,6 @@ export const extractionSubjects = [
             const {
                 user: { userId },
                 workspaceId,
-                organizationId,
                 extractionRunId,
                 messages,
                 sourceContextSnapshot,
@@ -58,6 +58,19 @@ export const extractionSubjects = [
                     natsService?.publish(`${NATS_SUBJECTS.AI_INTERACTION_SUBJECTS.CHAT_SEND_MESSAGE_RESPONSE}.${workspaceId}.${extractionRunId}`, {
                         error: workspace?.error || 'WORKSPACE_NOT_FOUND',
                     })
+                    return
+                }
+
+                // Resolve the owning organization server-side from the authenticated user.
+                // Workspaces carry no org link and the client has no active-org concept, so the
+                // read paths (feature listByScope) resolve identically — see resolveUserOrganizationId
+                // in feature-subjects.ts. Both MUST match or extracted features won't be listed.
+                const userOrganizations = await Organization.getUserOrganizations({ userId })
+                const organizationId = userOrganizations[0]?.organizationId
+                if (!organizationId) {
+                    const message = 'Feature extraction could not start: no organization is associated with your account.'
+                    await ExtractionRun.markFailed({ extractionRunId, workspaceId, error: message })
+                    natsService?.publish(`${NATS_SUBJECTS.AI_INTERACTION_SUBJECTS.CHAT_SEND_MESSAGE_RESPONSE}.${workspaceId}.${extractionRunId}`, { error: message })
                     return
                 }
 

--- a/services/api/src/NATS/subscriptions/feature-subjects.test.ts
+++ b/services/api/src/NATS/subscriptions/feature-subjects.test.ts
@@ -11,6 +11,7 @@ const mocks = vi.hoisted(() => ({
     },
     organization: {
         getOrganization: vi.fn(),
+        getUserOrganizations: vi.fn(),
     },
     feature: {
         createFeature: vi.fn(),
@@ -19,10 +20,7 @@ const mocks = vi.hoisted(() => ({
         listByScope: vi.fn(),
         updateFeature: vi.fn(),
         deleteFeature: vi.fn(),
-        changeScope: vi.fn(),
-        incrementReportCount: vi.fn(),
     },
-    ensureFeatureSamplesForScope: vi.fn(),
 }))
 
 vi.mock('@lixpi/nats-service', () => ({
@@ -34,9 +32,6 @@ vi.mock('@lixpi/nats-service', () => ({
 vi.mock('../../models/workspace.ts', () => ({ default: mocks.workspace }))
 vi.mock('../../models/organization.ts', () => ({ default: mocks.organization }))
 vi.mock('../../models/feature.ts', () => ({ default: mocks.feature }))
-vi.mock('../../services/feature-sample-storage.ts', () => ({
-    ensureFeatureSamplesForScope: mocks.ensureFeatureSamplesForScope,
-}))
 
 import { featureSubjects } from './feature-subjects.ts'
 
@@ -55,8 +50,8 @@ const feature: Feature = {
     instructions: 'Keep edges soft.',
     parameters: {},
     sampleImages: [{ idx: 0, subject: 'sample', ext: 'png', fileId: 'feature/sample.png' }],
-    scope: 'workspace',
-    scopeOwnerId: 'workspace-1',
+    scope: 'organization',
+    scopeOwnerId: 'organization-1',
     status: 'active',
     ownerUserId: 'user-1',
     workspaceId: 'workspace-1',
@@ -69,45 +64,37 @@ const feature: Feature = {
     updatedAt: 1,
 }
 
-describe('Feature NATS authorization and sample durability', () => {
+describe('Feature NATS authorization', () => {
     beforeEach(() => {
         vi.clearAllMocks()
         mocks.workspace.getWorkspace.mockResolvedValue({ workspaceId: 'workspace-1' })
         mocks.organization.getOrganization.mockResolvedValue({ organizationId: 'organization-1' })
-        mocks.feature.getOwnedFeature.mockResolvedValue(feature)
-        mocks.feature.changeScope.mockResolvedValue({ ...feature, scope: 'user', scopeOwnerId: 'user-1' })
-        mocks.ensureFeatureSamplesForScope.mockResolvedValue(undefined)
+        // Org is resolved server-side from the user, not taken from the client payload.
+        mocks.organization.getUserOrganizations.mockResolvedValue([{ organizationId: 'organization-1' }])
+        mocks.feature.getFeature.mockResolvedValue(feature)
     })
 
-    it('derives promoted ownership from the authenticated user and copies samples before metadata', async () => {
-        const result = await getHandler(SUBJECTS.CHANGE_SCOPE)({
-            user: { userId: 'user-1' },
-            featureId: feature.featureId,
+    it('lets any member of the owning organization delete a feature', async () => {
+        // A different user (user-2) who belongs to the same org can delete.
+        const result = await getHandler(SUBJECTS.DELETE)({
+            user: { userId: 'user-2' },
             workspaceId: 'workspace-1',
-            newScope: 'user',
-            newScopeOwnerId: 'attacker-owner',
+            organizationId: 'organization-1',
+            featureId: feature.featureId,
         })
 
-        expect(mocks.ensureFeatureSamplesForScope).toHaveBeenCalledWith({
-            feature,
-            newScope: 'user',
-            newScopeOwnerId: 'user-1',
-        })
-        expect(mocks.feature.changeScope).toHaveBeenCalledWith({
-            feature,
-            newScope: 'user',
-            newScopeOwnerId: 'user-1',
-        })
-        expect(mocks.ensureFeatureSamplesForScope.mock.invocationCallOrder[0])
-            .toBeLessThan(mocks.feature.changeScope.mock.invocationCallOrder[0])
-        expect(result).toEqual(expect.objectContaining({ success: true, newScopeOwnerId: 'user-1' }))
+        expect(mocks.feature.deleteFeature).toHaveBeenCalledWith({ featureId: feature.featureId })
+        expect(mocks.publish).toHaveBeenCalledWith(SUBJECTS.EVENTS.DELETED, { type: 'deleted', featureId: feature.featureId })
+        expect(result).toEqual({ success: true, featureId: feature.featureId })
     })
 
-    it('does not delete a feature unless the authenticated user owns it', async () => {
-        mocks.feature.getOwnedFeature.mockResolvedValueOnce({ error: 'PERMISSION_DENIED' })
+    it('does not delete a feature the requester cannot read (other org)', async () => {
+        mocks.feature.getFeature.mockResolvedValueOnce({ error: 'PERMISSION_DENIED' })
 
         const result = await getHandler(SUBJECTS.DELETE)({
             user: { userId: 'user-2' },
+            workspaceId: 'workspace-1',
+            organizationId: 'organization-2',
             featureId: feature.featureId,
         })
 
@@ -115,12 +102,10 @@ describe('Feature NATS authorization and sample durability', () => {
         expect(mocks.feature.deleteFeature).not.toHaveBeenCalled()
     })
 
-    it('does not list workspace features when workspace membership validation fails', async () => {
-        mocks.workspace.getWorkspace.mockResolvedValueOnce({ error: 'PERMISSION_DENIED' })
-
+    it('does not list features for an unsupported scope', async () => {
         const result = await getHandler(SUBJECTS.LIST_BY_SCOPE)({
             user: { userId: 'user-2' },
-            workspaceId: 'workspace-1',
+            organizationId: 'organization-1',
             scope: 'workspace',
         })
 
@@ -128,15 +113,15 @@ describe('Feature NATS authorization and sample durability', () => {
         expect(mocks.feature.listByScope).not.toHaveBeenCalled()
     })
 
-    it('reports only accessible public features', async () => {
-        mocks.feature.getFeature.mockResolvedValueOnce(feature)
+    it('does not list organization features when the user has no organization', async () => {
+        mocks.organization.getUserOrganizations.mockResolvedValueOnce([])
 
-        const result = await getHandler(SUBJECTS.REPORT_ABUSE)({
+        const result = await getHandler(SUBJECTS.LIST_BY_SCOPE)({
             user: { userId: 'user-2' },
-            featureId: feature.featureId,
+            scope: 'organization',
         })
 
-        expect(result).toEqual({ error: 'PERMISSION_DENIED' })
-        expect(mocks.feature.incrementReportCount).not.toHaveBeenCalled()
+        expect(result).toEqual({ items: [] })
+        expect(mocks.feature.listByScope).not.toHaveBeenCalled()
     })
 })

--- a/services/api/src/NATS/subscriptions/feature-subjects.ts
+++ b/services/api/src/NATS/subscriptions/feature-subjects.ts
@@ -5,57 +5,48 @@ import { NATS_SUBJECTS, type FeatureScope } from '@lixpi/constants'
 import Feature, { type RequesterContext } from '../../models/feature.ts'
 import Organization from '../../models/organization.ts'
 import Workspace from '../../models/workspace.ts'
-import { ensureFeatureSamplesForScope } from '../../services/feature-sample-storage.ts'
 
 const { FEATURE_SUBJECTS } = NATS_SUBJECTS.WORKSPACE_SUBJECTS
-const VALID_SCOPES: FeatureScope[] = ['workspace', 'user', 'organization', 'public']
+const VALID_SCOPES: FeatureScope[] = ['organization', 'shared']
 
 const verifyWorkspaceAccess = async (userId: string, workspaceId: string): Promise<boolean> => {
     const workspace = await Workspace.getWorkspace({ userId, workspaceId })
     return !('error' in workspace)
 }
 
-const verifyOrganizationAccess = async (userId: string, organizationId: string): Promise<boolean> => {
-    const organization = await Organization.getOrganization({ userId, organizationId })
-    return !('error' in organization)
+// The owning organization is resolved server-side from the authenticated user — the
+// client has no active-org concept wired up, and workspaces carry no org link. Both the
+// write path (extraction) and the read paths (list/get/delete) MUST resolve the same way
+// or features scoped on write won't be found on read. See resolveUserOrganizationId in
+// extraction-subjects.ts which mirrors this.
+export const resolveUserOrganizationId = async (userId: string): Promise<string | undefined> => {
+    const organizations = await Organization.getUserOrganizations({ userId })
+    return organizations[0]?.organizationId
 }
 
 const getRequesterContext = async ({
     userId,
     workspaceId,
-    organizationId,
 }: {
     userId: string
     workspaceId?: string
-    organizationId?: string
 }): Promise<RequesterContext> => ({
     userId,
     workspaceId: workspaceId && await verifyWorkspaceAccess(userId, workspaceId) ? workspaceId : undefined,
-    organizationId: organizationId && await verifyOrganizationAccess(userId, organizationId) ? organizationId : undefined,
+    organizationId: await resolveUserOrganizationId(userId),
 })
 
 const getTargetScopeOwnerId = async ({
     userId,
-    workspaceId,
-    organizationId,
     scope,
 }: {
     userId: string
-    workspaceId?: string
-    organizationId?: string
     scope: FeatureScope
 }): Promise<string | { error: string }> => {
-    if (scope === 'user') return userId
-    if (scope === 'public') return 'public'
-    if (scope === 'workspace') {
-        if (!workspaceId || !(await verifyWorkspaceAccess(userId, workspaceId))) {
-            return { error: 'WORKSPACE_ACCESS_DENIED' }
-        }
-        return workspaceId
-    }
-    if (!organizationId || !(await verifyOrganizationAccess(userId, organizationId))) {
-        return { error: 'ORGANIZATION_ACCESS_DENIED' }
-    }
+    // 'shared' (external sharing) is reserved for a future release — no path yet.
+    if (scope !== 'organization') return { error: 'SCOPE_NOT_AVAILABLE' }
+    const organizationId = await resolveUserOrganizationId(userId)
+    if (!organizationId) return { error: 'ORGANIZATION_ACCESS_DENIED' }
     return organizationId
 }
 
@@ -68,7 +59,11 @@ export const featureSubjects = [
             if (!workspaceId || !(await verifyWorkspaceAccess(userId, workspaceId))) {
                 return { error: 'WORKSPACE_ACCESS_DENIED' }
             }
-            const feature = await Feature.createFeature({ category, name, summary, tags: tags ?? [], instructions, parameters: parameters ?? {}, sampleImages: sampleImages ?? [], scope: 'workspace', ownerUserId: userId, workspaceId, sourceContext })
+            const organizationId = await resolveUserOrganizationId(userId)
+            if (!organizationId) {
+                return { error: 'ORGANIZATION_ACCESS_DENIED' }
+            }
+            const feature = await Feature.createFeature({ category, name, summary, tags: tags ?? [], instructions, parameters: parameters ?? {}, sampleImages: sampleImages ?? [], ownerUserId: userId, workspaceId, organizationId, sourceContext })
             if (!feature) return { error: 'FAILED_TO_CREATE' }
             NATS_Service.getInstance()?.publish(FEATURE_SUBJECTS.EVENTS.CREATED, { type: 'created', feature })
             return feature
@@ -78,10 +73,10 @@ export const featureSubjects = [
         subject: FEATURE_SUBJECTS.GET, type: 'reply', payloadType: 'json',
         permissions: { pub: { allow: [FEATURE_SUBJECTS.GET] }, sub: { allow: [FEATURE_SUBJECTS.GET] } },
         handler: async (data: any) => {
-            const { user: { userId }, workspaceId, organizationId, featureId } = data
+            const { user: { userId }, workspaceId, featureId } = data
             return Feature.getFeature({
                 featureId,
-                requesterContext: await getRequesterContext({ userId, workspaceId, organizationId }),
+                requesterContext: await getRequesterContext({ userId, workspaceId }),
             })
         },
     },
@@ -89,15 +84,15 @@ export const featureSubjects = [
         subject: FEATURE_SUBJECTS.LIST_BY_SCOPE, type: 'reply', payloadType: 'json',
         permissions: { pub: { allow: [FEATURE_SUBJECTS.LIST_BY_SCOPE] }, sub: { allow: [FEATURE_SUBJECTS.LIST_BY_SCOPE] } },
         handler: async (data: any) => {
-            const { user: { userId }, workspaceId, organizationId, scope, limit, lastKey } = data
+            const { user: { userId }, workspaceId, scope, limit, lastKey } = data
             if (!VALID_SCOPES.includes(scope as FeatureScope)) return { items: [] }
             const typedScope = scope as FeatureScope
-            const scopeOwnerId = await getTargetScopeOwnerId({ userId, workspaceId, organizationId, scope: typedScope })
+            const scopeOwnerId = await getTargetScopeOwnerId({ userId, scope: typedScope })
             if (typeof scopeOwnerId !== 'string') return { items: [] }
             return Feature.listByScope({
                 scope: typedScope,
                 scopeOwnerId,
-                requesterContext: await getRequesterContext({ userId, workspaceId, organizationId }),
+                requesterContext: await getRequesterContext({ userId, workspaceId }),
                 paging: limit ? { limit, lastKey } : undefined,
             })
         },
@@ -117,45 +112,16 @@ export const featureSubjects = [
         subject: FEATURE_SUBJECTS.DELETE, type: 'reply', payloadType: 'json',
         permissions: { pub: { allow: [FEATURE_SUBJECTS.DELETE] }, sub: { allow: [FEATURE_SUBJECTS.DELETE, FEATURE_SUBJECTS.EVENTS.DELETED] } },
         handler: async (data: any) => {
-            const { user: { userId }, featureId } = data
-            const feature = await Feature.getOwnedFeature({ featureId, ownerUserId: userId })
+            const { user: { userId }, workspaceId, featureId } = data
+            // Features are org-wide: any member of the owning org can delete them.
+            const feature = await Feature.getFeature({
+                featureId,
+                requesterContext: await getRequesterContext({ userId, workspaceId }),
+            })
             if ('error' in feature) return feature
             await Feature.deleteFeature({ featureId })
             NATS_Service.getInstance()?.publish(FEATURE_SUBJECTS.EVENTS.DELETED, { type: 'deleted', featureId })
             return { success: true, featureId }
-        },
-    },
-    {
-        subject: FEATURE_SUBJECTS.CHANGE_SCOPE, type: 'reply', payloadType: 'json',
-        permissions: { pub: { allow: [FEATURE_SUBJECTS.CHANGE_SCOPE] }, sub: { allow: [FEATURE_SUBJECTS.CHANGE_SCOPE, FEATURE_SUBJECTS.EVENTS.UPDATED] } },
-        handler: async (data: any) => {
-            const { user: { userId }, featureId, newScope, workspaceId, organizationId } = data
-            if (!VALID_SCOPES.includes(newScope as FeatureScope)) return { error: 'INVALID_SCOPE' }
-            const feature = await Feature.getOwnedFeature({ featureId, ownerUserId: userId })
-            if ('error' in feature) return feature
-            const typedScope = newScope as FeatureScope
-            const newScopeOwnerId = await getTargetScopeOwnerId({ userId, workspaceId, organizationId, scope: typedScope })
-            if (typeof newScopeOwnerId !== 'string') return newScopeOwnerId
-            try {
-                await ensureFeatureSamplesForScope({ feature, newScope: typedScope, newScopeOwnerId })
-            } catch {
-                return { error: 'SAMPLE_COPY_FAILED' }
-            }
-            const updatedFeature = await Feature.changeScope({ feature, newScope: typedScope, newScopeOwnerId })
-            NATS_Service.getInstance()?.publish(FEATURE_SUBJECTS.EVENTS.UPDATED, { type: 'scopeChanged', featureId, newScope: typedScope, feature: updatedFeature })
-            return { success: true, featureId, newScope: typedScope, newScopeOwnerId }
-        },
-    },
-    {
-        subject: FEATURE_SUBJECTS.REPORT_ABUSE, type: 'reply', payloadType: 'json',
-        permissions: { pub: { allow: [FEATURE_SUBJECTS.REPORT_ABUSE] }, sub: { allow: [FEATURE_SUBJECTS.REPORT_ABUSE, FEATURE_SUBJECTS.EVENTS.UPDATED] } },
-        handler: async (data: any) => {
-            const { user: { userId }, featureId } = data
-            const feature = await Feature.getFeature({ featureId, requesterContext: { userId } })
-            if ('error' in feature || feature.scope !== 'public') return { error: 'PERMISSION_DENIED' }
-            const { newStatus } = await Feature.incrementReportCount({ featureId })
-            if (newStatus === 'reported') NATS_Service.getInstance()?.publish(FEATURE_SUBJECTS.EVENTS.UPDATED, { type: 'reported', featureId })
-            return { success: true, featureId, status: newStatus }
         },
     },
 ]

--- a/services/api/src/llm/extraction/stage6-persist.ts
+++ b/services/api/src/llm/extraction/stage6-persist.ts
@@ -7,6 +7,7 @@ import { info, err } from '@lixpi/debug-tools'
 
 import Feature from '../../models/feature.ts'
 import ExtractionRun from '../../models/extraction-run.ts'
+import { ensureFeatureSamplesForScope } from '../../services/feature-sample-storage.ts'
 import type { ExtractionDeps, ExtractionState, StageLogger } from './types.ts'
 
 export const persistFeature = async (state: ExtractionState, logger: StageLogger, _deps: ExtractionDeps): Promise<Partial<ExtractionState>> => {
@@ -14,6 +15,11 @@ export const persistFeature = async (state: ExtractionState, logger: StageLogger
         const draft = state.draft
         if (!draft) {
             throw new Error('Cannot persist: synthesis stage produced no draft')
+        }
+
+        const organizationId = state.input.organizationId
+        if (!organizationId) {
+            throw new Error('Cannot persist feature: organization context is required')
         }
 
         const featureId = uuid()
@@ -33,9 +39,9 @@ export const persistFeature = async (state: ExtractionState, logger: StageLogger
             instructions: draft.instructions,
             parameters: draft.parameters,
             sampleImages: orderedSamples,
-            scope: 'workspace',
             ownerUserId: state.input.userId,
             workspaceId: state.input.workspaceId,
+            organizationId,
             sourceContext: {
                 extractionRunId: state.input.extractionRunId,
                 sourceWorkspaceId: state.input.workspaceId,
@@ -49,6 +55,14 @@ export const persistFeature = async (state: ExtractionState, logger: StageLogger
 
         if (!feature) {
             throw new Error('Feature.createFeature returned undefined')
+        }
+
+        // Features are org-wide and outlive any single workspace, so copy sample bytes
+        // from the origin workspace bucket into the durable per-owner features bucket.
+        try {
+            await ensureFeatureSamplesForScope({ feature, newScope: 'organization', newScopeOwnerId: organizationId })
+        } catch (e) {
+            err(`Failed to durably store feature samples for ${featureId}: ${e instanceof Error ? e.message : String(e)}`)
         }
 
         await ExtractionRun.markComplete({

--- a/services/api/src/models/feature.test.ts
+++ b/services/api/src/models/feature.test.ts
@@ -1,0 +1,61 @@
+'use strict'
+
+import { describe, it, expect } from 'vitest'
+
+import type { Feature } from '@lixpi/constants'
+import { canRead } from './feature.ts'
+
+const makeFeature = (overrides: Partial<Feature> = {}): Feature => ({
+    featureId: 'feature-1',
+    version: 1,
+    category: 'illustration-style',
+    name: 'painted-light',
+    summary: 'Soft painted illumination.',
+    tags: [],
+    instructions: '',
+    parameters: {},
+    sampleImages: [],
+    scope: 'organization',
+    scopeOwnerId: 'org-1',
+    status: 'active',
+    ownerUserId: 'owner-user',
+    workspaceId: 'workspace-1',
+    sourceContext: { extractionRunId: 'run-1', sourceWorkspaceId: 'workspace-1' },
+    reportCount: 0,
+    createdAt: 1,
+    updatedAt: 1,
+    ...overrides,
+})
+
+// =============================================================================
+// canRead — org-wide access rule (the only two scopes are organization + shared)
+// =============================================================================
+
+describe('canRead', () => {
+    it('grants access to a member of the owning organization', () => {
+        const feature = makeFeature({ scope: 'organization', scopeOwnerId: 'org-1' })
+        // A different user than the owner, but same org, can read it.
+        expect(canRead('some-other-user', feature, 'workspace-1', 'org-1')).toBe(true)
+    })
+
+    it('denies access when the requester belongs to a different organization', () => {
+        const feature = makeFeature({ scope: 'organization', scopeOwnerId: 'org-1' })
+        expect(canRead('owner-user', feature, 'workspace-1', 'org-2')).toBe(false)
+    })
+
+    it('denies access when no organization context is supplied', () => {
+        const feature = makeFeature({ scope: 'organization', scopeOwnerId: 'org-1' })
+        expect(canRead('owner-user', feature, 'workspace-1', undefined)).toBe(false)
+    })
+
+    it('does not grant the owner access purely by ownership', () => {
+        // Ownership alone is not a read grant — access is gated on org membership.
+        const feature = makeFeature({ scope: 'organization', scopeOwnerId: 'org-1', ownerUserId: 'owner-user' })
+        expect(canRead('owner-user', feature, 'workspace-1', undefined)).toBe(false)
+    })
+
+    it('denies access to shared-scoped features (deferred to a future release)', () => {
+        const feature = makeFeature({ scope: 'shared', scopeOwnerId: 'org-1' })
+        expect(canRead('owner-user', feature, 'workspace-1', 'org-1')).toBe(false)
+    })
+})

--- a/services/api/src/models/feature.ts
+++ b/services/api/src/models/feature.ts
@@ -8,12 +8,9 @@ import {
     type Feature,
     type FeatureMeta,
     type FeatureScope,
-    type FeatureStatus,
 } from '@lixpi/constants'
 
 const { ORG_NAME, STAGE } = process.env
-
-const REPORT_THRESHOLD = 5
 
 const buildScopeAndOwnerKey = (scope: FeatureScope, scopeOwnerId: string): string =>
     `${scope}#${scopeOwnerId}`
@@ -31,10 +28,8 @@ export type RequesterContext = {
 }
 
 export const canRead = (userId: string, feature: Feature, workspaceId?: string, organizationId?: string): boolean => {
-    if (feature.ownerUserId === userId) return true
-    if (feature.scope === 'public' && feature.status === 'active') return true
-    if (feature.scope === 'workspace' && feature.scopeOwnerId === workspaceId) return true
-    if (feature.scope === 'user' && feature.ownerUserId === userId) return true
+    // Features are org-wide: any member of the owning organization can read them.
+    // 'shared' (external sharing) has no allow path yet — deferred to a future release.
     if (feature.scope === 'organization' && feature.scopeOwnerId === organizationId) return true
     return false
 }
@@ -49,18 +44,16 @@ const FeatureModel = {
         instructions: string
         parameters: Record<string, any>
         sampleImages: Feature['sampleImages']
-        scope: FeatureScope
         ownerUserId: string
         workspaceId: string
+        organizationId: string
         sourceContext: Feature['sourceContext']
     }): Promise<Feature | undefined> => {
         const now = Date.now()
         const featureId = data.featureId ?? uuid()
-        const scope: FeatureScope = data.scope
-        const scopeOwnerId = scope === 'workspace' ? data.workspaceId
-            : scope === 'user' ? data.ownerUserId
-            : scope === 'public' ? 'public'
-            : 'org-placeholder'
+        // All features are org-scoped so they are accessible across every workspace in the org.
+        const scope: FeatureScope = 'organization'
+        const scopeOwnerId = data.organizationId
 
         const feature: Feature & { scopeAndOwner: string } = {
             featureId, version: 1,
@@ -154,7 +147,7 @@ const FeatureModel = {
             origin: `Feature.listPromotedByOriginWorkspaceForCleanup(${workspaceId})`,
         })
         return ((result?.items ?? []) as Feature[]).filter((feature) =>
-            feature.workspaceId === workspaceId && feature.scope !== 'workspace',
+            feature.workspaceId === workspaceId,
         )
     },
 
@@ -177,24 +170,6 @@ const FeatureModel = {
         await dynamoDBService.deleteItems({ tableName: getDynamoDbTableStageName('FEATURES_META', ORG_NAME, STAGE), key: { featureId }, origin: 'Feature.deleteFeature:meta' })
     },
 
-    changeScope: async ({ feature, newScope, newScopeOwnerId }: { feature: Feature; newScope: FeatureScope; newScopeOwnerId: string }): Promise<Feature> => {
-        const now = Date.now()
-        const gsiKey = buildScopeAndOwnerKey(newScope, newScopeOwnerId)
-        await dynamoDBService.updateItem({ tableName: getDynamoDbTableStageName('FEATURES', ORG_NAME, STAGE), key: { featureId: feature.featureId, version: 1 }, updates: { scope: newScope, scopeOwnerId: newScopeOwnerId, scopeAndOwner: gsiKey, updatedAt: now }, origin: 'Feature.changeScope' })
-        await dynamoDBService.updateItem({ tableName: getDynamoDbTableStageName('FEATURES_META', ORG_NAME, STAGE), key: { featureId: feature.featureId }, updates: { scope: newScope, scopeOwnerId: newScopeOwnerId, updatedAt: now }, origin: 'Feature.changeScope:meta' })
-        return { ...feature, scope: newScope, scopeOwnerId: newScopeOwnerId, updatedAt: now }
-    },
-
-    incrementReportCount: async ({ featureId }: { featureId: string }): Promise<{ newStatus: FeatureStatus }> => {
-        const item = await dynamoDBService.getItem({ tableName: getDynamoDbTableStageName('FEATURES', ORG_NAME, STAGE), key: { featureId, version: 1 }, origin: 'Feature.incrementReportCount:get' })
-        if (!item) return { newStatus: 'active' }
-        const count = (item.reportCount ?? 0) + 1
-        const newStatus: FeatureStatus = count >= REPORT_THRESHOLD ? 'reported' : 'active'
-        const now = Date.now()
-        await dynamoDBService.updateItem({ tableName: getDynamoDbTableStageName('FEATURES', ORG_NAME, STAGE), key: { featureId, version: 1 }, updates: { reportCount: count, status: newStatus, updatedAt: now }, origin: 'Feature.incrementReportCount' })
-        if (newStatus === 'reported') await dynamoDBService.updateItem({ tableName: getDynamoDbTableStageName('FEATURES_META', ORG_NAME, STAGE), key: { featureId }, updates: { status: newStatus, updatedAt: now }, origin: 'Feature.incrementReportCount:meta' })
-        return { newStatus }
-    },
 }
 
 export default FeatureModel

--- a/services/api/src/services/feature-sample-storage.ts
+++ b/services/api/src/services/feature-sample-storage.ts
@@ -23,12 +23,11 @@ export const findFeatureSampleRef = (feature: Feature, sampleIndex: number): Fea
 
 export const getPrimaryFeatureSampleBucketName = (
     feature: Feature,
-    scope: FeatureScope = feature.scope,
-    scopeOwnerId: string = feature.scopeOwnerId,
+    _scope: FeatureScope = feature.scope,
+    _scopeOwnerId: string = feature.scopeOwnerId,
 ): string =>
-    scope === 'workspace'
-        ? getWorkspaceBucketName(scopeOwnerId)
-        : getDurableFeatureBucketName(feature.ownerUserId)
+    // All features are org-scoped, so samples live in the durable per-owner bucket.
+    getDurableFeatureBucketName(feature.ownerUserId)
 
 const getFeatureSampleBucketCandidates = (feature: Feature): string[] => {
     const primary = getPrimaryFeatureSampleBucketName(feature)

--- a/services/web-ui/src/infographics/workspace/extractionTab.ts
+++ b/services/web-ui/src/infographics/workspace/extractionTab.ts
@@ -557,7 +557,8 @@ export async function submitExtractionRequest(
         const token = await AuthService.getTokenSilently()
         accessToken = token || ''
         nats.publish(NATS_SUBJECTS.AI_INTERACTION_SUBJECTS.FEATURE_EXTRACT.START, {
-            token, workspaceId, organizationId: '', extractionRunId, messages,
+            // organizationId is resolved server-side from the authenticated user.
+            token, workspaceId, extractionRunId, messages,
             aiModel: ctx.aiModel,
             aiImageModel: ctx.aiImageModel,
             analysisModelId: ctx.modelConfig?.analysisModelId ?? ctx.aiModel,

--- a/services/web-ui/src/infographics/workspace/media-library-panel.scss
+++ b/services/web-ui/src/infographics/workspace/media-library-panel.scss
@@ -948,7 +948,7 @@
 }
 
 .media-library-inspector {
-    background: rgba(255, 255, 255, 0.37);
+    background: transparent;
 }
 
 .media-library-panel-extraction-selected .media-library-inspector {
@@ -1103,6 +1103,32 @@
 .feature-library-inspector-card {
     display: grid;
     gap: 14px;
+    // Breathing room so the last content (tags / delete) isn't clipped by the
+    // scroll container's bottom edge.
+    padding-bottom: 28px;
+}
+
+.feature-library-inspector-danger-zone {
+    margin-top: 6px;
+    padding-top: 16px;
+    border-top: 1px solid rgba(26, 39, 68, 0.1);
+    display: flex;
+}
+
+.feature-library-inspector-danger-zone .feature-library-row-action-danger {
+    flex: 1 1 auto;
+    height: 34px;
+}
+
+.feature-library-row-action-danger {
+    border-color: rgba(201, 64, 64, 0.32);
+    background: rgba(201, 64, 64, 0.08);
+    color: #b23636;
+
+    &:hover {
+        background: rgba(201, 64, 64, 0.16);
+        color: #9c2a2a;
+    }
 }
 
 .feature-library-inspector-nav {

--- a/services/web-ui/src/infographics/workspace/mediaLibraryPanel.ts
+++ b/services/web-ui/src/infographics/workspace/mediaLibraryPanel.ts
@@ -6,6 +6,7 @@ import {
     NATS_SUBJECTS,
     MEDIA_LIBRARY_BROWSE_ALL,
     MEDIA_LIBRARY_SCOPE,
+    FEATURE_SCOPE,
     type CanvasFeatureExtractionState,
     type Feature,
     type FeatureMeta,
@@ -21,11 +22,17 @@ import { organizationStore } from '$src/stores/organizationStore.ts'
 import { userStore } from '$src/stores/userStore.ts'
 import { renderExtractionTabBody } from '$src/infographics/workspace/extractionTab.ts'
 
+// Media library (images/videos) scopes. Features use FEATURE_SCOPES below.
 const SCOPES: Array<{ key: MediaLibraryScope; label: string }> = [
     { key: MEDIA_LIBRARY_SCOPE.WORKSPACE, label: 'Workspace' },
     { key: MEDIA_LIBRARY_SCOPE.USER, label: 'Mine' },
     { key: MEDIA_LIBRARY_SCOPE.ORGANIZATION, label: 'Organization' },
     { key: MEDIA_LIBRARY_SCOPE.PUBLIC, label: 'Public' },
+]
+
+// Features are org-wide — a single scope. 'shared' (external sharing) is deferred.
+const FEATURE_SCOPES: Array<{ key: string; label: string }> = [
+    { key: FEATURE_SCOPE.ORGANIZATION, label: 'Organization' },
 ]
 
 type MediaLibraryBrowseMode = MediaLibraryScope | typeof MEDIA_LIBRARY_BROWSE_ALL
@@ -296,10 +303,7 @@ export function createMediaLibraryPanel(options: MediaLibraryPanelOptions): Medi
             const token = await AuthService.getTokenSilently()
             accessToken = token
             const organizationId = organizationStore.getData('organizationId') || undefined
-            const scopes = browseMode === MEDIA_LIBRARY_BROWSE_ALL
-                ? SCOPES
-                : SCOPES.filter((scope) => scope.key === browseMode)
-            const results = await Promise.all(scopes.map((scope) =>
+            const results = await Promise.all(FEATURE_SCOPES.map((scope) =>
                 nats.request(NATS_SUBJECTS.WORKSPACE_SUBJECTS.FEATURE_SUBJECTS.LIST_BY_SCOPE, {
                     token,
                     workspaceId,
@@ -840,7 +844,8 @@ export function createMediaLibraryPanel(options: MediaLibraryPanelOptions): Medi
         if (!window.confirm(`Delete "${feature.name}"?`)) return
         const nats = servicesStore.getData('nats')
         const token = await AuthService.getTokenSilently()
-        const response = await nats?.request(NATS_SUBJECTS.WORKSPACE_SUBJECTS.FEATURE_SUBJECTS.DELETE, { token, workspaceId, featureId: feature.featureId })
+        const organizationId = organizationStore.getData('organizationId') || undefined
+        const response = await nats?.request(NATS_SUBJECTS.WORKSPACE_SUBJECTS.FEATURE_SUBJECTS.DELETE, { token, workspaceId, organizationId, featureId: feature.featureId })
         if (response?.error) {
             setFeedback(`Could not delete @${feature.name}.`)
             return
@@ -850,38 +855,6 @@ export function createMediaLibraryPanel(options: MediaLibraryPanelOptions): Medi
         if (selectedFeatureId === feature.featureId) selectedFeatureId = null
         renderContent()
         setFeedback(`Deleted @${feature.name}.`)
-    }
-
-    async function reportFeature(feature: FeatureMeta) {
-        const nats = servicesStore.getData('nats')
-        const token = await AuthService.getTokenSilently()
-        const response = await nats?.request(NATS_SUBJECTS.WORKSPACE_SUBJECTS.FEATURE_SUBJECTS.REPORT_ABUSE, { token, workspaceId, featureId: feature.featureId })
-        setFeedback(response?.error ? `Could not report @${feature.name}.` : `Reported @${feature.name}.`)
-    }
-
-    async function changeFeatureScope(feature: FeatureMeta, newScope: MediaLibraryScope, revert: () => void) {
-        if (newScope === feature.scope) return
-        if (newScope === MEDIA_LIBRARY_SCOPE.PUBLIC && !window.confirm(`Make @${feature.name} public? Anyone will be able to discover and use it.`)) {
-            revert()
-            return
-        }
-        const nats = servicesStore.getData('nats')
-        const token = await AuthService.getTokenSilently()
-        const organizationId = organizationStore.getData('organizationId') || undefined
-        const response = await nats?.request(NATS_SUBJECTS.WORKSPACE_SUBJECTS.FEATURE_SUBJECTS.CHANGE_SCOPE, {
-            token,
-            workspaceId,
-            organizationId,
-            featureId: feature.featureId,
-            newScope,
-        })
-        if (!response || response.error) {
-            revert()
-            setFeedback(`Could not change sharing for @${feature.name}.`)
-            return
-        }
-        setFeedback(`Moved @${feature.name} to ${SCOPES.find((scope) => scope.key === newScope)?.label ?? newScope}.`)
-        await loadFeatures()
     }
 
     function selectExtractionRun(extractionRunId: string): void {
@@ -901,15 +874,9 @@ export function createMediaLibraryPanel(options: MediaLibraryPanelOptions): Medi
         if (!featureId || !featureCard) return undefined
 
         const firstSample = Array.isArray(featureCard.sampleImages) ? featureCard.sampleImages[0] : undefined
-        const scope = (textValue(featureCard.scope) as MediaLibraryScope | undefined) ?? MEDIA_LIBRARY_SCOPE.WORKSPACE
+        const scope = FEATURE_SCOPE.ORGANIZATION
         const ownerUserId = userStore.getData('userId') || ''
-        const scopeOwnerId = scope === MEDIA_LIBRARY_SCOPE.WORKSPACE
-            ? workspaceId
-            : scope === MEDIA_LIBRARY_SCOPE.PUBLIC
-                ? 'public'
-                : scope === MEDIA_LIBRARY_SCOPE.ORGANIZATION
-                    ? organizationStore.getData('organizationId') || ''
-                    : ownerUserId
+        const scopeOwnerId = organizationStore.getData('organizationId') || ''
         return {
             featureId,
             category: textValue(featureCard.category) ?? 'other',
@@ -1070,8 +1037,6 @@ export function createMediaLibraryPanel(options: MediaLibraryPanelOptions): Medi
 
     function buildFeatureInspector(feature: FeatureMeta): HTMLElement {
         const details = featureDetails.get(feature.featureId)
-        const isOwner = userStore.getData('userId') === feature.ownerUserId
-        const organizationId = organizationStore.getData('organizationId') || undefined
         const inspectorEl = html`<article className="feature-library-inspector-card">
             <div className="feature-library-inspector-nav">
                 <button type="button" className="feature-library-inspector-back">Back</button>
@@ -1087,11 +1052,7 @@ export function createMediaLibraryPanel(options: MediaLibraryPanelOptions): Medi
             </div>
             <div className="feature-library-inspector-actions">
                 <button type="button" className="feature-library-row-action feature-library-row-action-primary" data-action="use">Use Feature</button>
-                ${isOwner ? html`<button type="button" className="feature-library-row-action" data-action="delete">Delete</button>` : feature.scope === MEDIA_LIBRARY_SCOPE.PUBLIC ? html`<button type="button" className="feature-library-row-action" data-action="report">Report</button>` : null}
             </div>
-            ${isOwner ? html`<label className="feature-library-inspector-scope">Sharing
-                <span className="feature-library-scope-editor-mount"></span>
-            </label>` : null}
             <div className="feature-library-row-detail-grid">
                 <div className="feature-library-row-detail-field"><span>Category</span><strong>${feature.category || 'feature'}</strong></div>
                 <div className="feature-library-row-detail-field"><span>Scope</span><strong>${feature.scope}</strong></div>
@@ -1102,29 +1063,20 @@ export function createMediaLibraryPanel(options: MediaLibraryPanelOptions): Medi
             <div className="feature-library-row-palette-mount"></div>
             <div className="feature-library-row-instructions-mount"></div>
             <div className="feature-library-row-detail-tags"></div>
+            <div className="feature-library-inspector-danger-zone">
+                <button type="button" className="feature-library-row-action feature-library-row-action-danger" data-action="delete">Delete feature</button>
+            </div>
         </article>` as HTMLElement
 
         inspectorEl.querySelector('.feature-library-inspector-back')!.addEventListener('click', () => {
             selectedFeatureId = null
             renderContent()
         })
-        const scopeEditorMount = inspectorEl.querySelector('.feature-library-scope-editor-mount') as HTMLElement | null
-        if (scopeEditorMount) {
-            const sharingOptions = SCOPES.filter((scope) => organizationId || scope.key !== MEDIA_LIBRARY_SCOPE.ORGANIZATION)
-            const sharingDropdown = trackTransientDropdown(createScopeDropdown({
-                id: `feature-library-scope-${feature.featureId}`,
-                options: sharingOptions,
-                selectedKey: feature.scope,
-                onSelect: (key) => void changeFeatureScope(feature, key as MediaLibraryScope, () => sharingDropdown.setSelectedKey(feature.scope)),
-            }))
-            scopeEditorMount.appendChild(sharingDropdown.dom)
-        }
         inspectorEl.querySelector('.feature-library-inspector-actions')!.addEventListener('click', (event) => {
             const action = (event.target as HTMLElement).closest('[data-action]')?.getAttribute('data-action')
             if (action === 'use') void handleUseFeature(feature)
-            else if (action === 'delete') void deleteFeature(feature)
-            else if (action === 'report') void reportFeature(feature)
         })
+        inspectorEl.querySelector('.feature-library-inspector-danger-zone [data-action="delete"]')!.addEventListener('click', () => void deleteFeature(feature))
 
         const samplesMount = inspectorEl.querySelector('.feature-library-row-samples-mount') as HTMLElement
         samplesMount.appendChild(buildSampleGallery(feature, details))


### PR DESCRIPTION
## Summary

Collapses the feature library access model to **two scopes** and makes deletion available from the feature details view.

### Scope model
- `FeatureScope` is now `organization | shared`; added `FEATURE_SCOPE` constant, decoupled from `MEDIA_LIBRARY_SCOPE` (images/videos unchanged).
- Extracted features are created `organization`-scoped, so they are accessible across every workspace in the org.
- `shared` (external sharing) is reserved — no UI or code path yet.
- The owning organization is resolved **server-side from the authenticated user** in both the write path (`extraction-subjects`, `stage6-persist`) and the read paths (`feature-subjects` list/get/delete via `resolveUserOrganizationId`). The client value is never trusted; workspaces carry no org link, so resolution is keyed on the JWT-verified userId. Both paths resolve identically so a feature scoped on write is found on read.
- Removed the `CHANGE_SCOPE` and `REPORT_ABUSE` feature subjects/handlers (no remaining valid transitions / no public scope).

### Delete from feature details
- Any org member can delete an org feature (authorized via `canRead` on the resolved org), not just the original extractor.
- The Delete control moved to a dedicated danger zone at the bottom of the inspector; made the inspector background transparent and kept bottom padding so content isn't clipped.

### Sample storage
- Org-scoped samples resolve to the durable per-owner bucket; `stage6-persist` copies bytes there on create so features outlive any single workspace.

## Tests
- `feature.test.ts` (new): `canRead` org-wide rule — member match, other-org denial, missing-org denial, ownership is not a grant, `shared` denied.
- `feature-subjects.test.ts`: server-side org resolution for list/delete; any same-org member can delete; other-org/no-org denied; unsupported scope returns empty.
- `extraction-subjects.test.ts`: org resolved server-side; client-supplied org ignored; run fails when user has no org.
- Full suites green: API 305 passing, web-ui 1256 passing.

Not covered (stated per testing guide): the web-ui `mediaLibraryPanel` rendering changes are DOM/presentation and not unit-tested per the web-ui guide's no-DOM-rendering rule.

Closes #266