### PR TITLE
LIX-289 # Fix WebUI NATS reconnect after auth/API service restart

### DIFF
--- a/packages/lixpi/nats-service/python/nats_service.py
+++ b/packages/lixpi/nats-service/python/nats_service.py
@@ -131,6 +131,8 @@ class NatsServiceConfig:
         subscriptions: Optional[List[Dict[str, Any]]] = None,
         middleware: Optional[List[Callable]] = None,
         reply_middleware: Optional[List[Callable]] = None,
+        get_token: Optional[Callable[[], Any]] = None,
+        on_auth_error: Optional[Callable[[Exception], Any]] = None,
     ):
         """
         Initialize NATS service configuration.
@@ -146,6 +148,14 @@ class NatsServiceConfig:
             tls_ca_cert: Path to TLS CA certificate (optional)
             max_reconnect_attempts: Maximum reconnection attempts (-1 for infinite)
             reconnect_time_wait: Wait time between reconnections in seconds
+            get_token: Optional (async) callable used to (re)fetch a fresh auth
+                token before every connect/reconnect attempt. When supplied it
+                takes precedence over the static `token` and lets the connection
+                recover from token expiry or signing-key rotation without a
+                manual restart.
+            on_auth_error: Optional callable invoked when the server rejects our
+                credentials so the caller can invalidate any cached token before
+                `get_token` is called again.
         """
         self.servers = servers or ["nats://localhost:4222"]
         self.name = name or "default"
@@ -160,6 +170,8 @@ class NatsServiceConfig:
         self.subscriptions = subscriptions or []
         self.middleware = middleware or []
         self.reply_middleware = reply_middleware or []
+        self.get_token = get_token
+        self.on_auth_error = on_auth_error
 
 
 class NatsService:
@@ -187,6 +199,13 @@ class NatsService:
         self._reconnect_timer: Optional[asyncio.Task] = None
         self._subscriptions_initialized = False
         self._reconnect_attempts = 0
+        # Latest token handed to the connection. Kept in sync so a reconnect after
+        # a token expiry or signing-key rotation presents fresh credentials rather
+        # than the token captured once at connect time.
+        self._current_token: Optional[str] = None
+        # Set during graceful disconnect()/drain() so the close callback does not
+        # try to reconnect after an intentional close.
+        self._intentional_close = False
 
     @classmethod
     def get_instance(cls) -> Optional['NatsService']:
@@ -322,24 +341,73 @@ class NatsService:
         """Apply authentication to connection options."""
         if self.config.nkey_seed and self.config.user_id:
             # Priority 1: Self-issued JWT using NKey seed (Ed25519 signing)
-            # Used by services that need cryptographically signed authentication
-            info("Generating self-issued JWT...")
-            options["token"] = generate_self_issued_jwt(
-                nkey_seed=self.config.nkey_seed,
-                user_id=self.config.user_id,
-                expiry_hours=1
-            )
+            # Used by services that need cryptographically signed authentication.
+            # _refresh_token() regenerates a fresh (non-expired) JWT before each
+            # connect attempt; fall back to generating one here if it wasn't set.
+            if not self._current_token:
+                self._current_token = generate_self_issued_jwt(
+                    nkey_seed=self.config.nkey_seed,
+                    user_id=self.config.user_id,
+                    expiry_hours=1
+                )
             info(f"Using self-issued JWT for user: {self.config.user_id}")
-        elif self.config.token:
-            # Priority 2: Pre-generated JWT token
-            # Used when token is already available from external source
-            options["token"] = self.config.token
+            options["token"] = self._current_token
+        elif self.config.get_token or self.config.token or self._current_token:
+            # Priority 2: Pre-generated / provider-supplied JWT token.
+            # Uses the freshest token captured by _refresh_token() so a reconnect
+            # never replays a token that has since expired or been rotated out.
+            if not self._current_token and self.config.token:
+                self._current_token = self.config.token
+            options["token"] = self._current_token
         elif self.config.user and self.config.password:
             # Priority 3: Basic username/password authentication
             # Legacy auth method, less secure than JWT
             options["user"] = self.config.user
             options["password"] = self.config.password
         # If none provided, connection will be attempted without authentication
+
+    async def _refresh_token(self) -> None:
+        """Refresh the token used for authentication before a connect attempt.
+
+        Prefers the async provider, then regenerates the self-issued JWT (which
+        expires hourly), then falls back to the static token.
+        """
+        if self.config.get_token:
+            try:
+                fresh = self.config.get_token()
+                if asyncio.iscoroutine(fresh):
+                    fresh = await fresh
+                if fresh:
+                    self._current_token = fresh
+            except Exception as error:
+                err(f"NATS -> failed to refresh auth token: {error}")
+        elif self.config.nkey_seed and self.config.user_id:
+            self._current_token = generate_self_issued_jwt(
+                nkey_seed=self.config.nkey_seed,
+                user_id=self.config.user_id,
+                expiry_hours=1
+            )
+        elif self.config.token:
+            self._current_token = self.config.token
+
+    async def _handle_auth_error(self, error: Exception) -> None:
+        """Notify the caller that the server rejected our credentials so it can
+        clear any cached token before the next _refresh_token() call."""
+        if not self.config.on_auth_error:
+            return
+        try:
+            result = self.config.on_auth_error(error)
+            if asyncio.iscoroutine(result):
+                await result
+        except Exception as cb_error:
+            err(f"NATS -> on_auth_error handler failed: {cb_error}")
+
+    @staticmethod
+    def _is_auth_error(error: Any) -> bool:
+        """Detect authorization/authentication failures across error shapes."""
+        name = type(error).__name__ if isinstance(error, BaseException) else ''
+        message = str(error) if error is not None else ''
+        return 'Authorization' in name or 'authoriz' in message.lower() or 'authentic' in message.lower()
 
     async def connect(self, initial_connect_timeout: int = 2) -> None:
         """
@@ -352,8 +420,13 @@ class NatsService:
             return
 
         self._is_connecting = True
+        self._intentional_close = False
 
         try:
+            # Fetch a fresh token before every attempt so a reconnect after a token
+            # expiry or signing-key rotation does not keep replaying stale creds.
+            await self._refresh_token()
+
             options = self._build_connection_options()
 
             # Handle TLS if CA cert provided
@@ -388,7 +461,14 @@ class NatsService:
             err("NATS -> connection error or timeout")
             self._schedule_reconnect()
         except Exception as error:
-            err(f"NATS -> connection error or timeout: {error}")
+            if self._is_auth_error(error):
+                # Server rejected our credentials. Let the caller invalidate its
+                # cached token so the next _refresh_token() obtains a valid one
+                # instead of looping forever on the same rejected token.
+                err(f"NATS -> authorization failed, refreshing credentials: {error}")
+                await self._handle_auth_error(error)
+            else:
+                err(f"NATS -> connection error or timeout: {error}")
             self._schedule_reconnect()
         finally:
             self._is_connecting = False
@@ -396,12 +476,18 @@ class NatsService:
     async def disconnect(self) -> None:
         """Disconnect from NATS server."""
         if self.nc and not self.nc.is_closed:
+            self._intentional_close = True
+            if self._reconnect_timer:
+                self._reconnect_timer.cancel()
             await self.nc.close()
             info("NATS disconnected gracefully.")
 
     async def drain(self) -> None:
         """Drain all subscriptions and disconnect."""
         if self.nc and not self.nc.is_closed:
+            self._intentional_close = True
+            if self._reconnect_timer:
+                self._reconnect_timer.cancel()
             await self.nc.drain()
             info("NATS drained all subscriptions and disconnected.")
 
@@ -622,6 +708,11 @@ class NatsService:
     async def _error_callback(self, e: Exception) -> None:
         """Handle NATS errors."""
         err(f"NATS -> connection error: {e}")
+        # If the server rejected our credentials (expired token or rotated signing
+        # key), refresh them so the next reconnect presents valid credentials.
+        if self._is_auth_error(e):
+            await self._handle_auth_error(e)
+            await self._refresh_token()
 
     async def _disconnected_callback(self) -> None:
         """Handle NATS disconnection."""
@@ -639,6 +730,9 @@ class NatsService:
         warn("NATS -> connection closed")
         # Reset the initialized flag on close so we can reconnect properly
         self._subscriptions_initialized = False
+        # Reconnect unless we intentionally closed the connection.
+        if not self._intentional_close:
+            self._schedule_reconnect()
 
     # ===========================================
     # JetStream Object Store Methods

--- a/packages/lixpi/nats-service/ts/nats-service.ts
+++ b/packages/lixpi/nats-service/ts/nats-service.ts
@@ -1,7 +1,7 @@
 'use strict'
 
 import c from 'chalk'
-import { wsconnect } from '@nats-io/nats-core'
+import { wsconnect, tokenAuthenticator } from '@nats-io/nats-core'
 import { connect } from "@nats-io/transport-node"
 import { fromSeed } from '@nats-io/nkeys'
 import { jetstream, jetstreamManager } from '@nats-io/jetstream'
@@ -40,6 +40,14 @@ export type NatsServiceConfig = {
     pass?: string
     nkeySeed?: string       // Optional NKey seed for self-issued JWT
     userId?: string         // Optional user ID for JWT subject (used with nkeySeed)
+    // Optional async provider used to (re)fetch a fresh auth token before every
+    // connect/reconnect attempt. When supplied it takes precedence over the
+    // static `token` and lets the connection recover from token expiry or
+    // signing-key rotation without a page reload.
+    getToken?: () => Promise<string | false>
+    // Invoked when the server rejects our credentials (AuthorizationError) so the
+    // caller can invalidate any cached token before `getToken` is called again.
+    onAuthError?: (error: unknown) => void | Promise<void>
     subscriptions?: NatsSubjectSubscription[]
     middleware?: NatsMiddleware[]              // Middleware for all subscriptions
     replyMiddleware?: ReplyMiddleware[]        // Middleware specifically for replies
@@ -168,6 +176,18 @@ export default class NatsService {
     private isConnecting = false
     private reconnectTimer: NodeJS.Timeout | null = null
     private subscriptionsInitialized = false
+    // Latest token handed to the NATS authenticator. Kept in sync so the client's
+    // own internal reconnect loop always presents fresh credentials rather than a
+    // stale token that was captured once at connect time.
+    private currentToken: string | null = null
+    // Set during graceful disconnect()/drain() so the status monitor does not try
+    // to reconnect after an intentional close.
+    private intentionalClose = false
+    // Consecutive failed connect attempts, used for exponential backoff so a
+    // persistent auth failure does not flood the auth callout / JWKS endpoint.
+    private reconnectAttempts = 0
+    // Timeout (ms) applied to each connect attempt; captured from connect().
+    private connectTimeout = 2000
 
     static getInstance(): NatsService | null {
         return NatsService.instance || null
@@ -186,9 +206,14 @@ export default class NatsService {
         this.streamReplicas = config.streamReplicas ?? DEFAULT_STREAM_REPLICAS
     }
 
-    private scheduleReconnect(delay = 500) {
+    private scheduleReconnect(delay?: number) {
         if (this.reconnectTimer) clearTimeout(this.reconnectTimer)
-        this.reconnectTimer = setTimeout(() => this.connect(), delay)
+        // Exponential backoff: 500ms, 1s, 2s, 4s, 8s, capped at 16s. Prevents a
+        // stale token or a down server from hammering the auth callout / JWKS
+        // endpoint (which is itself rate-limited) tens of times per second.
+        const backoff = delay ?? Math.min(500 * (2 ** this.reconnectAttempts), 16000)
+        this.reconnectAttempts++
+        this.reconnectTimer = setTimeout(() => this.connect(this.connectTimeout), backoff)
     }
 
     private monitorStatus(): void {
@@ -213,11 +238,23 @@ export default class NatsService {
                         break
                     case "error":
                         err('NATS -> connection error:', status)
+                        // The client keeps retrying internally (maxReconnectAttempts: -1),
+                        // but with the credentials captured at connect time. If the server
+                        // rejected our token (expired or signing key rotated), refresh it so
+                        // the next internal reconnect presents valid credentials.
+                        if (this.isAuthError((status as any).error ?? status)) {
+                            await this.handleAuthError((status as any).error ?? status)
+                            await this.refreshToken()
+                        }
                         break
                     case "close":
                         warn('NATS -> connection closed:', status)
                         // Reset the initialized flag on close so we can reconnect properly
                         this.subscriptionsInitialized = false
+                        // Reconnect unless we intentionally closed the connection.
+                        if (!this.intentionalClose) {
+                            this.scheduleReconnect()
+                        }
                         break
                 }
             }
@@ -319,15 +356,21 @@ export default class NatsService {
     async connect(initialConnectTimeout = 2000): Promise<void> {
         if (this.isConnecting || this.isConnected()) return
         this.isConnecting = true
+        this.intentionalClose = false
+        this.connectTimeout = initialConnectTimeout
 
         try {
+            // Fetch a fresh token before every attempt so a reload/reconnect after a
+            // token expiry or signing-key rotation does not keep replaying stale creds.
+            await this.refreshToken()
+
             const options = this.buildConnectionOptions()
-            this.nc = await Promise.race([
-                this.config.webSocket ? wsconnect(options) : connect(options),
-                new Promise<never>((_, reject) =>
-                    setTimeout(() => reject(new Error('Initial connect timeout')), initialConnectTimeout)
-                )
-            ])
+            // The client honours `options.timeout` and rejects on failure (see
+            // waitOnFirstConnect: false), so there is no need for a Promise.race
+            // timeout that would leave a background client retrying forever.
+            this.nc = await (this.config.webSocket ? wsconnect(options) : connect(options))
+            // Connected: reset the reconnect backoff.
+            this.reconnectAttempts = 0
             infoStr([
                 c.green('NATS -> listening on: '),
                 c.blue(`${this.config.webSocket ? 'wss://' : 'nats://'}${this.nc.getServer()}`)
@@ -335,11 +378,52 @@ export default class NatsService {
             this.monitorStatus()
             await this.initSubscriptions()
         } catch (error) {
-            err('NATS -> connection error or timeout', error)
+            if (this.isAuthError(error)) {
+                // Server rejected our credentials. Let the caller invalidate its cached
+                // token so the next refreshToken() obtains a valid one instead of looping
+                // forever on the same rejected token.
+                err('NATS -> authorization failed, refreshing credentials', error)
+                await this.handleAuthError(error)
+            } else {
+                err('NATS -> connection error or timeout', error)
+            }
             this.scheduleReconnect()
         } finally {
             this.isConnecting = false
         }
+    }
+
+    // Refresh the token used by the authenticator. Prefers the async provider so
+    // credentials can be regenerated on demand; falls back to the static token.
+    private async refreshToken(): Promise<void> {
+        if (this.config.getToken) {
+            try {
+                const fresh = await this.config.getToken()
+                if (fresh) this.currentToken = fresh
+            } catch (error) {
+                err('NATS -> failed to refresh auth token', error)
+            }
+        } else if (this.config.token) {
+            this.currentToken = this.config.token
+        }
+    }
+
+    // Notify the caller that the server rejected our credentials so it can clear
+    // any cached token before the next refreshToken() call.
+    private async handleAuthError(error: unknown): Promise<void> {
+        try {
+            await this.config.onAuthError?.(error)
+        } catch (cbError) {
+            err('NATS -> onAuthError handler failed', cbError)
+        }
+    }
+
+    // Detect authorization/authentication failures across the various error shapes
+    // the client surfaces them in (thrown errors and status events).
+    private isAuthError(error: unknown): boolean {
+        const name = (error as any)?.name
+        const message = String((error as any)?.message ?? error ?? '')
+        return name === 'AuthorizationError' || /authoriz|authentic/i.test(message)
     }
 
     private buildConnectionOptions(): ConnectionOptions {
@@ -350,7 +434,17 @@ export default class NatsService {
             name,
             maxReconnectAttempts: -1,
             reconnectTimeWait: 500,
-            waitOnFirstConnect: true,
+            // Reject the initial connect on failure instead of retrying silently in
+            // the background. With `waitOnFirstConnect: true` an auth failure never
+            // surfaced to our catch block: the client kept retrying forever with the
+            // rejected token, our own connect timeout fired, and we spawned yet
+            // another background client that also retried forever — flooding the
+            // auth callout / JWKS endpoint. Failing fast lets us detect the auth
+            // error, refresh the token, and back off.
+            waitOnFirstConnect: false,
+            // Let the client enforce the connect timeout so a slow/hanging attempt
+            // is torn down cleanly rather than leaked behind a Promise.race.
+            timeout: this.connectTimeout,
         }
 
         this.applyAuthentication(options)
@@ -364,10 +458,13 @@ export default class NatsService {
             // Priority 1: Self-issued JWT using NKey seed (Ed25519 signing)
             // Used by services that need cryptographically signed authentication
             options.token = generateSelfIssuedJWT(nkeySeed, userId, 1)
-        } else if (token) {
-            // Priority 2: Pre-generated JWT token
-            // Used when token is already available from external source
-            options.token = token
+        } else if (this.config.getToken || token || this.currentToken) {
+            // Priority 2: Pre-generated / provider-supplied JWT token.
+            // Use a token authenticator that reads `currentToken` on every (re)connect
+            // so the client's internal reconnect loop always presents the freshest
+            // token instead of the one captured when the connection was first opened.
+            if (!this.currentToken && token) this.currentToken = token
+            options.authenticator = tokenAuthenticator(() => this.currentToken ?? '')
         } else if (user && pass) {
             // Priority 3: Basic username/password authentication
             // Legacy auth method, less secure than JWT
@@ -379,6 +476,8 @@ export default class NatsService {
 
     async disconnect(): Promise<void> {
         if (this.nc && !this.nc.isClosed()) {
+            this.intentionalClose = true
+            if (this.reconnectTimer) clearTimeout(this.reconnectTimer)
             await this.nc.close()
             info('NATS disconnected gracefully.')
         }
@@ -386,6 +485,8 @@ export default class NatsService {
 
     async drain(): Promise<void> {
         if (this.nc && !this.nc.isClosed()) {
+            this.intentionalClose = true
+            if (this.reconnectTimer) clearTimeout(this.reconnectTimer)
             await this.nc.drain()
             info('NATS drained all subscriptions and disconnected.')
         }

--- a/services/web-ui/src/main.ts
+++ b/services/web-ui/src/main.ts
@@ -42,6 +42,13 @@ async function initializeServicesSequentially() {
             webSocket: true,
             name: 'web-client',
             token: authToken,
+            // Re-fetch a valid token before every (re)connect so the client recovers
+            // from token expiry or a signing-key rotation (e.g. after the auth/API
+            // service restarts) without needing the user to clear cookies/localStorage.
+            getToken: () => AuthService.getTokenSilently(),
+            // When the server rejects our credentials, force a fresh token so the
+            // subsequent getToken() no longer returns the stale, cached one.
+            onAuthError: () => AuthService.getTokenSilently(true),
         });
 
         servicesStore.setDataValues({

--- a/services/web-ui/src/services/auth0-mock-service.test.ts
+++ b/services/web-ui/src/services/auth0-mock-service.test.ts
@@ -1,0 +1,117 @@
+'use strict'
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import mockAuthService from '$src/services/auth0-mock-service.ts'
+
+// The mock Auth0 service only touches authStore/domTemplates on the login and
+// callback paths, none of which the token-refresh logic under test exercises.
+// Stub them so importing the singleton has no side effects.
+vi.mock('$src/stores/authStore.ts', () => ({
+    authStore: {
+        setMetaValues: vi.fn(),
+        setDataValues: vi.fn(),
+    },
+}))
+
+vi.mock('$src/utils/domTemplates.ts', () => ({
+    applyStyle: vi.fn(),
+}))
+
+const STORAGE_KEY = 'localauth0_token'
+
+// Build a syntactically valid JWT whose payload carries the given `exp` claim.
+// Only the payload matters here — the mock service never verifies the signature.
+const makeToken = (expSecondsFromNow: number): string => {
+    const now = Math.floor(Date.now() / 1000)
+    const base64url = (obj: object) =>
+        btoa(JSON.stringify(obj)).replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '')
+    const header = base64url({ typ: 'JWT', alg: 'none' })
+    const payload = base64url({ exp: now + expSecondsFromNow })
+    return `${header}.${payload}.sig`
+}
+
+let refreshSpy: ReturnType<typeof vi.spyOn>
+let loginSpy: ReturnType<typeof vi.spyOn>
+let consoleWarnSpy: ReturnType<typeof vi.spyOn> | null = null
+
+// =============================================================================
+// Auth0MockService.getTokenSilently — cache vs. forced refresh
+// =============================================================================
+
+describe('Auth0MockService — getTokenSilently', () => {
+    beforeEach(() => {
+        localStorage.clear()
+        // refreshTokenViaIframe drives a hidden-iframe redirect that cannot run
+        // under happy-dom, so stub it; login() would navigate the page away.
+        refreshSpy = vi.spyOn(mockAuthService as any, 'refreshTokenViaIframe')
+        loginSpy = vi.spyOn(mockAuthService as any, 'login').mockResolvedValue(undefined)
+        consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    })
+
+    afterEach(() => {
+        refreshSpy.mockRestore()
+        loginSpy.mockRestore()
+        consoleWarnSpy?.mockRestore()
+        consoleWarnSpy = null
+        localStorage.clear()
+    })
+
+    it('returns the cached token without refreshing when it is still valid', async () => {
+        const token = makeToken(3600)
+        localStorage.setItem(STORAGE_KEY, token)
+
+        const result = await mockAuthService.getTokenSilently()
+
+        expect(result).toBe(token)
+        expect(refreshSpy).not.toHaveBeenCalled()
+    })
+
+    it('bypasses a still-valid cached token when forceRefresh is true', async () => {
+        localStorage.setItem(STORAGE_KEY, makeToken(3600))
+        refreshSpy.mockResolvedValue('fresh-token')
+
+        const result = await mockAuthService.getTokenSilently(true)
+
+        expect(result).toBe('fresh-token')
+        expect(refreshSpy).toHaveBeenCalledTimes(1)
+    })
+
+    it('refreshes when the cached token is expired', async () => {
+        localStorage.setItem(STORAGE_KEY, makeToken(-10))
+        refreshSpy.mockResolvedValue('fresh-token')
+
+        const result = await mockAuthService.getTokenSilently()
+
+        expect(result).toBe('fresh-token')
+        expect(refreshSpy).toHaveBeenCalledTimes(1)
+    })
+
+    it('treats a token expiring within the 60s skew window as expired', async () => {
+        localStorage.setItem(STORAGE_KEY, makeToken(30))
+        refreshSpy.mockResolvedValue('fresh-token')
+
+        const result = await mockAuthService.getTokenSilently()
+
+        expect(result).toBe('fresh-token')
+        expect(refreshSpy).toHaveBeenCalledTimes(1)
+    })
+
+    it('refreshes when no token is cached', async () => {
+        refreshSpy.mockResolvedValue('fresh-token')
+
+        const result = await mockAuthService.getTokenSilently()
+
+        expect(result).toBe('fresh-token')
+        expect(refreshSpy).toHaveBeenCalledTimes(1)
+    })
+
+    it('falls back to a full-page login and returns false when silent refresh fails', async () => {
+        refreshSpy.mockRejectedValue(new Error('iframe blew up'))
+
+        const result = await mockAuthService.getTokenSilently(true)
+
+        expect(result).toBe(false)
+        expect(loginSpy).toHaveBeenCalledTimes(1)
+    })
+})

--- a/services/web-ui/src/services/auth0-mock-service.ts
+++ b/services/web-ui/src/services/auth0-mock-service.ts
@@ -181,9 +181,9 @@ class Auth0MockService {
         })
     }
 
-    public async getTokenSilently(): Promise<string | false> {
+    public async getTokenSilently(forceRefresh = false): Promise<string | false> {
         const token = localStorage.getItem('localauth0_token')
-        if (token && !this.isTokenExpired(token)) {
+        if (!forceRefresh && token && !this.isTokenExpired(token)) {
             return token
         }
 

--- a/services/web-ui/src/services/auth0-service.test.ts
+++ b/services/web-ui/src/services/auth0-service.test.ts
@@ -1,0 +1,84 @@
+'use strict'
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const getTokenSilentlyMock = vi.hoisted(() => vi.fn())
+const isAuthenticatedMock = vi.hoisted(() => vi.fn())
+const loginWithRedirectMock = vi.hoisted(() => vi.fn())
+const handleRedirectCallbackMock = vi.hoisted(() => vi.fn())
+const getUserMock = vi.hoisted(() => vi.fn())
+
+vi.mock('@auth0/auth0-spa-js', () => ({
+    createAuth0Client: vi.fn(async () => ({
+        getTokenSilently: getTokenSilentlyMock,
+        isAuthenticated: isAuthenticatedMock,
+        loginWithRedirect: loginWithRedirectMock,
+        handleRedirectCallback: handleRedirectCallbackMock,
+        getUser: getUserMock,
+        logout: vi.fn(),
+    })),
+    Auth0Client: class {},
+}))
+
+vi.mock('$src/stores/authStore.ts', () => ({
+    authStore: {
+        setMetaValues: vi.fn(),
+        setDataValues: vi.fn(),
+    },
+}))
+
+import authService from '$src/services/auth0-service.ts'
+
+let consoleErrorSpy: ReturnType<typeof vi.spyOn> | null = null
+
+// =============================================================================
+// Auth0Service.getTokenSilently — cache mode forwarding + error fallback
+// =============================================================================
+
+describe('Auth0Service — getTokenSilently', () => {
+    beforeEach(async () => {
+        getTokenSilentlyMock.mockReset()
+        loginWithRedirectMock.mockReset().mockResolvedValue(undefined)
+        // Keep init()'s updateAuthData quiet: report not-authenticated so it does
+        // not try to resolve a user profile.
+        isAuthenticatedMock.mockReset().mockResolvedValue(false)
+        handleRedirectCallbackMock.mockReset()
+        getUserMock.mockReset()
+        consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+
+        // Wire up the underlying (mocked) Auth0 client on the singleton.
+        await authService.init()
+    })
+
+    afterEach(() => {
+        consoleErrorSpy?.mockRestore()
+        consoleErrorSpy = null
+    })
+
+    it('uses the cache by default (no cacheMode override)', async () => {
+        getTokenSilentlyMock.mockResolvedValue('cached-token')
+
+        const result = await authService.getTokenSilently()
+
+        expect(result).toBe('cached-token')
+        expect(getTokenSilentlyMock).toHaveBeenCalledWith(undefined)
+    })
+
+    it('bypasses the cache when forceRefresh is true', async () => {
+        getTokenSilentlyMock.mockResolvedValue('fresh-token')
+
+        const result = await authService.getTokenSilently(true)
+
+        expect(result).toBe('fresh-token')
+        expect(getTokenSilentlyMock).toHaveBeenCalledWith({ cacheMode: 'off' })
+    })
+
+    it('returns false and redirects to login when token retrieval throws', async () => {
+        getTokenSilentlyMock.mockRejectedValue(new Error('login_required'))
+
+        const result = await authService.getTokenSilently(true)
+
+        expect(result).toBe(false)
+        expect(loginWithRedirectMock).toHaveBeenCalledTimes(1)
+    })
+})

--- a/services/web-ui/src/services/auth0-service.ts
+++ b/services/web-ui/src/services/auth0-service.ts
@@ -81,9 +81,11 @@ class Auth0Service {
         authStore.setDataValues({ user: null })
     }
 
-    public async getTokenSilently(): Promise<string | false> {
+    public async getTokenSilently(forceRefresh = false): Promise<string | false> {
         try {
-            return await this.auth0.getTokenSilently() ?? false
+            return await this.auth0.getTokenSilently(
+                forceRefresh ? { cacheMode: 'off' } : undefined
+            ) ?? false
         } catch (error) {
             await this.login()
             return false


### PR DESCRIPTION
## Summary

When the auth/API service (or LocalAuth0) restarts, the WebUI never reconnected to NATS — the only recovery was manually clearing cookies and localStorage. This fixes the root cause in the shared `NatsService` and the WebUI auth layer.

### Root cause

- **`waitOnFirstConnect: true` swallowed auth failures.** With `maxReconnectAttempts: -1`, `wsconnect()` never rejected on an `AuthorizationError`; it retried forever in the background. Our `Promise.race` connect timeout fired instead (a generic error that serialized to `{}` and was never classified as auth), so token refresh never triggered.
- **Leaked zombie connections.** Each timed-out `wsconnect` was never closed and kept retrying. Every ~2s a new client spawned; within a minute ~30 zombie clients hammered the auth callout → JWKS endpoint, blowing past `jwksRequestsPerMinute: 10` (`Too many requests to the JWKS endpoint`). This then failed even valid, freshly issued tokens.
- **Stale-but-unexpired token replayed.** After a signing-key rotation the cached token was still within its `exp` window, so `getTokenSilently()` kept returning it with no path to force a refresh on rejection.

### Changes

Shared `NatsService` (TypeScript + Python parity):
- Fail fast on initial connect (`waitOnFirstConnect: false`) and use the client's own connect timeout instead of a `Promise.race` that leaks background clients.
- Refresh the token before every (re)connect via a `getToken` provider; use a dynamic token authenticator so internal reconnects present fresh credentials.
- Detect authorization failures, invoke an `onAuthError` hook so callers can invalidate cached tokens, and reconnect.
- Exponential backoff on reconnect (500ms → 16s) so a persistent failure can no longer flood the rate-limited JWKS endpoint.
- Reconnect on unexpected close; suppress reconnect on graceful `disconnect()`/`drain()`.

WebUI auth layer:
- `getTokenSilently(forceRefresh)` on both the real and mock Auth0 services to bypass the cache when the server rejects credentials.
- `main.ts` wires `getToken` and `onAuthError` into `NatsService.init`.

### Result

On an auth rejection the client fails fast, forces a fresh token, and backs off — the JWKS rate-limit window clears and the fresh token verifies, with no zombie connections and no manual cache clearing.

Closes #289