### PR TITLE
LIX-278 # Move media reference thumbnails out of AI user message bubble

### DIFF
--- a/services/web-ui/src/components/proseMirror/plugins/aiChatThreadPlugin/ai-chat-thread.scss
+++ b/services/web-ui/src/components/proseMirror/plugins/aiChatThreadPlugin/ai-chat-thread.scss
@@ -17,8 +17,11 @@ $userMessageTextColor: #fff;
     display: flex;
     flex-wrap: wrap;
     align-items: flex-start;
+    justify-content: flex-end;
     gap: 6px;
-    max-width: 100%;
+    max-width: 85%;
+    margin-left: auto;
+    margin-right: 1rem;
     margin-bottom: 8px;
 }
 

--- a/services/web-ui/src/components/proseMirror/plugins/aiChatThreadPlugin/aiChatMessageShells.test.ts
+++ b/services/web-ui/src/components/proseMirror/plugins/aiChatThreadPlugin/aiChatMessageShells.test.ts
@@ -1,5 +1,57 @@
 import { describe, expect, it } from 'vitest'
-import { createAiResponseMessageShell } from '$src/components/proseMirror/plugins/aiChatThreadPlugin/aiChatMessageShells.ts'
+import {
+	createAiResponseMessageShell,
+	createAiUserMessageShell,
+} from '$src/components/proseMirror/plugins/aiChatThreadPlugin/aiChatMessageShells.ts'
+
+// =============================================================================
+// aiUserMessageShell — reference previews live outside the message bubble
+// =============================================================================
+
+describe('aiUserMessageShell', () => {
+	it('renders shell structure with wrapper, message shell, previews, and content slots', () => {
+		const shell = createAiUserMessageShell()
+
+		expect(shell.wrapper.className).toBe('ai-user-message-wrapper')
+		expect(shell.messageEl.className).toBe('ai-user-message')
+		expect(shell.referencePreviewsEl.className).toBe('ai-user-message-reference-previews')
+		expect(shell.contentEl.className).toBe('ai-user-message-content')
+	})
+
+	it('renders reference previews outside the message bubble', () => {
+		const shell = createAiUserMessageShell()
+
+		expect(shell.messageEl.contains(shell.referencePreviewsEl)).toBe(false)
+		expect(shell.wrapper.contains(shell.referencePreviewsEl)).toBe(true)
+	})
+
+	it('positions reference previews above the message bubble', () => {
+		const shell = createAiUserMessageShell()
+		const children = Array.from(shell.wrapper.children)
+
+		expect(children.indexOf(shell.referencePreviewsEl))
+			.toBeLessThan(children.indexOf(shell.messageEl))
+	})
+
+	it('keeps the content slot inside the message bubble', () => {
+		const shell = createAiUserMessageShell()
+
+		expect(shell.messageEl.contains(shell.contentEl)).toBe(true)
+	})
+
+	it('hides the reference previews container by default', () => {
+		const shell = createAiUserMessageShell()
+
+		expect(shell.referencePreviewsEl.hidden).toBe(true)
+	})
+
+	it('supports a custom wrapper class', () => {
+		const shell = createAiUserMessageShell({ wrapperClassName: 'custom-user-shell' })
+
+		expect(shell.wrapper.classList.contains('ai-user-message-wrapper')).toBe(true)
+		expect(shell.wrapper.classList.contains('custom-user-shell')).toBe(true)
+	})
+})
 
 describe('aiResponseMessageShell', () => {
 	it('renders shell structure with wrapper, message shell, and content slots', () => {

--- a/services/web-ui/src/components/proseMirror/plugins/aiChatThreadPlugin/aiChatMessageShells.ts
+++ b/services/web-ui/src/components/proseMirror/plugins/aiChatThreadPlugin/aiChatMessageShells.ts
@@ -28,8 +28,8 @@ export function createAiUserMessageShell(options: MessageShellOptions = {}): AiU
     const wrapperClassName = ['ai-user-message-wrapper', options.wrapperClassName].filter(Boolean).join(' ')
     const wrapper = html`
         <div className=${wrapperClassName}>
+            <div className="ai-user-message-reference-previews" contenteditable="false" hidden="true"></div>
             <div className="ai-user-message">
-                <div className="ai-user-message-reference-previews" contenteditable="false" hidden="true"></div>
                 <div className="ai-user-message-content"></div>
             </div>
         </div>

--- a/services/web-ui/src/components/proseMirror/plugins/aiChatThreadPlugin/aiUserMessageNode.test.ts
+++ b/services/web-ui/src/components/proseMirror/plugins/aiChatThreadPlugin/aiUserMessageNode.test.ts
@@ -14,7 +14,7 @@ import {
 // Helper: instantiate aiUserMessageNodeView with minimal mocks
 // =============================================================================
 
-function createUserMessageNodeView(attrs: Record<string, unknown> = {}) {
+function createUserMessageNodeView(attrs: Record<string, unknown> = {}, options: any = undefined) {
     const node = schema.nodes.aiUserMessage.create(
         { id: 'user-msg-test-1', createdAt: 1700000000000, ...attrs }
     )
@@ -22,8 +22,32 @@ function createUserMessageNodeView(attrs: Record<string, unknown> = {}) {
     const mockView = {} as any
     const getPos = vi.fn(() => 0)
 
-    const nodeView = aiUserMessageNodeView(node, mockView, getPos)
+    const nodeView = aiUserMessageNodeView(node, mockView, getPos, options)
     return { nodeView, node, mockView, getPos }
+}
+
+function createImageCanvasNode(nodeId: string): any {
+    return {
+        type: 'image',
+        nodeId,
+        referenceId: nodeId,
+        src: `/api/images/${nodeId}.png`,
+        posterSrc: `/api/images/${nodeId}-poster.png`,
+        dimensions: { width: 420, height: 560 },
+        aspectRatio: 0.75,
+    }
+}
+
+function createMockContextPreview(nodes: Record<string, any>): any {
+    return {
+        getNodeById: (id: string) => nodes[id],
+        environment: {
+            getDocuments: () => [],
+            getThreads: () => [],
+            getApiBaseUrl: () => 'https://api.example.com',
+            getAuthToken: async () => 'token-123',
+        },
+    }
 }
 
 // =============================================================================
@@ -172,6 +196,85 @@ describe('aiUserMessageNodeView — DOM structure', () => {
 
         expect(aiUserMsg).not.toBeNull()
         expect(aiUserMsg!.contains(nodeView.contentDOM!)).toBe(true)
+    })
+})
+
+// =============================================================================
+// aiUserMessageNodeView — reference previews placement
+// =============================================================================
+
+describe('aiUserMessageNodeView — reference previews placement', () => {
+    it('renders reference preview tiles outside the message bubble', () => {
+        const contextPreview = createMockContextPreview({
+            'img-1': createImageCanvasNode('img-1'),
+        })
+
+        const { nodeView } = createUserMessageNodeView(
+            { referenceNodeIds: ['img-1'] },
+            { contextPreview },
+        )
+
+        const dom = nodeView.dom as HTMLElement
+        const previewsEl = dom.querySelector('.ai-user-message-reference-previews') as HTMLElement
+        const bubbleEl = dom.querySelector('.ai-user-message') as HTMLElement
+
+        expect(previewsEl.hidden).toBe(false)
+        expect(previewsEl.childElementCount).toBe(1)
+        // Tiles live outside the bubble, directly under the wrapper.
+        expect(bubbleEl.contains(previewsEl)).toBe(false)
+        expect(previewsEl.parentElement).toBe(dom)
+    })
+
+    it('positions the previews above the message bubble in the wrapper', () => {
+        const contextPreview = createMockContextPreview({
+            'img-1': createImageCanvasNode('img-1'),
+        })
+
+        const { nodeView } = createUserMessageNodeView(
+            { referenceNodeIds: ['img-1'] },
+            { contextPreview },
+        )
+
+        const dom = nodeView.dom as HTMLElement
+        const previewsEl = dom.querySelector('.ai-user-message-reference-previews') as HTMLElement
+        const bubbleEl = dom.querySelector('.ai-user-message') as HTMLElement
+        const children = Array.from(dom.children)
+
+        expect(children.indexOf(previewsEl)).toBeLessThan(children.indexOf(bubbleEl))
+    })
+
+    it('keeps the previews container hidden when there are no reference nodes', () => {
+        const contextPreview = createMockContextPreview({})
+
+        const { nodeView } = createUserMessageNodeView({}, { contextPreview })
+
+        const dom = nodeView.dom as HTMLElement
+        const previewsEl = dom.querySelector('.ai-user-message-reference-previews') as HTMLElement
+
+        expect(previewsEl.hidden).toBe(true)
+        expect(previewsEl.childElementCount).toBe(0)
+    })
+
+    it('ignoreMutation returns true for mutations inside the previews container', () => {
+        const contextPreview = createMockContextPreview({
+            'img-1': createImageCanvasNode('img-1'),
+        })
+
+        const { nodeView } = createUserMessageNodeView(
+            { referenceNodeIds: ['img-1'] },
+            { contextPreview },
+        )
+
+        const dom = nodeView.dom as HTMLElement
+        const previewsEl = dom.querySelector('.ai-user-message-reference-previews') as HTMLElement
+
+        const mutation = {
+            type: 'childList',
+            attributeName: null,
+            target: previewsEl.firstChild ?? previewsEl,
+        } as unknown as MutationRecord
+
+        expect(nodeView.ignoreMutation!(mutation)).toBe(true)
     })
 })
 


### PR DESCRIPTION
## Summary

In the branch lineage node meta details (AI thread), media reference thumbnails were rendered inside the user message bubble. This moves them out and positions them above the bubble, preserving the existing hover/preview mechanism.

### Changes

- **`aiChatMessageShells.ts`** — Moved the `.ai-user-message-reference-previews` element out of `.ai-user-message` so it is now a sibling rendered above the bubble inside the wrapper.
- **`ai-chat-thread.scss`** — Right-aligned the previews row (`justify-content: flex-end`, `margin-left: auto`, `max-width: 85%`, `margin-right: 1rem`) so it lines up above the right-aligned bubble.

The hover mechanism and tile rendering are untouched: the same `createContextPreviewTile` instances are appended to the previews element, and `ignoreMutation`/`destroy` continue to reference the same element.

Closes #278